### PR TITLE
feat: establish ICS02 and ICS07 components + implement client creation and update logic

### DIFF
--- a/cairo-contracts/src/apps/transfer/component.cairo
+++ b/cairo-contracts/src/apps/transfer/component.cairo
@@ -16,7 +16,7 @@ pub mod ICS20TransferComponent {
     };
     use starknet_ibc::apps::transferrable::interface::ITransferrable;
     use starknet_ibc::core::channel::types::Packet;
-    use starknet_ibc::core::host::types::{PortId, ChannelId, ChannelIdTrait};
+    use starknet_ibc::core::host::{PortId, ChannelId, ChannelIdTrait};
     use starknet_ibc::utils::{ComputeKeyTrait, ValidateBasicTrait};
 
     #[storage]

--- a/cairo-contracts/src/apps/transfer/types.cairo
+++ b/cairo-contracts/src/apps/transfer/types.cairo
@@ -17,8 +17,8 @@ use starknet_ibc::apps::mintable::interface::{
 };
 use starknet_ibc::apps::transfer::TRANSFER_PORT_ID_HASH;
 use starknet_ibc::apps::transfer::errors::TransferErrors;
-use starknet_ibc::core::client::types::{Height, Timestamp};
-use starknet_ibc::core::host::types::{PortId, PortIdTrait, ChannelId, ChannelIdTrait};
+use starknet_ibc::core::client::{Height, Timestamp};
+use starknet_ibc::core::host::{PortId, PortIdTrait, ChannelId, ChannelIdTrait};
 use starknet_ibc::utils::{ValidateBasicTrait, ComputeKeyTrait};
 
 /// Maximum memo length allowed for ICS-20 transfers. This bound corresponds to

--- a/cairo-contracts/src/clients.cairo
+++ b/cairo-contracts/src/clients.cairo
@@ -1,0 +1,1 @@
+pub mod tendermint;

--- a/cairo-contracts/src/clients/tendermint.cairo
+++ b/cairo-contracts/src/clients/tendermint.cairo
@@ -13,7 +13,7 @@ pub use consensus_state::{
     TendermintConsensusState, TendermintConsensusStateImpl, TendermintConsensusStateTrait
 };
 
-pub use errors::ICS07Errors;
+pub use errors::TendermintErrors;
 pub use header::{
     TendermintHeader, TendermintHeaderImpl, TendermintHeaderIntoConsensusState,
     TendermintHeaderTrait

--- a/cairo-contracts/src/clients/tendermint.cairo
+++ b/cairo-contracts/src/clients/tendermint.cairo
@@ -1,0 +1,21 @@
+mod client_state;
+mod component;
+mod consensus_state;
+mod errors;
+mod header;
+
+pub use client_state::{
+    TendermintClientState, TendermintClientStateImpl, TendermintClientStateTrait
+};
+
+pub use component::ICS07ClientComponent;
+pub use consensus_state::{
+    TendermintConsensusState, TendermintConsensusStateImpl, TendermintConsensusStateTrait
+};
+
+pub use errors::ICS07Errors;
+pub use header::{
+    TendermintHeader, TendermintHeaderImpl, TendermintHeaderIntoConsensusState,
+    TendermintHeaderTrait
+};
+

--- a/cairo-contracts/src/clients/tendermint/client_state.cairo
+++ b/cairo-contracts/src/clients/tendermint/client_state.cairo
@@ -1,0 +1,37 @@
+use starknet_ibc::clients::tendermint::ICS07Errors;
+use starknet_ibc::core::client::{Height, Status};
+
+#[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
+pub struct TendermintClientState {
+    pub latest_height: Height,
+    pub trusting_period: u64,
+    pub status: Status,
+}
+
+pub trait TendermintClientStateTrait {
+    fn deserialize(client_state: Array<felt252>,) -> TendermintClientState;
+    fn update(ref self: TendermintClientState, new_height: Height);
+    fn freeze(ref self: TendermintClientState, freezing_height: Height);
+}
+
+pub impl TendermintClientStateImpl of TendermintClientStateTrait {
+    fn deserialize(client_state: Array<felt252>,) -> TendermintClientState {
+        let mut client_state_span = client_state.span();
+
+        let maybe_client_state = Serde::<TendermintClientState>::deserialize(ref client_state_span);
+
+        assert(maybe_client_state.is_some(), ICS07Errors::INVALID_CLIENT_STATE);
+
+        maybe_client_state.unwrap()
+    }
+
+    fn update(ref self: TendermintClientState, new_height: Height) {
+        if self.latest_height.clone() < new_height.clone() {
+            self.latest_height = new_height;
+        }
+    }
+
+    fn freeze(ref self: TendermintClientState, freezing_height: Height) {
+        self.status = Status::Frozen(freezing_height);
+    }
+}

--- a/cairo-contracts/src/clients/tendermint/client_state.cairo
+++ b/cairo-contracts/src/clients/tendermint/client_state.cairo
@@ -1,4 +1,4 @@
-use starknet_ibc::clients::tendermint::ICS07Errors;
+use starknet_ibc::clients::tendermint::TendermintErrors;
 use starknet_ibc::core::client::{Height, Status};
 
 #[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
@@ -20,7 +20,7 @@ pub impl TendermintClientStateImpl of TendermintClientStateTrait {
 
         let maybe_client_state = Serde::<TendermintClientState>::deserialize(ref client_state_span);
 
-        assert(maybe_client_state.is_some(), ICS07Errors::INVALID_CLIENT_STATE);
+        assert(maybe_client_state.is_some(), TendermintErrors::INVALID_CLIENT_STATE);
 
         maybe_client_state.unwrap()
     }

--- a/cairo-contracts/src/clients/tendermint/component.cairo
+++ b/cairo-contracts/src/clients/tendermint/component.cairo
@@ -1,19 +1,16 @@
 #[starknet::component]
 pub mod ICS07ClientComponent {
     use core::num::traits::zero::Zero;
-    use core::traits::Into;
     use starknet::{get_block_timestamp, get_block_number};
     use starknet_ibc::clients::tendermint::{
         TendermintClientState, TendermintClientStateImpl, TendermintConsensusState,
-        TendermintConsensusStateImpl, TendermintHeader, TendermintHeaderImpl,
-        TendermintConsensusStateTrait, TendermintClientStateTrait, ICS07Errors
+        TendermintConsensusStateImpl, TendermintHeader, TendermintHeaderImpl, TendermintErrors
     };
     use starknet_ibc::core::client::{
         MsgCreateClient, MsgUpdateClient, MsgRecoverClient, MsgUpgradeClient, Height, Timestamp,
         Status, StatusTrait, UpdateResult, IClientHandler, IClientState, IClientStateValidation,
         IClientStateExecution
     };
-    use starknet_ibc::core::host::ClientId;
 
     #[storage]
     struct Storage {
@@ -55,15 +52,15 @@ pub mod ICS07ClientComponent {
         fn create_validate(
             self: @ComponentState<TContractState>, msg: MsgCreateClient, client_sequence: u64
         ) {
-            assert(msg.client_type == self.client_type(), ICS07Errors::INVALID_CLIENT_TYPE);
+            assert(msg.client_type == self.client_type(), TendermintErrors::INVALID_CLIENT_TYPE);
 
-            assert(!msg.client_state.is_empty(), ICS07Errors::EMPTY_CLIENT_STATE);
+            assert(!msg.client_state.is_empty(), TendermintErrors::EMPTY_CLIENT_STATE);
 
-            assert(!msg.consensus_state.is_empty(), ICS07Errors::EMPTY_CONSENSUS_STATE);
+            assert(!msg.consensus_state.is_empty(), TendermintErrors::EMPTY_CONSENSUS_STATE);
 
             let status = self.status(msg.client_state, client_sequence);
 
-            assert(status.is_active(), ICS07Errors::INACTIVE_CLIENT);
+            assert(status.is_active(), TendermintErrors::INACTIVE_CLIENT);
         }
 
         fn create_execute(
@@ -79,10 +76,11 @@ pub mod ICS07ClientComponent {
     > of UpdateClientTrait<TContractState> {
         fn update_validate(self: @ComponentState<TContractState>, msg: MsgUpdateClient) {
             assert(
-                msg.client_id.client_type == self.client_type(), ICS07Errors::INVALID_CLIENT_TYPE
+                msg.client_id.client_type == self.client_type(),
+                TendermintErrors::INVALID_CLIENT_TYPE
             );
 
-            assert(!msg.client_message.is_empty(), ICS07Errors::EMPTY_CLIENT_MESSAGE);
+            assert(!msg.client_message.is_empty(), TendermintErrors::EMPTY_CLIENT_MESSAGE);
 
             let tendermint_client_state: TendermintClientState = self
                 .client_states
@@ -90,7 +88,7 @@ pub mod ICS07ClientComponent {
 
             let status = self._status(tendermint_client_state, msg.client_id.sequence);
 
-            assert(status.is_active(), ICS07Errors::INACTIVE_CLIENT);
+            assert(status.is_active(), TendermintErrors::INACTIVE_CLIENT);
 
             self.verify_client_message(msg.client_id.sequence, msg.client_message);
         }

--- a/cairo-contracts/src/clients/tendermint/component.cairo
+++ b/cairo-contracts/src/clients/tendermint/component.cairo
@@ -1,0 +1,320 @@
+#[starknet::component]
+pub mod ICS07ClientComponent {
+    use core::num::traits::zero::Zero;
+    use core::traits::Into;
+    use starknet::{get_block_timestamp, get_block_number};
+    use starknet_ibc::clients::tendermint::{
+        TendermintClientState, TendermintClientStateImpl, TendermintConsensusState,
+        TendermintConsensusStateImpl, TendermintHeader, TendermintHeaderImpl,
+        TendermintConsensusStateTrait, TendermintClientStateTrait, ICS07Errors
+    };
+    use starknet_ibc::core::client::{
+        MsgCreateClient, MsgUpdateClient, MsgRecoverClient, MsgUpgradeClient, Height, Timestamp,
+        Status, StatusTrait, UpdateResult, IClientHandler, IClientState, IClientStateValidation,
+        IClientStateExecution
+    };
+    use starknet_ibc::core::host::ClientId;
+
+    #[storage]
+    struct Storage {
+        client_states: LegacyMap<u64, TendermintClientState>,
+        consensus_states: LegacyMap<(u64, Height), TendermintConsensusState>,
+        client_processed_times: LegacyMap<(u64, Height), u64>,
+        client_processed_heights: LegacyMap<(u64, Height), u64>,
+    }
+
+    #[event]
+    #[derive(Debug, Drop, starknet::Event)]
+    pub enum Event {}
+
+    #[embeddable_as(ICS07ClientHandler)]
+    impl ClientHandlerImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of IClientHandler<ComponentState<TContractState>> {
+        fn create(
+            ref self: ComponentState<TContractState>, msg: MsgCreateClient, client_sequence: u64,
+        ) {
+            self.create_validate(msg.clone(), client_sequence);
+            self.create_execute(msg, client_sequence);
+        }
+
+        fn update(ref self: ComponentState<TContractState>, msg: MsgUpdateClient) -> UpdateResult {
+            self.update_validate(msg.clone());
+            self.update_execute(msg)
+        }
+
+        fn recover(ref self: ComponentState<TContractState>, msg: MsgRecoverClient) {}
+
+        fn upgrade(ref self: ComponentState<TContractState>, msg: MsgUpgradeClient) {}
+    }
+
+    #[generate_trait]
+    pub impl CreateClientImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of CreateClientTrait<TContractState> {
+        fn create_validate(
+            self: @ComponentState<TContractState>, msg: MsgCreateClient, client_sequence: u64
+        ) {
+            assert(msg.client_type == self.client_type(), ICS07Errors::INVALID_CLIENT_TYPE);
+
+            assert(!msg.client_state.is_empty(), ICS07Errors::EMPTY_CLIENT_STATE);
+
+            assert(!msg.consensus_state.is_empty(), ICS07Errors::EMPTY_CONSENSUS_STATE);
+
+            let status = self.status(msg.client_state, client_sequence);
+
+            assert(status.is_active(), ICS07Errors::INACTIVE_CLIENT);
+        }
+
+        fn create_execute(
+            ref self: ComponentState<TContractState>, msg: MsgCreateClient, client_sequence: u64
+        ) {
+            self.initialize(client_sequence, msg.client_state, msg.consensus_state);
+        }
+    }
+
+    #[generate_trait]
+    pub impl UpdateClientImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of UpdateClientTrait<TContractState> {
+        fn update_validate(self: @ComponentState<TContractState>, msg: MsgUpdateClient) {
+            assert(
+                msg.client_id.client_type == self.client_type(), ICS07Errors::INVALID_CLIENT_TYPE
+            );
+
+            assert(!msg.client_message.is_empty(), ICS07Errors::EMPTY_CLIENT_MESSAGE);
+
+            let tendermint_client_state: TendermintClientState = self
+                .client_states
+                .read(msg.client_id.sequence);
+
+            let status = self._status(tendermint_client_state, msg.client_id.sequence);
+
+            assert(status.is_active(), ICS07Errors::INACTIVE_CLIENT);
+
+            self.verify_client_message(msg.client_id.sequence, msg.client_message);
+        }
+
+        fn update_execute(
+            ref self: ComponentState<TContractState>, msg: MsgUpdateClient
+        ) -> UpdateResult {
+            if self.verify_misbehaviour(msg.client_id.sequence, msg.client_message.clone()) {
+                return self
+                    .update_on_misbehaviour(msg.client_id.sequence, msg.client_message.clone());
+            }
+
+            self.update_state(msg.client_id.sequence, msg.client_message.clone())
+        }
+    }
+
+    #[generate_trait]
+    pub impl RecoverClientImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of RecoverClientTrait<TContractState> {
+        fn recover_validate(self: @ComponentState<TContractState>, msg: MsgRecoverClient) {}
+
+        fn recover_execute(ref self: ComponentState<TContractState>, msg: MsgRecoverClient) {}
+    }
+
+    #[generate_trait]
+    pub impl UpgradeClientImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of UpgradeClientTrait<TContractState> {
+        fn upgrade_validate(self: @ComponentState<TContractState>, msg: MsgUpgradeClient,) {}
+
+        fn upgrade_execute(ref self: ComponentState<TContractState>, msg: MsgUpgradeClient,) {}
+    }
+
+    #[embeddable_as(ICS07ClientState)]
+    impl ClientStateImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of IClientState<ComponentState<TContractState>> {
+        fn client_type(self: @ComponentState<TContractState>) -> felt252 {
+            '07-tendermint'
+        }
+
+        fn latest_height(self: @ComponentState<TContractState>, client_sequence: u64) -> Height {
+            let tendermint_client_state: TendermintClientState = self
+                .client_states
+                .read(client_sequence);
+
+            tendermint_client_state.latest_height
+        }
+
+        fn status(
+            self: @ComponentState<TContractState>,
+            client_state: Array<felt252>,
+            client_sequence: u64
+        ) -> Status {
+            let tendermint_client_state = TendermintClientStateImpl::deserialize(client_state);
+
+            self._status(tendermint_client_state, client_sequence)
+        }
+    }
+
+    #[embeddable_as(ICS07ClientValidation)]
+    impl ClientValidationImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of IClientStateValidation<ComponentState<TContractState>> {
+        fn verify_client_message(
+            self: @ComponentState<TContractState>,
+            client_sequence: u64,
+            client_message: Array<felt252>
+        ) {}
+
+        fn verify_misbehaviour(
+            self: @ComponentState<TContractState>,
+            client_sequence: u64,
+            client_message: Array<felt252>
+        ) -> bool {
+            false
+        }
+
+        fn verify_substitute(
+            self: @ComponentState<TContractState>, substitute_client_state: Array<felt252>
+        ) {}
+
+        fn verify_upgrade(
+            self: @ComponentState<TContractState>,
+            upgrade_client_state: Array<felt252>,
+            upgrade_consensus_state: Array<felt252>,
+            proof_upgrade_client: Array<felt252>,
+            proof_upgrade_consensus: Array<felt252>,
+            root: felt252
+        ) {}
+    }
+
+    #[embeddable_as(ICS07ClientExecution)]
+    impl ClientExecutionImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of IClientStateExecution<ComponentState<TContractState>> {
+        fn initialize(
+            ref self: ComponentState<TContractState>,
+            client_sequence: u64,
+            client_state: Array<felt252>,
+            consensus_state: Array<felt252>
+        ) {
+            let tendermint_client_state = TendermintClientStateImpl::deserialize(client_state);
+
+            let tendermint_consensus_state = TendermintConsensusStateImpl::deserialize(
+                consensus_state
+            );
+
+            self
+                ._update_state(
+                    client_sequence, tendermint_client_state, tendermint_consensus_state
+                );
+        }
+
+        fn update_state(
+            ref self: ComponentState<TContractState>,
+            client_sequence: u64,
+            client_message: Array<felt252>
+        ) -> UpdateResult {
+            let header: TendermintHeader = TendermintHeaderImpl::deserialize(client_message);
+
+            let header_height = header.clone().trusted_height;
+
+            // TODO: Implement consensus state pruning mechanism.
+
+            let maybe_consensus_state = self
+                .consensus_states
+                .read((client_sequence, header_height.clone()));
+
+            if maybe_consensus_state.root.is_zero() {
+                let mut client_state = self.client_states.read(client_sequence);
+
+                client_state.update(header_height.clone());
+
+                let new_consensus_state: TendermintConsensusState = header.into();
+
+                self._update_state(client_sequence, client_state, new_consensus_state);
+            }
+
+            array![header_height].into()
+        }
+
+        fn update_on_misbehaviour(
+            ref self: ComponentState<TContractState>,
+            client_sequence: u64,
+            client_message: Array<felt252>
+        ) -> UpdateResult {
+            let header = TendermintHeaderImpl::deserialize(client_message);
+
+            let mut client_state = self.client_states.read(client_sequence);
+
+            client_state.freeze(header.trusted_height);
+
+            UpdateResult::Misbehaviour
+        }
+
+        fn update_on_recover(
+            ref self: ComponentState<TContractState>,
+            subject_client_sequence: u64,
+            substitute_client_state: Array<felt252>,
+            substitute_consensus_state: Array<felt252>
+        ) {}
+
+        fn update_on_upgrade(
+            ref self: ComponentState<TContractState>,
+            client_sequence: u64,
+            new_client_state: Array<felt252>,
+            new_consensus_state: Array<felt252>
+        ) {}
+    }
+
+    #[generate_trait]
+    pub(crate) impl ClientInternalImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of ClientInternalTrait<TContractState> {
+        fn _status(
+            self: @ComponentState<TContractState>,
+            client_state: TendermintClientState,
+            client_sequence: u64
+        ) -> Status {
+            if !client_state.status.is_active() {
+                return client_state.status;
+            }
+
+            let latest_consensus_state = self
+                .consensus_states
+                .read((client_sequence, client_state.latest_height));
+
+            let host_timestamp = get_block_timestamp();
+
+            let consensus_state_status = latest_consensus_state
+                .status(host_timestamp, client_state.trusting_period,);
+
+            if !consensus_state_status.is_active() {
+                return consensus_state_status;
+            }
+
+            Status::Active
+        }
+
+        fn _update_state(
+            ref self: ComponentState<TContractState>,
+            client_sequence: u64,
+            client_state: TendermintClientState,
+            consensus_state: TendermintConsensusState,
+        ) {
+            self.client_states.write(client_sequence, client_state.clone());
+
+            let latest_height = client_state.latest_height;
+
+            self
+                .consensus_states
+                .write((client_sequence, latest_height.clone()), consensus_state.clone());
+
+            let host_height = get_block_number();
+
+            self
+                .client_processed_heights
+                .write((client_sequence, latest_height.clone()), host_height);
+
+            let host_timestamp = get_block_timestamp();
+
+            self.client_processed_times.write((client_sequence, latest_height), host_timestamp);
+        }
+    }
+}

--- a/cairo-contracts/src/clients/tendermint/consensus_state.cairo
+++ b/cairo-contracts/src/clients/tendermint/consensus_state.cairo
@@ -1,0 +1,39 @@
+use starknet_ibc::clients::tendermint::ICS07Errors;
+use starknet_ibc::core::client::{Height, Status};
+
+#[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
+pub struct TendermintConsensusState {
+    pub timestamp: u64,
+    pub root: felt252,
+}
+
+pub trait TendermintConsensusStateTrait {
+    fn deserialize(consensus_state: Array<felt252>,) -> TendermintConsensusState;
+    fn status(self: @TendermintConsensusState, host_timestamp: u64, trusting_period: u64) -> Status;
+}
+
+pub impl TendermintConsensusStateImpl of TendermintConsensusStateTrait {
+    fn deserialize(consensus_state: Array<felt252>,) -> TendermintConsensusState {
+        let mut consensus_state_span = consensus_state.span();
+
+        let maybe_consensus_state = Serde::<
+            TendermintConsensusState
+        >::deserialize(ref consensus_state_span);
+
+        assert(maybe_consensus_state.is_some(), ICS07Errors::INVALID_CLIENT_STATE);
+
+        maybe_consensus_state.unwrap()
+    }
+
+    fn status(
+        self: @TendermintConsensusState, host_timestamp: u64, trusting_period: u64
+    ) -> Status {
+        let elapsed_time = host_timestamp - *self.timestamp;
+
+        if elapsed_time < trusting_period {
+            Status::Active
+        } else {
+            Status::Expired
+        }
+    }
+}

--- a/cairo-contracts/src/clients/tendermint/consensus_state.cairo
+++ b/cairo-contracts/src/clients/tendermint/consensus_state.cairo
@@ -1,4 +1,4 @@
-use starknet_ibc::clients::tendermint::ICS07Errors;
+use starknet_ibc::clients::tendermint::TendermintErrors;
 use starknet_ibc::core::client::{Height, Status};
 
 #[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
@@ -20,7 +20,7 @@ pub impl TendermintConsensusStateImpl of TendermintConsensusStateTrait {
             TendermintConsensusState
         >::deserialize(ref consensus_state_span);
 
-        assert(maybe_consensus_state.is_some(), ICS07Errors::INVALID_CLIENT_STATE);
+        assert(maybe_consensus_state.is_some(), TendermintErrors::INVALID_CLIENT_STATE);
 
         maybe_consensus_state.unwrap()
     }

--- a/cairo-contracts/src/clients/tendermint/errors.cairo
+++ b/cairo-contracts/src/clients/tendermint/errors.cairo
@@ -1,4 +1,4 @@
-pub mod ICS07Errors {
+pub mod TendermintErrors {
     pub const EMPTY_CLIENT_STATE: felt252 = 'ICS07: empty client state';
     pub const EMPTY_CLIENT_MESSAGE: felt252 = 'ICS07: empty client message';
     pub const EMPTY_CONSENSUS_STATE: felt252 = 'ICS07: empty consensus state';

--- a/cairo-contracts/src/clients/tendermint/errors.cairo
+++ b/cairo-contracts/src/clients/tendermint/errors.cairo
@@ -1,0 +1,10 @@
+pub mod ICS07Errors {
+    pub const EMPTY_CLIENT_STATE: felt252 = 'ICS07: empty client state';
+    pub const EMPTY_CLIENT_MESSAGE: felt252 = 'ICS07: empty client message';
+    pub const EMPTY_CONSENSUS_STATE: felt252 = 'ICS07: empty consensus state';
+    pub const INACTIVE_CLIENT: felt252 = 'ICS07: inactive client';
+    pub const INVALID_CLIENT_TYPE: felt252 = 'ICS07: invalid client type';
+    pub const INVALID_CLIENT_STATE: felt252 = 'ICS07: invalid client state';
+    pub const INVALID_CONSENSUS_STATE: felt252 = 'ICS07: invalid consensus state';
+    pub const INVALID_HEADER: felt252 = 'ICS07: invalid header';
+}

--- a/cairo-contracts/src/clients/tendermint/header.cairo
+++ b/cairo-contracts/src/clients/tendermint/header.cairo
@@ -1,4 +1,4 @@
-use starknet_ibc::clients::tendermint::{ICS07Errors, TendermintConsensusState};
+use starknet_ibc::clients::tendermint::{TendermintErrors, TendermintConsensusState};
 use starknet_ibc::core::client::Height;
 
 #[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
@@ -17,7 +17,7 @@ pub impl TendermintHeaderImpl of TendermintHeaderTrait {
 
         let maybe_header = Serde::<TendermintHeader>::deserialize(ref header_span);
 
-        assert(maybe_header.is_some(), ICS07Errors::INVALID_HEADER);
+        assert(maybe_header.is_some(), TendermintErrors::INVALID_HEADER);
 
         maybe_header.unwrap()
     }

--- a/cairo-contracts/src/clients/tendermint/header.cairo
+++ b/cairo-contracts/src/clients/tendermint/header.cairo
@@ -1,0 +1,38 @@
+use starknet_ibc::clients::tendermint::{ICS07Errors, TendermintConsensusState};
+use starknet_ibc::core::client::Height;
+
+#[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
+pub struct TendermintHeader {
+    pub trusted_height: Height,
+    pub signed_header: SignedHeader,
+}
+
+pub trait TendermintHeaderTrait {
+    fn deserialize(header: Array<felt252>,) -> TendermintHeader;
+}
+
+pub impl TendermintHeaderImpl of TendermintHeaderTrait {
+    fn deserialize(header: Array<felt252>,) -> TendermintHeader {
+        let mut header_span = header.span();
+
+        let maybe_header = Serde::<TendermintHeader>::deserialize(ref header_span);
+
+        assert(maybe_header.is_some(), ICS07Errors::INVALID_HEADER);
+
+        maybe_header.unwrap()
+    }
+}
+
+#[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
+pub struct SignedHeader {
+    pub time: u64,
+    pub root: felt252,
+}
+
+pub impl TendermintHeaderIntoConsensusState of Into<TendermintHeader, TendermintConsensusState> {
+    fn into(self: TendermintHeader) -> TendermintConsensusState {
+        TendermintConsensusState {
+            timestamp: self.signed_header.time, root: self.signed_header.root,
+        }
+    }
+}

--- a/cairo-contracts/src/core/channel/types.cairo
+++ b/cairo-contracts/src/core/channel/types.cairo
@@ -1,5 +1,5 @@
-use starknet_ibc::core::client::types::{Height, Timestamp};
-use starknet_ibc::core::host::types::{ChannelId, PortId, Sequence};
+use starknet_ibc::core::client::{Height, Timestamp};
+use starknet_ibc::core::host::{ChannelId, PortId, Sequence};
 
 #[derive(Clone, Debug, Drop, Serde, Store)]
 pub struct Packet {

--- a/cairo-contracts/src/core/client.cairo
+++ b/cairo-contracts/src/core/client.cairo
@@ -1,1 +1,26 @@
-pub mod types;
+mod component;
+mod contract;
+mod errors;
+mod interface;
+mod msgs;
+mod types;
+
+pub use component::ICS02ClientComponent;
+
+pub use contract::{ClientContract, ClientContractTrait};
+
+pub use errors::ICS02Errors;
+
+pub use interface::{
+    IClientHandler, IClientHandlerDispatcher, IClientState, IClientStateDispatcher,
+    IClientStateDispatcherTrait, IClientHandlerDispatcherTrait, IClientStateValidation,
+    IClientStateValidationDispatcher, IClientStateValidationDispatcherTrait, IClientStateExecution,
+    IClientStateExecutionDispatcher, IClientStateExecutionDispatcherTrait,
+};
+
+pub use msgs::{MsgCreateClient, MsgRecoverClient, MsgUpdateClient, MsgUpgradeClient,};
+
+pub use types::{
+    UpdateResult, Status, StatusImpl, StatusTrait, Height, HeightPartialOrd, Timestamp,
+    HeightsIntoUpdateResult
+};

--- a/cairo-contracts/src/core/client.cairo
+++ b/cairo-contracts/src/core/client.cairo
@@ -9,7 +9,7 @@ pub use component::ICS02ClientComponent;
 
 pub use contract::{ClientContract, ClientContractTrait};
 
-pub use errors::ICS02Errors;
+pub use errors::ClientErrors;
 
 pub use interface::{
     IClientHandler, IClientHandlerDispatcher, IClientState, IClientStateDispatcher,

--- a/cairo-contracts/src/core/client/component.cairo
+++ b/cairo-contracts/src/core/client/component.cairo
@@ -1,0 +1,185 @@
+#[starknet::component]
+pub mod ICS02ClientComponent {
+    use starknet::ContractAddress;
+    use starknet_ibc::core::client::ICS02Errors;
+    use starknet_ibc::core::client::StatusTrait;
+    use starknet_ibc::core::client::{
+        MsgCreateClient, MsgUpdateClient, MsgRecoverClient, MsgUpgradeClient, Height, UpdateResult
+    };
+    use starknet_ibc::core::client::{ClientContract, ClientContractTrait};
+    use starknet_ibc::core::host::{ClientId, ClientIdImpl, ClientIdTrait};
+
+    #[storage]
+    struct Storage {
+        client_sequence: u64,
+        supported_clients: LegacyMap<felt252, ContractAddress>,
+    }
+
+    #[event]
+    #[derive(Debug, Drop, starknet::Event)]
+    pub enum Event {
+        CreateClientEvent: CreateClientEvent,
+        UpdateClientEvent: UpdateClientEvent,
+        MisbehaviourEvent: MisbehaviourEvent,
+        RecoverClientEvent: RecoverClientEvent,
+        UpgradeClientEvent: UpgradeClientEvent,
+    }
+
+    #[derive(Debug, Drop, starknet::Event)]
+    pub struct CreateClientEvent {
+        #[key]
+        pub client_id: ClientId,
+        pub consensus_height: Height,
+    }
+
+    #[derive(Debug, Drop, starknet::Event)]
+    pub struct UpdateClientEvent {
+        #[key]
+        pub client_id: ClientId,
+        pub consensus_heights: Array<Height>,
+        pub header: Array<felt252>,
+    }
+
+    #[derive(Debug, Drop, starknet::Event)]
+    pub struct MisbehaviourEvent {
+        #[key]
+        pub client_id: ClientId,
+    }
+
+    #[derive(Debug, Drop, starknet::Event)]
+    pub struct RecoverClientEvent {}
+
+    #[derive(Debug, Drop, starknet::Event)]
+    pub struct UpgradeClientEvent {}
+
+    #[generate_trait]
+    pub(crate) impl ClientInitializerImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of ClientInitializerTrait<TContractState> {
+        fn initializer(ref self: ComponentState<TContractState>) {
+            self.client_sequence.write(0);
+        }
+    }
+
+    #[generate_trait]
+    pub impl ICS02ClientImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of ICS02ClientTrait<TContractState> {
+        fn create_client(ref self: ComponentState<TContractState>, msg: MsgCreateClient) {
+            let mut client = self.get_client(msg.client_type);
+
+            let client_sequence = self.client_sequence.read();
+
+            client.create(msg, client_sequence);
+
+            self.emit_create_client_event(@client, client_sequence);
+
+            self.client_sequence.write(client_sequence + 1);
+        }
+
+        fn update_client(ref self: ComponentState<TContractState>, msg: MsgUpdateClient) {
+            let mut client = self.get_client(msg.client_id.client_type);
+
+            let update_result = client.update(msg.clone());
+
+            match update_result {
+                UpdateResult::Success(heights) => self
+                    .emit_update_client_event(
+                        @client, msg.client_id.sequence, heights, msg.client_message
+                    ),
+                UpdateResult::Misbehaviour => self.emit_misbehaviour_event(@client),
+            }
+        }
+
+        fn recover_client(ref self: ComponentState<TContractState>, msg: MsgRecoverClient) {
+            let mut client = self.get_client(msg.subject_client_id.client_type);
+
+            client.recover(msg);
+
+            self.emit_recover_client_event();
+        }
+
+        fn upgrade_client(ref self: ComponentState<TContractState>, msg: MsgUpgradeClient) {
+            let mut client = self.get_client(msg.client_id.client_type);
+
+            client.upgrade(msg);
+
+            self.emit_upgrade_client_event();
+        }
+    }
+
+    #[generate_trait]
+    pub(crate) impl ClientInternalImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of ClientInternalTrait<TContractState> {
+        fn get_client(
+            ref self: ComponentState<TContractState>, client_type: felt252
+        ) -> ClientContract {
+            let client: ClientContract = self.supported_clients.read(client_type).into();
+
+            assert(client.is_non_zero(), ICS02Errors::UNSUPPORTED_CLIENT_TYPE);
+
+            client
+        }
+
+        fn register_client(
+            ref self: ComponentState<TContractState>,
+            client_type: felt252,
+            client_address: ContractAddress
+        ) {
+            self.supported_clients.write(client_type, client_address);
+        }
+    }
+
+    #[generate_trait]
+    pub(crate) impl ClientEventImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>
+    > of ClientEventTrait<TContractState> {
+        fn emit_create_client_event(
+            ref self: ComponentState<TContractState>, client: @ClientContract, client_sequence: u64
+        ) {
+            self
+                .emit(
+                    CreateClientEvent {
+                        client_id: ClientIdImpl::new(client.client_type(), client_sequence),
+                        consensus_height: client.latest_height(client_sequence),
+                    }
+                );
+        }
+
+        fn emit_update_client_event(
+            ref self: ComponentState<TContractState>,
+            client: @ClientContract,
+            client_sequence: u64,
+            update_heights: Array<Height>,
+            client_message: Array<felt252>
+        ) {
+            self
+                .emit(
+                    UpdateClientEvent {
+                        client_id: ClientIdImpl::new(client.client_type(), client_sequence,),
+                        consensus_heights: update_heights,
+                        header: client_message,
+                    }
+                );
+        }
+
+        fn emit_misbehaviour_event(
+            ref self: ComponentState<TContractState>, client: @ClientContract
+        ) {
+            self
+                .emit(
+                    MisbehaviourEvent {
+                        client_id: ClientIdImpl::new(
+                            client.client_type(), self.client_sequence.read()
+                        ),
+                    }
+                );
+        }
+
+        fn emit_recover_client_event(ref self: ComponentState<TContractState>) {}
+
+        fn emit_upgrade_client_event(ref self: ComponentState<TContractState>) {}
+    }
+}
+

--- a/cairo-contracts/src/core/client/component.cairo
+++ b/cairo-contracts/src/core/client/component.cairo
@@ -1,13 +1,12 @@
 #[starknet::component]
 pub mod ICS02ClientComponent {
     use starknet::ContractAddress;
-    use starknet_ibc::core::client::ICS02Errors;
-    use starknet_ibc::core::client::StatusTrait;
+    use starknet_ibc::core::client::ClientErrors;
     use starknet_ibc::core::client::{
         MsgCreateClient, MsgUpdateClient, MsgRecoverClient, MsgUpgradeClient, Height, UpdateResult
     };
     use starknet_ibc::core::client::{ClientContract, ClientContractTrait};
-    use starknet_ibc::core::host::{ClientId, ClientIdImpl, ClientIdTrait};
+    use starknet_ibc::core::host::{ClientId, ClientIdImpl};
 
     #[storage]
     struct Storage {
@@ -117,7 +116,7 @@ pub mod ICS02ClientComponent {
         ) -> ClientContract {
             let client: ClientContract = self.supported_clients.read(client_type).into();
 
-            assert(client.is_non_zero(), ICS02Errors::UNSUPPORTED_CLIENT_TYPE);
+            assert(client.is_non_zero(), ClientErrors::UNSUPPORTED_CLIENT_TYPE);
 
             client
         }

--- a/cairo-contracts/src/core/client/contract.cairo
+++ b/cairo-contracts/src/core/client/contract.cairo
@@ -1,0 +1,75 @@
+use core::num::traits::Zero;
+use starknet::ContractAddress;
+use starknet_ibc::core::client::interface::{
+    IClientHandler, IClientHandlerDispatcher, IClientStateDispatcher, IClientStateDispatcherTrait,
+    IClientHandlerDispatcherTrait, IClientStateValidation, IClientStateValidationDispatcher,
+    IClientStateValidationDispatcherTrait,
+};
+use starknet_ibc::core::client::msgs::{
+    MsgCreateClient, MsgUpdateClient, MsgRecoverClient, MsgUpgradeClient
+};
+use starknet_ibc::core::client::{UpdateResult, Height};
+
+#[derive(Clone, Debug, Drop, Serde, Store)]
+pub struct ClientContract {
+    pub address: ContractAddress,
+}
+
+impl ContractAddressIntoClientAddr of Into<ContractAddress, ClientContract> {
+    fn into(self: ContractAddress) -> ClientContract {
+        ClientContract { address: self }
+    }
+}
+
+impl ClientContractIntoFelt252 of Into<ClientContract, felt252> {
+    fn into(self: ClientContract) -> felt252 {
+        self.address.into()
+    }
+}
+
+pub trait ClientContractTrait {
+    fn is_non_zero(self: @ClientContract) -> bool;
+
+    fn client_type(self: @ClientContract) -> felt252;
+
+    fn latest_height(self: @ClientContract, client_sequence: u64) -> Height;
+
+    fn create(ref self: ClientContract, msg: MsgCreateClient, client_sequence: u64);
+
+    fn update(ref self: ClientContract, msg: MsgUpdateClient,) -> UpdateResult;
+
+    fn recover(ref self: ClientContract, msg: MsgRecoverClient,);
+
+    fn upgrade(ref self: ClientContract, msg: MsgUpgradeClient,);
+}
+
+
+impl ClientContractImpl of ClientContractTrait {
+    fn is_non_zero(self: @ClientContract) -> bool {
+        self.address.is_non_zero()
+    }
+
+    fn client_type(self: @ClientContract) -> felt252 {
+        IClientStateDispatcher { contract_address: *self.address }.client_type()
+    }
+
+    fn latest_height(self: @ClientContract, client_sequence: u64) -> Height {
+        IClientStateDispatcher { contract_address: *self.address }.latest_height(client_sequence)
+    }
+
+    fn create(ref self: ClientContract, msg: MsgCreateClient, client_sequence: u64) {
+        IClientHandlerDispatcher { contract_address: self.address }.create(msg, client_sequence)
+    }
+
+    fn update(ref self: ClientContract, msg: MsgUpdateClient,) -> UpdateResult {
+        IClientHandlerDispatcher { contract_address: self.address }.update(msg)
+    }
+
+    fn recover(ref self: ClientContract, msg: MsgRecoverClient,) {
+        IClientHandlerDispatcher { contract_address: self.address }.recover(msg)
+    }
+
+    fn upgrade(ref self: ClientContract, msg: MsgUpgradeClient,) {
+        IClientHandlerDispatcher { contract_address: self.address }.upgrade(msg)
+    }
+}

--- a/cairo-contracts/src/core/client/errors.cairo
+++ b/cairo-contracts/src/core/client/errors.cairo
@@ -1,0 +1,3 @@
+pub mod ICS02Errors {
+    pub const UNSUPPORTED_CLIENT_TYPE: felt252 = 'ICS02: unsupported client type';
+}

--- a/cairo-contracts/src/core/client/errors.cairo
+++ b/cairo-contracts/src/core/client/errors.cairo
@@ -1,3 +1,3 @@
-pub mod ICS02Errors {
+pub mod ClientErrors {
     pub const UNSUPPORTED_CLIENT_TYPE: felt252 = 'ICS02: unsupported client type';
 }

--- a/cairo-contracts/src/core/client/interface.cairo
+++ b/cairo-contracts/src/core/client/interface.cairo
@@ -1,0 +1,88 @@
+use starknet::ContractAddress;
+use starknet_ibc::apps::transfer::types::{MsgTransfer, PrefixedDenom};
+use starknet_ibc::core::channel::types::Packet;
+use starknet_ibc::core::client::types::Height;
+use starknet_ibc::core::client::types::{Status, UpdateResult};
+use starknet_ibc::core::client::{
+    MsgCreateClient, MsgUpdateClient, MsgRecoverClient, MsgUpgradeClient
+};
+use starknet_ibc::core::host::ClientId;
+
+#[starknet::interface]
+pub trait IClientHandler<TContractState> {
+    fn create(ref self: TContractState, msg: MsgCreateClient, client_sequence: u64);
+
+    fn update(ref self: TContractState, msg: MsgUpdateClient,) -> UpdateResult;
+
+    fn recover(ref self: TContractState, msg: MsgRecoverClient,);
+
+    fn upgrade(ref self: TContractState, msg: MsgUpgradeClient,);
+}
+
+#[starknet::interface]
+pub trait IRegisterClient<TContractState> {
+    fn register(ref self: TContractState, client_type: felt252, client_address: ContractAddress,);
+}
+
+#[starknet::interface]
+pub trait IClientState<TContractState> {
+    fn client_type(self: @TContractState) -> felt252;
+
+    fn latest_height(self: @TContractState, client_sequence: u64) -> Height;
+
+    fn status(self: @TContractState, client_state: Array<felt252>, client_sequence: u64) -> Status;
+}
+
+#[starknet::interface]
+pub trait IClientStateValidation<TContractState> {
+    fn verify_client_message(
+        self: @TContractState, client_sequence: u64, client_message: Array<felt252>
+    );
+
+    fn verify_misbehaviour(
+        self: @TContractState, client_sequence: u64, client_message: Array<felt252>,
+    ) -> bool;
+
+    fn verify_substitute(self: @TContractState, substitute_client_state: Array<felt252>,);
+
+    fn verify_upgrade(
+        self: @TContractState,
+        upgrade_client_state: Array<felt252>,
+        upgrade_consensus_state: Array<felt252>,
+        proof_upgrade_client: Array<felt252>,
+        proof_upgrade_consensus: Array<felt252>,
+        root: felt252,
+    );
+}
+
+#[starknet::interface]
+pub trait IClientStateExecution<TContractState> {
+    fn initialize(
+        ref self: TContractState,
+        client_sequence: u64,
+        client_state: Array<felt252>,
+        consensus_state: Array<felt252>
+    );
+
+    fn update_state(
+        ref self: TContractState, client_sequence: u64, client_message: Array<felt252>,
+    ) -> UpdateResult;
+
+    fn update_on_misbehaviour(
+        ref self: TContractState, client_sequence: u64, client_message: Array<felt252>,
+    ) -> UpdateResult;
+
+    fn update_on_recover(
+        ref self: TContractState,
+        subject_client_sequence: u64,
+        substitute_client_state: Array<felt252>,
+        substitute_consensus_state: Array<felt252>,
+    );
+
+    fn update_on_upgrade(
+        ref self: TContractState,
+        client_sequence: u64,
+        new_client_state: Array<felt252>,
+        new_consensus_state: Array<felt252>,
+    );
+}

--- a/cairo-contracts/src/core/client/interface.cairo
+++ b/cairo-contracts/src/core/client/interface.cairo
@@ -1,12 +1,8 @@
 use starknet::ContractAddress;
-use starknet_ibc::apps::transfer::types::{MsgTransfer, PrefixedDenom};
-use starknet_ibc::core::channel::types::Packet;
-use starknet_ibc::core::client::types::Height;
-use starknet_ibc::core::client::types::{Status, UpdateResult};
 use starknet_ibc::core::client::{
-    MsgCreateClient, MsgUpdateClient, MsgRecoverClient, MsgUpgradeClient
+    MsgCreateClient, MsgUpdateClient, MsgRecoverClient, MsgUpgradeClient, Height, Status,
+    UpdateResult
 };
-use starknet_ibc::core::host::ClientId;
 
 #[starknet::interface]
 pub trait IClientHandler<TContractState> {

--- a/cairo-contracts/src/core/client/msgs.cairo
+++ b/cairo-contracts/src/core/client/msgs.cairo
@@ -1,0 +1,25 @@
+use starknet_ibc::core::host::ClientId;
+
+#[derive(Clone, Debug, Drop, PartialEq, Serde)]
+pub struct MsgCreateClient {
+    pub client_type: felt252,
+    pub client_state: Array<felt252>,
+    pub consensus_state: Array<felt252>,
+}
+
+#[derive(Clone, Debug, Drop, PartialEq, Serde)]
+pub struct MsgUpdateClient {
+    pub client_id: ClientId,
+    pub client_message: Array<felt252>,
+}
+
+#[derive(Clone, Debug, Drop, PartialEq, Serde)]
+pub struct MsgRecoverClient {
+    pub subject_client_id: ClientId,
+    pub substitute_client_id: ClientId,
+}
+
+#[derive(Clone, Debug, Drop, PartialEq, Serde)]
+pub struct MsgUpgradeClient {
+    pub client_id: ClientId,
+}

--- a/cairo-contracts/src/core/client/types.cairo
+++ b/cairo-contracts/src/core/client/types.cairo
@@ -1,10 +1,85 @@
-#[derive(Clone, Debug, Drop, PartialEq, Eq, Serde, Store)]
+use core::traits::PartialOrd;
+
+#[derive(Clone, Debug, Drop, PartialEq, Serde)]
+pub enum UpdateResult {
+    Success: Array<Height>,
+    Misbehaviour,
+}
+
+pub impl HeightsIntoUpdateResult of Into<Array<Height>, UpdateResult> {
+    fn into(self: Array<Height>) -> UpdateResult {
+        UpdateResult::Success(self)
+    }
+}
+
+#[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
+pub enum Status {
+    Active,
+    Expired,
+    Frozen: Height,
+}
+
+pub trait StatusTrait {
+    fn is_active(self: @Status) -> bool;
+    fn is_expired(self: @Status) -> bool;
+    fn is_frozen(self: @Status) -> bool;
+}
+
+pub impl StatusImpl of StatusTrait {
+    fn is_active(self: @Status) -> bool {
+        match self {
+            Status::Active => true,
+            _ => false,
+        }
+    }
+
+    fn is_expired(self: @Status) -> bool {
+        match self {
+            Status::Expired => true,
+            _ => false,
+        }
+    }
+
+    fn is_frozen(self: @Status) -> bool {
+        match self {
+            Status::Frozen => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
 pub struct Height {
     pub revision_number: u64,
     pub revision_height: u64,
 }
 
-#[derive(Clone, Debug, Drop, PartialEq, Eq, Serde, Store)]
+pub impl HeightPartialOrd of PartialOrd<Height> {
+    fn le(lhs: Height, rhs: Height) -> bool {
+        lhs.revision_number < rhs.revision_number
+            || (lhs.revision_number == rhs.revision_number
+                && lhs.revision_height <= rhs.revision_height)
+    }
+    fn ge(lhs: Height, rhs: Height) -> bool {
+        lhs.revision_number > rhs.revision_number
+            || (lhs.revision_number == rhs.revision_number
+                && lhs.revision_height >= rhs.revision_height)
+    }
+    fn lt(lhs: Height, rhs: Height) -> bool {
+        lhs.revision_number < rhs.revision_number
+            || (lhs.revision_number == rhs.revision_number
+                && lhs.revision_height < rhs.revision_height)
+    }
+    fn gt(lhs: Height, rhs: Height) -> bool {
+        lhs.revision_number > rhs.revision_number
+            || (lhs.revision_number == rhs.revision_number
+                && lhs.revision_height > rhs.revision_height)
+    }
+}
+
+
+#[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
 pub struct Timestamp {
     pub timestamp: u64,
 }
+

--- a/cairo-contracts/src/core/host.cairo
+++ b/cairo-contracts/src/core/host.cairo
@@ -1,2 +1,8 @@
-pub mod errors;
-pub mod types;
+mod errors;
+mod types;
+
+pub use errors::HostErrors;
+pub use types::{
+    ClientId, ClientIdImpl, ClientIdTrait, ChannelId, ChannelIdTrait, PortId, PortIdTrait, Sequence
+};
+

--- a/cairo-contracts/src/lib.cairo
+++ b/cairo-contracts/src/lib.cairo
@@ -1,4 +1,5 @@
 pub mod apps;
+pub mod clients;
 pub mod core;
 pub mod presets;
 pub mod tests;

--- a/cairo-contracts/src/presets.cairo
+++ b/cairo-contracts/src/presets.cairo
@@ -1,6 +1,8 @@
 mod erc20;
+mod ibc;
 mod transfer;
 
 pub use erc20::ERC20Mintable;
+pub use ibc::IBC;
 pub use transfer::Transfer;
 

--- a/cairo-contracts/src/presets/ibc.cairo
+++ b/cairo-contracts/src/presets/ibc.cairo
@@ -1,0 +1,26 @@
+#[starknet::contract]
+pub(crate) mod IBC {
+    use starknet_ibc::core::client::ICS02ClientComponent;
+
+    component!(path: ICS02ClientComponent, storage: client, event: ICS02ClientEvent);
+
+    impl ICS02ClientInitializerImpl = ICS02ClientComponent::ClientInitializerImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        client: ICS02ClientComponent::Storage,
+    }
+
+    #[event]
+    #[derive(Debug, Drop, starknet::Event)]
+    pub enum Event {
+        #[flat]
+        ICS02ClientEvent: ICS02ClientComponent::Event,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState) {
+        self.client.initializer();
+    }
+}

--- a/cairo-contracts/src/tests/config.cairo
+++ b/cairo-contracts/src/tests/config.cairo
@@ -5,8 +5,8 @@ use starknet_ibc::apps::transfer::types::{
     MsgTransfer, PacketData, PrefixedDenom, Denom, Memo, TracePrefixTrait
 };
 use starknet_ibc::core::channel::types::Packet;
-use starknet_ibc::core::client::types::{Height, Timestamp};
-use starknet_ibc::core::host::types::{PortId, ChannelId, Sequence};
+use starknet_ibc::core::client::{Height, Timestamp};
+use starknet_ibc::core::host::{PortId, ChannelId, Sequence};
 use starknet_ibc::tests::constants::{PUBKEY, NAME, AMOUNT, SUPPLY};
 
 #[derive(Clone, Debug, Drop, Serde)]

--- a/cairo-contracts/src/tests/mocks/transfer_mock.cairo
+++ b/cairo-contracts/src/tests/mocks/transfer_mock.cairo
@@ -11,7 +11,7 @@ pub(crate) mod TransferMock {
         ERC20TokenTrait, ERC20Token, PrefixedDenomTrait
     };
     use starknet_ibc::apps::transferrable::component::TransferrableComponent;
-    use starknet_ibc::core::host::types::{PortId, ChannelId, ChannelIdTrait};
+    use starknet_ibc::core::host::{PortId, ChannelId, ChannelIdTrait};
 
     component!(path: TransferrableComponent, storage: transferrable, event: TransferrableEvent);
     component!(path: ICS20TransferComponent, storage: transfer, event: ICS20TransferEvent);


### PR DESCRIPTION
Part of #20

## Description
This PR establishes the core types, interfaces, and implementations needed to draw the relationship between the ICS-02 client component and each distinct client type (here ICS-07). The ICS02 component acts as a client router, responsible for processing messages like `MsgCreateClient`, `MsgUpdateClient`, `MsgRecoverClient`, and `MsgUpgradeClient`. Upon receiving one of these messages, it routes the message to the appropriate Cairo contract for the specified client.

As for the architecture, briefly: each client type should have its own Cairo contract, which can be declared and deployed by anyone. However, the light client's `ContractAddress` must be registered with the IBC core contract, a process only the governance contract is authorized to perform. Once registered, the `ContractAddress` is added to the list of supported clients in the core IBC contract, allowing users to permissionless interact with registered light clients.

In this PR, I've implemented the client creation and update logic for a simplified ICS07 Tendermint client component. Logic related to the recovery, upgrade, and pruning old states has been deferred to future PRs, as these features are of lower priority at this stage. Additionally, unit tests will be added in a subsequent PR to further consolidate the implementation.