### PR TITLE
Update relayer dependencies

### DIFF
--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -704,9 +704,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cgp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf6008adf1725d51be8a8e6e93c83b5cf19fb2e7f2061328af663aa97c306a1"
+dependencies = [
+ "cgp-core",
+ "cgp-extra",
+]
+
+[[package]]
 name = "cgp-async"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d071d4e97afc6ce344786d52f513204e271032e1dc51e59408b6ea545fd270b7"
 dependencies = [
  "cgp-async-macro",
 ]
@@ -714,7 +725,8 @@ dependencies = [
 [[package]]
 name = "cgp-async-macro"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4eeae095965f957262c70b7b3d52eeb7859c5a7f24db7e4330e02ba4e500d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -724,7 +736,8 @@ dependencies = [
 [[package]]
 name = "cgp-component"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2622c229c16df5194795974fe869c875371ac526398f35b9f42853e73123e4dc"
 dependencies = [
  "cgp-async",
  "cgp-component-macro",
@@ -733,7 +746,8 @@ dependencies = [
 [[package]]
 name = "cgp-component-macro"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b293063f328ce024cce876357dbaf4e0341cd202c32ad02d182c00b894d8a1"
 dependencies = [
  "cgp-component-macro-lib",
  "proc-macro2",
@@ -742,7 +756,8 @@ dependencies = [
 [[package]]
 name = "cgp-component-macro-lib"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2505f365511950fec58adb513a8307b11ffea1a06f10b647aa51162de217b424"
 dependencies = [
  "itertools 0.11.0",
  "prettyplease",
@@ -754,20 +769,21 @@ dependencies = [
 [[package]]
 name = "cgp-core"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff5a8db0975e0efa7bb1b8295a0b582059552d0228d441e47c5f4196914f3bd4"
 dependencies = [
  "cgp-async",
  "cgp-component",
  "cgp-error",
  "cgp-field",
  "cgp-inner",
- "cgp-run",
 ]
 
 [[package]]
 name = "cgp-error"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40e53c31277f55360d2ba76a616f2335e006a58ff19c05e6070a0f45931e1cb"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -776,16 +792,27 @@ dependencies = [
 [[package]]
 name = "cgp-error-eyre"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a85dc1bbf5991df1f72742ab8b4496b62c7b2ab4eac54f35856634de0aa9d69"
 dependencies = [
  "cgp-core",
  "eyre",
 ]
 
 [[package]]
+name = "cgp-extra"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704f0d30d3235cb181cc83146f3c9d42999435ff9236743be71aaf182e758ba9"
+dependencies = [
+ "cgp-run",
+]
+
+[[package]]
 name = "cgp-field"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5c75d9db95765005f357690a589c357debb95b6a3233737e095560c5e273cb"
 dependencies = [
  "cgp-field-macro",
 ]
@@ -793,7 +820,8 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c315a7a8847191333ab189234e5eae77df650b9bdf57abfdfc5fe83f188b883"
 dependencies = [
  "cgp-field-macro-lib",
  "proc-macro2",
@@ -802,7 +830,8 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro-lib"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba35e703bac9e476efb61793bdd79b2bfd6abc551f4c7bf9f42899766536d87c"
 dependencies = [
  "itertools 0.11.0",
  "prettyplease",
@@ -814,7 +843,8 @@ dependencies = [
 [[package]]
 name = "cgp-inner"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9992e1a6cf0bb8a13bb72e8a91125a5594c1616555776905043e5924a8e12dd7"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -823,7 +853,8 @@ dependencies = [
 [[package]]
 name = "cgp-run"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/cgp.git#c545eb3cc73df3b9285e282e7fed8b2492af6edb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a08c8d94641ad0376d23aab67b703d0aac7f178d3a2483cf679074fc2b277d"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -1702,9 +1733,10 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 [[package]]
 name = "hermes-any-counterparty"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953baf43f881d8e5f0c13b9ed08a089e4514f40ab28243bfce3afea58b19292e"
 dependencies = [
- "cgp-core",
+ "cgp",
  "cgp-error-eyre",
  "hermes-cosmos-chain-components",
  "hermes-encoding-components",
@@ -1719,10 +1751,11 @@ dependencies = [
 [[package]]
 name = "hermes-async-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ebd58f534e8951d1f5fecad31e2622150bafcbabca5b26456256dbe09531f9"
 dependencies = [
  "async-trait",
- "cgp-core",
+ "cgp",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1733,7 +1766,7 @@ dependencies = [
 name = "hermes-cairo-encoding-components"
 version = "0.1.0"
 dependencies = [
- "cgp-core",
+ "cgp",
  "hermes-encoding-components",
  "hermes-relayer-components",
  "starknet",
@@ -1742,11 +1775,12 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6fd5551d353d08dbd2502c5fac5487c292662cc387b175c72e297d2045e6796"
 dependencies = [
  "bech32 0.9.1",
+ "cgp",
  "cgp-component-macro",
- "cgp-core",
  "eyre",
  "futures",
  "hermes-encoding-components",
@@ -1760,7 +1794,7 @@ dependencies = [
  "ibc-relayer",
  "ibc-relayer-types",
  "ics23",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "prost",
  "prost-types",
  "serde_json",
@@ -1776,9 +1810,10 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-integration-tests"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba81cdbce165224dad2bb46d94dbd72ab91c7dee78349fa903209123b716010d"
 dependencies = [
- "cgp-core",
+ "cgp",
  "eyre",
  "hermes-async-runtime-components",
  "hermes-cosmos-chain-components",
@@ -1810,9 +1845,10 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c97425140376d0d3756e8d851280b9adf61973a3e650d62e15b101df0f959773"
 dependencies = [
- "cgp-core",
+ "cgp",
  "eyre",
  "futures",
  "hermes-any-counterparty",
@@ -1838,7 +1874,7 @@ dependencies = [
  "ibc-relayer",
  "ibc-relayer-types",
  "ibc-telemetry",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "moka",
  "opentelemetry 0.17.0",
  "prost",
@@ -1856,9 +1892,10 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c47a605965aa2ace76186ce0fd5d251edecc47a94df9579c31ef5e76d12b91ee"
 dependencies = [
- "cgp-core",
+ "cgp",
  "hdpath",
  "hermes-cosmos-chain-components",
  "hermes-relayer-components",
@@ -1868,7 +1905,7 @@ dependencies = [
  "ibc-proto",
  "ibc-relayer",
  "ibc-relayer-types",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "prost",
  "serde",
  "serde_json",
@@ -1881,9 +1918,10 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-wasm-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fdde1d45448e718affba18c22c27f4f202f42d57c32238e0471e841009b5069"
 dependencies = [
- "cgp-core",
+ "cgp",
  "eyre",
  "futures",
  "hermes-any-counterparty",
@@ -1911,7 +1949,7 @@ dependencies = [
  "ibc-relayer",
  "ibc-relayer-types",
  "ibc-telemetry",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "moka",
  "opentelemetry 0.17.0",
  "prost",
@@ -1932,17 +1970,19 @@ dependencies = [
 [[package]]
 name = "hermes-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b65ff1e8765232fb550bd30d9159c6ebd54827122ffa9575d5a3ff22c68b72"
 dependencies = [
- "cgp-core",
+ "cgp",
 ]
 
 [[package]]
 name = "hermes-error"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd31d7da382967dfcf33f0a62704876d271c101ade9b8fc542a2cec61cb8baac"
 dependencies = [
- "cgp-core",
+ "cgp",
  "eyre",
  "hermes-relayer-components",
 ]
@@ -1950,9 +1990,10 @@ dependencies = [
 [[package]]
 name = "hermes-ibc-test-suite"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb509b9720088703ccf111f63e626b0597c22bf6c23c54facc3f3ec46564425"
 dependencies = [
- "cgp-core",
+ "cgp",
  "hermes-logging-components",
  "hermes-relayer-components",
  "hermes-test-components",
@@ -1961,9 +2002,10 @@ dependencies = [
 [[package]]
 name = "hermes-logger"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4a7eaf2c85295add84cbe86016085c831e2c2b2d2be9c3d8decdc09bf54488"
 dependencies = [
- "cgp-core",
+ "cgp",
  "hermes-logging-components",
  "hermes-relayer-components",
  "hermes-relayer-components-extra",
@@ -1973,17 +2015,19 @@ dependencies = [
 [[package]]
 name = "hermes-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d30569fdc5eb626e938225dfddcbf1a946cd45ee254a18326763b67747bb4938"
 dependencies = [
- "cgp-core",
+ "cgp",
 ]
 
 [[package]]
 name = "hermes-protobuf-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c200637bd33c20c7038f5880c04a898f4ee2ab27a09b2168060552095560078b"
 dependencies = [
- "cgp-core",
+ "cgp",
  "hermes-encoding-components",
  "prost",
  "prost-types",
@@ -1992,10 +2036,10 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e22a8df3d40132a35059bfbdcb38f1ee40a1b4148c4f3dcebc8958993e1ab0"
 dependencies = [
- "cgp-component-macro",
- "cgp-core",
+ "cgp",
  "hermes-encoding-components",
  "hermes-logging-components",
  "hermes-runtime-components",
@@ -2004,9 +2048,10 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components-extra"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd245e3a539a562b8cf1430feaf1efd4630fa1132c6c756f94c55aa3eb5c9a6"
 dependencies = [
- "cgp-core",
+ "cgp",
  "hermes-logging-components",
  "hermes-relayer-components",
  "hermes-runtime-components",
@@ -2015,9 +2060,10 @@ dependencies = [
 [[package]]
 name = "hermes-runtime"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61d1b64498f9972a1267c77e3804823f7e9bc73a5cfdcc6d22172fa71e7d57c3"
 dependencies = [
- "cgp-core",
+ "cgp",
  "hermes-async-runtime-components",
  "hermes-runtime-components",
  "hermes-tokio-runtime-components",
@@ -2027,9 +2073,10 @@ dependencies = [
 [[package]]
 name = "hermes-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991db35393e0c62db2ca738c5a9a6fec2d54e8b4d814ac96f4deb83ebf8a885a"
 dependencies = [
- "cgp-core",
+ "cgp",
 ]
 
 [[package]]
@@ -2037,7 +2084,7 @@ name = "hermes-starknet-chain-components"
 version = "0.1.0"
 dependencies = [
  "cairo-lang-starknet-classes",
- "cgp-core",
+ "cgp",
  "hermes-cairo-encoding-components",
  "hermes-encoding-components",
  "hermes-protobuf-encoding-components",
@@ -2056,7 +2103,7 @@ name = "hermes-starknet-chain-context"
 version = "0.1.0"
 dependencies = [
  "cairo-lang-starknet-classes",
- "cgp-core",
+ "cgp",
  "eyre",
  "hermes-cairo-encoding-components",
  "hermes-cosmos-chain-components",
@@ -2084,7 +2131,7 @@ dependencies = [
 name = "hermes-starknet-integration-tests"
 version = "0.1.0"
 dependencies = [
- "cgp-core",
+ "cgp",
  "eyre",
  "hermes-cosmos-chain-components",
  "hermes-cosmos-integration-tests",
@@ -2113,7 +2160,7 @@ dependencies = [
 name = "hermes-starknet-test-components"
 version = "0.1.0"
 dependencies = [
- "cgp-core",
+ "cgp",
  "hermes-cosmos-test-components",
  "hermes-relayer-components",
  "hermes-runtime-components",
@@ -2125,9 +2172,10 @@ dependencies = [
 [[package]]
 name = "hermes-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6266d0255b20877d5a250f0218eadadec1aeb322de54f5fcf6214e3a45c0d13"
 dependencies = [
- "cgp-core",
+ "cgp",
  "hermes-relayer-components",
  "hermes-relayer-components-extra",
  "hermes-runtime-components",
@@ -2136,9 +2184,10 @@ dependencies = [
 [[package]]
 name = "hermes-tokio-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c53d99adcb1526d7b9ed5954ad84fbcd33fb4b74c0a07e815efde8c1cd41f97"
 dependencies = [
- "cgp-core",
+ "cgp",
  "futures",
  "hermes-async-runtime-components",
  "hermes-runtime-components",
@@ -2150,9 +2199,10 @@ dependencies = [
 [[package]]
 name = "hermes-tracing-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e6fe47336097bb6ef1f1eb2e25b565bde6e49768757e6a4945a16b957bb9a2"
 dependencies = [
- "cgp-core",
+ "cgp",
  "hermes-logging-components",
  "hermes-relayer-components",
  "hermes-relayer-components-extra",
@@ -2162,9 +2212,10 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f988b126a93012851c3dd6bbfc9c0fed29787fe7297d96437dae156c906d236e"
 dependencies = [
- "cgp-core",
+ "cgp",
  "cgp-error-eyre",
  "hermes-cosmos-chain-components",
  "hermes-encoding-components",
@@ -2180,9 +2231,10 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#f34901035805b91227d36ed0d01eebea31476826"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728777e6a0ae478bf58084891742f7b5670c3a3b54c5b6b3586914daa78d7d5e"
 dependencies = [
- "cgp-core",
+ "cgp",
  "cgp-error-eyre",
  "hermes-cosmos-chain-components",
  "hermes-cosmos-test-components",
@@ -2431,7 +2483,8 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e95f55d8c5cf080fc3824031e5d8026c96cc0707ffb19cf9db0deda0cd5ea186"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2444,7 +2497,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89617c6b9d10039af154e0fa53f9a4a916ba8be1a07b867d138dc562df60228"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2454,7 +2508,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708033d0e7ae4c2ba3e5537a614a6f58809dda7bbe720d10d288ade99bc8934e"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2475,7 +2530,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b227c94f3c5602a7771a8909e8e5403b3f5cdc0144ef229d46ec9f54118cc5a"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2485,7 +2541,8 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631d60b8c1dbd74ba2609d5a7787ff73925fb4c444fe29ef62dbc7fa9b1bde94"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2503,7 +2560,8 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00955ee844a6fee8e13068432c8d9d9b52fd2471121d73fb0ea9f6865e24a587"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2523,7 +2581,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3699afb0fd43f67b08318e48031c6e7efd40cd9dd2507e17cbc00e188ccef60f"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2540,7 +2599,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2bbdc8edd4aa65a02e4255763e2ec11fefcbe019c784373bbba72e2a5cdf1f"
 dependencies = [
  "borsh",
  "displaydoc",
@@ -2558,7 +2618,8 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488bee9150aa0600781007ed7d2c5cd957f037c428ba72c40a04e522d66f27b3"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -2573,7 +2634,8 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ee36072817816bc71e4e33bdf587ed3a05d0ca7625236653112ef15a7e5ff2"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2582,7 +2644,8 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cddf3c01d56ca1ee49b9ffd8c5e8e6f8c650711fb93c88dcabae4b726f07a43"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2598,7 +2661,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93dd27559decbcc30ea4a7d37870a2d819e0c701ce789d4a99419a289eacc6d"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2613,7 +2677,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d0c1d8da6c2f6843d951ec2ccfe0df93f32e96f136870bed90182981648cfb1"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2636,7 +2701,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3fdd2d1cbb6b4e003dec33ed8303254341e75bd828d028aa71deddf67f9ec45"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2649,7 +2715,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969c1f3411b2ca4e6a041ab8e222937f2cea5a26b26beca45164d05468dc4de4"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2665,7 +2732,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6799c8383872fd4bf523dceaadd8c884c2748ad1a542e84e93dcbbd667efc59"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2685,7 +2753,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6e681fc7336d546f7606670b107e8487fd99867f317c2add7eb79b41060d09"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2704,7 +2773,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26abf3cc801896860728d1780c9895994f6ff5ab7bb2af3e5686963c0901654e"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -2718,7 +2788,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c07695b8fba97aded7003031480dd25bdb194fdc1f0cca02508f2dcefe10385"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2739,7 +2810,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658069f1a43790c6dc1288a980a30e1a1667bf0af53fb3f836d56b7ab7ec728c"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2754,7 +2826,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3931e41a6feae1819c59788d2a0a4a08fa51bac3024b63cec4fb88d13882dbee"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2778,7 +2851,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "856e37bcabd67cf26934bd127189844b9fc40004fb545b80bef899bef9092df3"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2796,7 +2870,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34b203c12236140e627270c4d7d469ab2e776a94c22da9051b020303bc6b21f"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2820,7 +2895,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1b9b6000e8f55cc09e00f7552a7c4acb8c42548ef76088e2154ca839387aba"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2835,7 +2911,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195c93f19d8c9c6e36e518656ca381cd4f86131515ad4e99f7e6d2a1836b7b7e"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2849,7 +2926,8 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90d27386ce69af9d3e3c63e590cf6e1d466f948c2b3e2b0911872cb6d88adf5b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2868,7 +2946,8 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.8.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0eb1d08a424a2d714652aca4c2738a016c90f4eb78f6f64913f9fe2c77fe34"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2878,7 +2957,8 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.54.0"
-source = "git+https://github.com/cosmos/ibc-rs.git#60ff9bd16d43d3475ba443069868959f0fdc5bd6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95544f3bc56c8c9cc335910d5aa567a6743a3aeeb33084bb3e31dc6801936edb"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2917,8 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-relayer"
-version = "0.29.2"
-source = "git+https://github.com/informalsystems/hermes.git#ccd1d907df4853203349057bba200077254bb83d"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c476e68cbc686885bdf392162a47f4d122e1c129cf71bdfad7da7c0f478083e6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2983,8 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-relayer-types"
-version = "0.29.2"
-source = "git+https://github.com/informalsystems/hermes.git#ccd1d907df4853203349057bba200077254bb83d"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73841980ed06deeca409245f7a94c25bcec058893435f0a8941542d47c7e7089"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3010,8 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-telemetry"
-version = "0.29.2"
-source = "git+https://github.com/informalsystems/hermes.git#ccd1d907df4853203349057bba200077254bb83d"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a1a80117aa7892e25455e1f9709f0436b54fe39f584fb6e67d2c99e814b121"
 dependencies = [
  "axum 0.6.20",
  "dashmap 5.5.3",
@@ -6200,8 +6283,3 @@ dependencies = [
  "quote",
  "syn 2.0.76",
 ]
-
-[[patch.unused]]
-name = "cairo-lang-starknet-classes"
-version = "2.7.0"
-source = "git+https://github.com/starkware-libs/cairo?tag=v2.7.0#223ca99633f50809c4b574df55545b042494d8d0"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -24,25 +24,22 @@ rust-version = "1.79"
 overflow-checks = true
 
 [workspace.dependencies]
-cgp-core            = { version = "0.1.0" }
-cgp-error-eyre      = { version = "0.1.0" }
-cgp-component-macro = { version = "0.1.0" }
+cgp            = { version = "0.1.0" }
+cgp-error-eyre = { version = "0.1.0" }
 
-clap        = { version = "4.5.8" }
-starknet    = { version = "0.11.0" }
-url         = { version = "2.4.0" }
-eyre        = { version = "0.6.12" }
-tokio       = { version = "1.38" }
-serde_json  = { version = "1.0" }
-rand        = { version = "0.8.5" }
-sha2        = { version = "0.10.8" }
-prost       = { version = "0.13.1" }
-prost-types = { version = "0.13.1" }
+starknet                    = { version = "0.11.0" }
+url                         = { version = "2.4.0" }
+eyre                        = { version = "0.6.12" }
+tokio                       = { version = "1.38" }
+serde_json                  = { version = "1.0" }
+rand                        = { version = "0.8.5" }
+sha2                        = { version = "0.10.8" }
+prost                       = { version = "0.13.1" }
+prost-types                 = { version = "0.13.1" }
+cairo-lang-starknet-classes = { version = "2.7.0" }
 
 ibc                       = { version = "0.54.0" }
 ibc-client-starknet-types = { version = "0.1.0" }
-
-cairo-lang-starknet-classes = { version = "2.7.0" }
 
 hermes-runtime-components           = { version = "0.1.0" }
 hermes-async-runtime-components     = { version = "0.1.0" }
@@ -70,57 +67,6 @@ hermes-starknet-test-components     = { version = "0.1.0" }
 hermes-starknet-chain-context       = { version = "0.1.0" }
 
 [patch.crates-io]
-ibc                   = { git = "https://github.com/cosmos/ibc-rs.git" }
-ibc-core              = { git = "https://github.com/cosmos/ibc-rs.git" }
-ibc-core-client       = { git = "https://github.com/cosmos/ibc-rs.git" }
-ibc-core-host-cosmos  = { git = "https://github.com/cosmos/ibc-rs.git" }
-ibc-client-tendermint = { git = "https://github.com/cosmos/ibc-rs.git" }
-ibc-client-wasm-types = { git = "https://github.com/cosmos/ibc-rs.git" }
-ibc-app-transfer      = { git = "https://github.com/cosmos/ibc-rs.git" }
-ibc-primitives        = { git = "https://github.com/cosmos/ibc-rs.git" }
-ibc-derive            = { git = "https://github.com/cosmos/ibc-rs.git" }
-
-cgp-core                = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-component           = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-component-macro     = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-component-macro-lib = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-field               = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-field-macro         = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-field-macro-lib     = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-error               = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-error-eyre          = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-async               = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-async-macro         = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-run                 = { git = "https://github.com/informalsystems/cgp.git" }
-cgp-inner               = { git = "https://github.com/informalsystems/cgp.git" }
-
-ibc-relayer       = { git = "https://github.com/informalsystems/hermes.git" }
-ibc-telemetry     = { git = "https://github.com/informalsystems/hermes.git" }
-ibc-relayer-types = { git = "https://github.com/informalsystems/hermes.git" }
-
-hermes-relayer-components           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-relayer-components-extra     = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-runtime-components           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-async-runtime-components     = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-tokio-runtime-components     = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-runtime                      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-error                        = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-encoding-components          = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-protobuf-encoding-components = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-logging-components           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-tracing-logging-components   = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-logger                       = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-test-components              = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-ibc-test-suite               = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-any-counterparty             = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-chain-components      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-relayer               = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-wasm-relayer          = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-test-components       = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-integration-tests     = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-wasm-client-components       = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-wasm-test-components         = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-
 hermes-cairo-encoding-components = { path = "./crates/cairo-encoding-components" }
 hermes-starknet-chain-components = { path = "./crates/starknet-chain-components" }
 hermes-starknet-test-components  = { path = "./crates/starknet-test-components" }
@@ -128,4 +74,39 @@ hermes-starknet-chain-context    = { path = "./crates/starknet-chain-context" }
 
 ibc-client-starknet-types = { path = "../light-client/ibc-client-starknet-types" }
 
-cairo-lang-starknet-classes = { git = "https://github.com/starkware-libs/cairo", tag = "v2.7.0" }
+# ibc                   = { git = "https://github.com/cosmos/ibc-rs.git" }
+# ibc-core              = { git = "https://github.com/cosmos/ibc-rs.git" }
+# ibc-core-client       = { git = "https://github.com/cosmos/ibc-rs.git" }
+# ibc-core-host-cosmos  = { git = "https://github.com/cosmos/ibc-rs.git" }
+# ibc-client-tendermint = { git = "https://github.com/cosmos/ibc-rs.git" }
+# ibc-client-wasm-types = { git = "https://github.com/cosmos/ibc-rs.git" }
+# ibc-app-transfer      = { git = "https://github.com/cosmos/ibc-rs.git" }
+# ibc-primitives        = { git = "https://github.com/cosmos/ibc-rs.git" }
+# ibc-derive            = { git = "https://github.com/cosmos/ibc-rs.git" }
+
+# ibc-relayer       = { git = "https://github.com/informalsystems/hermes.git" }
+# ibc-telemetry     = { git = "https://github.com/informalsystems/hermes.git" }
+# ibc-relayer-types = { git = "https://github.com/informalsystems/hermes.git" }
+
+# hermes-relayer-components           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-relayer-components-extra     = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-runtime-components           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-async-runtime-components     = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-tokio-runtime-components     = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-runtime                      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-error                        = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-encoding-components          = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-protobuf-encoding-components = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-logging-components           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-tracing-logging-components   = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-logger                       = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-test-components              = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-ibc-test-suite               = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-any-counterparty             = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-cosmos-chain-components      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-cosmos-relayer               = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-cosmos-wasm-relayer          = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-cosmos-test-components       = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-cosmos-integration-tests     = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-wasm-client-components       = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+# hermes-wasm-test-components         = { git = "https://github.com/informalsystems/hermes-sdk.git" }

--- a/relayer/crates/cairo-encoding-components/Cargo.toml
+++ b/relayer/crates/cairo-encoding-components/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 readme       = "README.md"
 
 [dependencies]
-cgp-core                   = { workspace = true }
+cgp                        = { workspace = true }
 hermes-relayer-components  = { workspace = true }
 hermes-encoding-components = { workspace = true }
 

--- a/relayer/crates/cairo-encoding-components/src/components/encode_mut.rs
+++ b/relayer/crates/cairo-encoding-components/src/components/encode_mut.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 pub use starknet::core::types::{Felt, U256};
 
 use crate::impls::encode_mut::bool::EncodeBool;

--- a/relayer/crates/cairo-encoding-components/src/components/encoding.rs
+++ b/relayer/crates/cairo-encoding-components/src/components/encoding.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 pub use hermes_encoding_components::traits::decode::DecoderComponent;
 pub use hermes_encoding_components::traits::decode_mut::DecodeBufferPeekerComponent;
 pub use hermes_encoding_components::traits::encode::EncoderComponent;

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/bool.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/bool.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
 use starknet::core::types::Felt;

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/combine.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/combine.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use cgp_core::error::HasErrorType;
+use cgp::core::error::HasErrorType;
 use hermes_encoding_components::traits::encode_mut::MutEncoder;
 use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
 

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/delegate.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/delegate.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
-use cgp_core::error::HasErrorType;
-use cgp_core::prelude::DelegateComponent;
+use cgp::core::error::HasErrorType;
+use cgp::prelude::DelegateComponent;
 use hermes_encoding_components::traits::decode_mut::MutDecoder;
 use hermes_encoding_components::traits::encode_mut::MutEncoder;
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/end.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/end.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_encoding_components::traits::decode_mut::MutDecoder;
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;
 

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/felt.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/felt.rs
@@ -1,6 +1,6 @@
 use core::iter;
 
-use cgp_core::error::{CanRaiseError, HasErrorType};
+use cgp::core::error::{CanRaiseError, HasErrorType};
 use hermes_encoding_components::traits::decode_mut::MutDecoder;
 use hermes_encoding_components::traits::encode_mut::MutEncoder;
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/field.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/field.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use cgp_core::field::HasField;
+use cgp::core::field::HasField;
 use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
 
 pub struct EncodeField<Tag>(pub PhantomData<Tag>);

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/from_u128.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/from_u128.rs
@@ -1,4 +1,4 @@
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
 

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/option.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/option.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_encoding_components::traits::decode_mut::MutDecoderComponent;
 use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
 

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/pair.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/pair.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use cgp_core::error::HasErrorType;
+use cgp::core::error::HasErrorType;
 use hermes_encoding_components::traits::decode_mut::MutDecoder;
 use hermes_encoding_components::traits::encode_mut::MutEncoder;
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/string.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/string.rs
@@ -1,7 +1,7 @@
 use std::string::FromUtf8Error;
 
-use cgp_core::error::CanRaiseError;
-use cgp_core::prelude::DelegateComponent;
+use cgp::core::error::CanRaiseError;
+use cgp::prelude::DelegateComponent;
 use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
 

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/u128.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/u128.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::DelegateComponent;
+use cgp::prelude::DelegateComponent;
 use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
 use starknet::core::types::Felt;

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/unit.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/unit.rs
@@ -1,4 +1,4 @@
-use cgp_core::error::HasErrorType;
+use cgp::core::error::HasErrorType;
 use hermes_encoding_components::traits::decode_mut::MutDecoder;
 use hermes_encoding_components::traits::encode_mut::MutEncoder;
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/variant.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/variant.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use cgp_core::error::{CanRaiseError, HasErrorType};
+use cgp::core::error::{CanRaiseError, HasErrorType};
 use hermes_encoding_components::traits::decode_mut::{
     CanDecodeMut, CanPeekDecodeBuffer, MutDecoder,
 };

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/variant_from.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/variant_from.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use cgp_core::error::HasErrorType;
+use cgp::core::error::HasErrorType;
 use hermes_encoding_components::traits::decode_mut::MutDecoder;
 use hermes_encoding_components::traits::encode_mut::MutEncoder;
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;

--- a/relayer/crates/cairo-encoding-components/src/impls/types/encode_buffer.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/types/encode_buffer.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_encoding_components::traits::types::encode_buffer::ProvideEncodeBufferType;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
 use starknet::core::types::Felt;

--- a/relayer/crates/cairo-encoding-components/src/impls/types/encoded.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/types/encoded.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_encoding_components::traits::types::encoded::ProvideEncodedType;
 use starknet::core::types::Felt;
 

--- a/relayer/crates/starknet-chain-components/Cargo.toml
+++ b/relayer/crates/starknet-chain-components/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 readme       = "README.md"
 
 [dependencies]
-cgp-core                            = { workspace = true }
+cgp                                 = { workspace = true }
 ibc                                 = { workspace = true }
 hermes-relayer-components           = { workspace = true }
 hermes-test-components              = { workspace = true }

--- a/relayer/crates/starknet-chain-components/src/components/cairo_encoding.rs
+++ b/relayer/crates/starknet-chain-components/src/components/cairo_encoding.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::components::encode_mut::*;
 pub use hermes_cairo_encoding_components::components::encoding::*;
 use hermes_cairo_encoding_components::impls::encode_mut::delegate::DelegateEncodeMutComponents;

--- a/relayer/crates/starknet-chain-components/src/components/chain.rs
+++ b/relayer/crates/starknet-chain-components/src/components/chain.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 pub use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;
 pub use hermes_relayer_components::chain::traits::types::chain_id::ChainIdTypeComponent;
 pub use hermes_relayer_components::chain::traits::types::client_state::ClientStateTypeComponent;

--- a/relayer/crates/starknet-chain-components/src/components/cosmos_to_starknet.rs
+++ b/relayer/crates/starknet-chain-components/src/components/cosmos_to_starknet.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_relayer_components::chain::impls::queries::query_and_convert_client_state::QueryAndConvertRawClientState;
 use hermes_relayer_components::chain::impls::queries::query_and_convert_consensus_state::QueryAndConvertRawConsensusState;
 use hermes_relayer_components::chain::traits::queries::client_state::{

--- a/relayer/crates/starknet-chain-components/src/components/protobuf_encoding.rs
+++ b/relayer/crates/starknet-chain-components/src/components/protobuf_encoding.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_encoding_components::impls::convert::{ConvertFrom, TryConvertFrom};
 use hermes_encoding_components::impls::convert_and_encode::ConvertAndEncode;
 use hermes_encoding_components::impls::delegate::DelegateEncoding;

--- a/relayer/crates/starknet-chain-components/src/impls/account.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/account.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use starknet::accounts::ConnectedAccount;
 
 use crate::traits::account::{

--- a/relayer/crates/starknet-chain-components/src/impls/contract/call.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/call.rs
@@ -1,4 +1,4 @@
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use starknet::core::types::{BlockId, BlockTag, Felt, FunctionCall};
 use starknet::providers::{Provider, ProviderError};

--- a/relayer/crates/starknet-chain-components/src/impls/contract/declare.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/declare.rs
@@ -4,7 +4,7 @@ use cairo_lang_starknet_classes::casm_contract_class::{
     CasmContractClass, StarknetSierraCompilationError,
 };
 use cairo_lang_starknet_classes::contract_class::ContractClass;
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_relayer_components::transaction::traits::poll_tx_response::CanPollTxResponse;
 use starknet::accounts::Account;
 use starknet::core::types::contract::{

--- a/relayer/crates/starknet-chain-components/src/impls/contract/deploy.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/deploy.rs
@@ -1,4 +1,4 @@
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_relayer_components::transaction::traits::poll_tx_response::CanPollTxResponse;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use starknet::contract::ContractFactory;

--- a/relayer/crates/starknet-chain-components/src/impls/error/account.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/error/account.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use cgp_core::error::{CanRaiseError, ErrorRaiser};
+use cgp::core::error::{CanRaiseError, ErrorRaiser};
 use starknet::accounts::AccountError;
 use starknet::providers::ProviderError;
 

--- a/relayer/crates/starknet-chain-components/src/impls/error/provider.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/error/provider.rs
@@ -1,4 +1,4 @@
-use cgp_core::error::{CanRaiseError, ErrorRaiser};
+use cgp::core::error::{CanRaiseError, ErrorRaiser};
 use starknet::core::types::StarknetError;
 use starknet::providers::ProviderError;
 

--- a/relayer/crates/starknet-chain-components/src/impls/error/starknet.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/error/starknet.rs
@@ -1,4 +1,4 @@
-use cgp_core::error::{CanRaiseError, ErrorRaiser};
+use cgp::core::error::{CanRaiseError, ErrorRaiser};
 use starknet::core::types::StarknetError;
 
 pub struct RaiseStarknetError;

--- a/relayer/crates/starknet-chain-components/src/impls/provider.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/provider.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use starknet::providers::Provider;
 
 use crate::traits::provider::{

--- a/relayer/crates/starknet-chain-components/src/impls/queries/token_balance.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/token_balance.rs
@@ -1,4 +1,4 @@
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_cairo_encoding_components::strategy::ViaCairo;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_encoding_components::traits::decode::CanDecode;

--- a/relayer/crates/starknet-chain-components/src/impls/send_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/send_message.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_relayer_components::chain::traits::send_message::MessageSender;
 use hermes_relayer_components::chain::traits::types::event::HasEventType;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;

--- a/relayer/crates/starknet-chain-components/src/impls/tx_response.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/tx_response.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_relayer_components::transaction::impls::poll_tx_response::PollTimeoutGetter;
 use hermes_relayer_components::transaction::traits::query_tx_response::TxResponseQuerier;
 use hermes_relayer_components::transaction::traits::types::tx_hash::HasTransactionHashType;

--- a/relayer/crates/starknet-chain-components/src/impls/types/address.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/address.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_test_components::chain::traits::types::address::ProvideAddressType;
 use starknet::core::types::Felt;
 

--- a/relayer/crates/starknet-chain-components/src/impls/types/amount.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/amount.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_test_components::chain::traits::types::amount::ProvideAmountType;
 use hermes_test_components::chain::traits::types::denom::HasDenomType;
 use starknet::core::types::Felt;

--- a/relayer/crates/starknet-chain-components/src/impls/types/blob.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/blob.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use starknet::core::types::Felt;
 
 use crate::traits::types::blob::ProvideBlobType;

--- a/relayer/crates/starknet-chain-components/src/impls/types/chain_id.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/chain_id.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_relayer_components::chain::traits::types::chain_id::ProvideChainIdType;
 use starknet::core::types::Felt;
 

--- a/relayer/crates/starknet-chain-components/src/impls/types/client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/client.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_relayer_components::chain::traits::types::client_state::ProvideClientStateType;
 use hermes_relayer_components::chain::traits::types::consensus_state::ProvideConsensusStateType;
 

--- a/relayer/crates/starknet-chain-components/src/impls/types/contract.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/contract.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use starknet::core::types::contract::SierraClass;
 use starknet::core::types::Felt;
 

--- a/relayer/crates/starknet-chain-components/src/impls/types/event.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/event.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_relayer_components::chain::traits::types::event::ProvideEventType;
 
 use crate::types::event::StarknetEvent;

--- a/relayer/crates/starknet-chain-components/src/impls/types/message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/message.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_relayer_components::chain::traits::types::message::ProvideMessageType;
 use starknet::accounts::Call;
 

--- a/relayer/crates/starknet-chain-components/src/impls/types/method.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/method.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use starknet::core::types::Felt;
 
 use crate::traits::types::method::ProvideSelectorType;

--- a/relayer/crates/starknet-chain-components/src/impls/types/transaction.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/transaction.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_relayer_components::transaction::traits::types::transaction::ProvideTransactionType;
 use starknet::accounts::Call;
 

--- a/relayer/crates/starknet-chain-components/src/impls/types/tx_hash.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/tx_hash.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_relayer_components::transaction::traits::types::tx_hash::ProvideTransactionHashType;
 use starknet::core::types::Felt;
 

--- a/relayer/crates/starknet-chain-components/src/impls/types/tx_response.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/tx_response.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_relayer_components::transaction::traits::types::tx_response::ProvideTxResponseType;
 
 use crate::types::tx_response::TxResponse;

--- a/relayer/crates/starknet-chain-components/src/traits/account.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/account.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use starknet::accounts::{Account, AccountError, ConnectedAccount};
 
 #[derive_component(StarknetAccountTypeComponent, ProvideStarknetAccountType<Chain>)]

--- a/relayer/crates/starknet-chain-components/src/traits/client.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/client.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 

--- a/relayer/crates/starknet-chain-components/src/traits/contract/call.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/contract/call.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 
 use crate::traits::types::blob::HasBlobType;

--- a/relayer/crates/starknet-chain-components/src/traits/contract/declare.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/contract/declare.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 
 use crate::traits::types::contract_class::{HasContractClassHashType, HasContractClassType};
 

--- a/relayer/crates/starknet-chain-components/src/traits/contract/deploy.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/contract/deploy.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 
 use crate::traits::types::blob::HasBlobType;

--- a/relayer/crates/starknet-chain-components/src/traits/contract/invoke.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/contract/invoke.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::event::HasEventType;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 

--- a/relayer/crates/starknet-chain-components/src/traits/contract/message.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/contract/message.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 

--- a/relayer/crates/starknet-chain-components/src/traits/event.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/event.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use std::marker::PhantomData;
 
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::event::HasEventType;
 
 #[derive_component(EventParserComponent, EventParser<Chain>)]

--- a/relayer/crates/starknet-chain-components/src/traits/messages/transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/messages/transfer.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use hermes_test_components::chain::traits::types::amount::HasAmountType;

--- a/relayer/crates/starknet-chain-components/src/traits/provider.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/provider.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use starknet::providers::Provider;
 
 #[derive_component(StarknetProviderTypeComponent, ProvideStarknetProviderType<Chain>)]

--- a/relayer/crates/starknet-chain-components/src/traits/queries/token_balance.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/queries/token_balance.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use hermes_test_components::chain::traits::types::amount::HasAmountType;
 

--- a/relayer/crates/starknet-chain-components/src/traits/transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/transfer.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use hermes_test_components::chain::traits::types::amount::HasAmountType;
 

--- a/relayer/crates/starknet-chain-components/src/traits/types/blob.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/types/blob.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 
 #[derive_component(BlobTypeComponent, ProvideBlobType<Chain>)]
 pub trait HasBlobType: Async {

--- a/relayer/crates/starknet-chain-components/src/traits/types/contract_class.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/types/contract_class.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 
 #[derive_component(ContractClassTypeComponent, ProvideContractClassType<Chain>)]
 pub trait HasContractClassType: Async {

--- a/relayer/crates/starknet-chain-components/src/traits/types/method.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/types/method.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 
 #[derive_component(SelectorTypeComponent, ProvideSelectorType<Chain>)]
 pub trait HasSelectorType: Async {

--- a/relayer/crates/starknet-chain-components/src/types/events/erc20.rs
+++ b/relayer/crates/starknet-chain-components/src/types/events/erc20.rs
@@ -1,4 +1,4 @@
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_cairo_encoding_components::strategy::ViaCairo;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_cairo_encoding_components::HList;

--- a/relayer/crates/starknet-chain-components/src/types/events/ics20.rs
+++ b/relayer/crates/starknet-chain-components/src/types/events/ics20.rs
@@ -1,4 +1,4 @@
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_cairo_encoding_components::strategy::ViaCairo;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_cairo_encoding_components::HList;

--- a/relayer/crates/starknet-chain-components/src/types/height.rs
+++ b/relayer/crates/starknet-chain-components/src/types/height.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_relayer_components::chain::traits::types::height::{
     HasHeightType, HeightFieldGetter, ProvideHeightType,
 };

--- a/relayer/crates/starknet-chain-components/src/types/messages/erc20/deploy.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/erc20/deploy.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_cairo_encoding_components::impls::encode_mut::field::EncodeField;
 use hermes_cairo_encoding_components::HList;

--- a/relayer/crates/starknet-chain-components/src/types/messages/erc20/transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/erc20/transfer.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_cairo_encoding_components::impls::encode_mut::field::EncodeField;
 use hermes_cairo_encoding_components::strategy::ViaCairo;

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/denom.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/denom.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_cairo_encoding_components::impls::encode_mut::field::EncodeField;
 use hermes_cairo_encoding_components::impls::encode_mut::from::DecodeFrom;

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/height.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/height.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_cairo_encoding_components::impls::encode_mut::field::EncodeField;
 use hermes_cairo_encoding_components::impls::encode_mut::from::DecodeFrom;

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/ibc_transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/ibc_transfer.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_cairo_encoding_components::impls::encode_mut::field::EncodeField;
 use hermes_cairo_encoding_components::impls::encode_mut::variant_from::EncodeVariantFrom;

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/packet.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/packet.rs
@@ -1,4 +1,4 @@
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_cairo_encoding_components::impls::encode_mut::field::EncodeField;
 use hermes_cairo_encoding_components::impls::encode_mut::from::DecodeFrom;

--- a/relayer/crates/starknet-chain-context/Cargo.toml
+++ b/relayer/crates/starknet-chain-context/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 readme       = "README.md"
 
 [dependencies]
-cgp-core                            = { workspace = true }
+cgp                                 = { workspace = true }
 ibc                                 = { workspace = true }
 hermes-error                        = { workspace = true }
 hermes-runtime                      = { workspace = true }

--- a/relayer/crates/starknet-chain-context/src/contexts/cairo_encoding.rs
+++ b/relayer/crates/starknet-chain-context/src/contexts/cairo_encoding.rs
@@ -1,8 +1,8 @@
 use core::iter::Peekable;
 use core::slice::Iter;
 
-use cgp_core::error::{DelegateErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
-use cgp_core::prelude::*;
+use cgp::core::error::{DelegateErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::impls::encode_mut::pair::EncodeCons;
 use hermes_cairo_encoding_components::impls::encode_mut::with_context::EncodeWithContext;
 use hermes_cairo_encoding_components::strategy::ViaCairo;

--- a/relayer/crates/starknet-chain-context/src/contexts/chain.rs
+++ b/relayer/crates/starknet-chain-context/src/contexts/chain.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use cgp_core::error::{DelegateErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
-use cgp_core::prelude::*;
+use cgp::core::error::{DelegateErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_cosmos_chain_components::components::delegate::DelegateCosmosChainComponents;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;

--- a/relayer/crates/starknet-chain-context/src/contexts/protobuf_encoding.rs
+++ b/relayer/crates/starknet-chain-context/src/contexts/protobuf_encoding.rs
@@ -1,5 +1,5 @@
-use cgp_core::error::{DelegateErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
-use cgp_core::prelude::*;
+use cgp::core::error::{DelegateErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
+use cgp::prelude::*;
 use hermes_encoding_components::traits::convert::CanConvert;
 use hermes_encoding_components::traits::encode_and_decode::CanEncodeAndDecode;
 use hermes_error::impls::ProvideHermesError;

--- a/relayer/crates/starknet-chain-context/src/impls/error.rs
+++ b/relayer/crates/starknet-chain-context/src/impls/error.rs
@@ -3,7 +3,7 @@ use std::convert::Infallible;
 use std::string::FromUtf8Error;
 
 use cairo_lang_starknet_classes::casm_contract_class::StarknetSierraCompilationError;
-use cgp_core::prelude::*;
+use cgp::prelude::*;
 use eyre::Report;
 use hermes_cairo_encoding_components::impls::encode_mut::bool::DecodeBoolError;
 use hermes_cairo_encoding_components::impls::encode_mut::end::NonEmptyBuffer;

--- a/relayer/crates/starknet-integration-tests/Cargo.toml
+++ b/relayer/crates/starknet-integration-tests/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 readme       = "README.md"
 
 [dependencies]
-cgp-core                         = { workspace = true }
+cgp                              = { workspace = true }
 hermes-error                     = { workspace = true }
 hermes-runtime                   = { workspace = true }
 hermes-relayer-components        = { workspace = true }

--- a/relayer/crates/starknet-integration-tests/src/contexts/bootstrap.rs
+++ b/relayer/crates/starknet-integration-tests/src/contexts/bootstrap.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use cgp_core::error::{DelegateErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
-use cgp_core::prelude::*;
+use cgp::core::error::{DelegateErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
+use cgp::prelude::*;
 use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::{
     ChainGenesisConfigTypeComponent, ChainNodeConfigTypeComponent,
 };

--- a/relayer/crates/starknet-integration-tests/src/contexts/chain_driver.rs
+++ b/relayer/crates/starknet-integration-tests/src/contexts/chain_driver.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
-use cgp_core::error::{DelegateErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
-use cgp_core::prelude::*;
+use cgp::core::error::{DelegateErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent};
+use cgp::prelude::*;
 use hermes_error::impls::ProvideHermesError;
 use hermes_starknet_chain_context::contexts::chain::StarknetChain;
 use hermes_starknet_chain_context::impls::error::HandleStarknetError;

--- a/relayer/crates/starknet-test-components/Cargo.toml
+++ b/relayer/crates/starknet-test-components/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 readme       = "README.md"
 
 [dependencies]
-cgp-core                         = { workspace = true }
+cgp                              = { workspace = true }
 hermes-runtime-components        = { workspace = true }
 hermes-relayer-components        = { workspace = true }
 hermes-test-components           = { workspace = true }

--- a/relayer/crates/starknet-test-components/src/impls/bootstrap/bootstrap_chain.rs
+++ b/relayer/crates/starknet-test-components/src/impls/bootstrap/bootstrap_chain.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_cosmos_test_components::bootstrap::traits::chain::build_chain_driver::CanBuildChainDriver;
 use hermes_cosmos_test_components::bootstrap::traits::chain::start_chain::CanStartChainFullNode;
 use hermes_cosmos_test_components::bootstrap::traits::fields::chain_store_dir::HasChainStoreDir;

--- a/relayer/crates/starknet-test-components/src/impls/bootstrap/start_chain.rs
+++ b/relayer/crates/starknet-test-components/src/impls/bootstrap/start_chain.rs
@@ -1,4 +1,4 @@
-use cgp_core::error::CanRaiseError;
+use cgp::core::error::CanRaiseError;
 use hermes_cosmos_test_components::bootstrap::traits::chain::start_chain::ChainFullNodeStarter;
 use hermes_cosmos_test_components::bootstrap::traits::fields::chain_command_path::HasChainCommandPath;
 use hermes_cosmos_test_components::bootstrap::traits::types::chain_node_config::HasChainNodeConfigType;

--- a/relayer/crates/starknet-test-components/src/impls/types/genesis_config.rs
+++ b/relayer/crates/starknet-test-components/src/impls/types/genesis_config.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::ProvideChainGenesisConfigType;
 
 use crate::types::genesis_config::StarknetGenesisConfig;

--- a/relayer/crates/starknet-test-components/src/impls/types/node_config.rs
+++ b/relayer/crates/starknet-test-components/src/impls/types/node_config.rs
@@ -1,4 +1,4 @@
-use cgp_core::Async;
+use cgp::core::Async;
 use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::ProvideChainNodeConfigType;
 
 use crate::types::node_config::StarknetNodeConfig;


### PR DESCRIPTION
We can now use published versions of `cgp` and `hermes-sdk`.