### PR TITLE
imp: refine ICS20 and `IAppCallback` interfaces and improve the wiring

### DIFF
--- a/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
@@ -100,7 +100,7 @@ pub mod TokenTransferComponent {
     }
 
     #[generate_trait]
-    pub(crate) impl SendTransferInternalImpl<
+    impl SendTransferInternalImpl<
         TContractState,
         +HasComponent<TContractState>,
         +ITransferrable<TContractState>,

--- a/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
@@ -10,10 +10,10 @@ pub mod TokenTransferComponent {
     use openzeppelin_access::ownable::interface::IOwnable;
     use starknet::ClassHash;
     use starknet::ContractAddress;
-    use starknet::get_contract_address;
+    use starknet::{get_contract_address, get_caller_address};
     use starknet::storage::Map;
     use starknet_ibc_apps::transfer::interfaces::{
-        ITransferrable, ISendTransfer, IRecvPacket, ITokenAddress
+        ITransferrable, ISendTransfer, ITokenAddress
     };
     use starknet_ibc_apps::transfer::types::{
         MsgTransfer, PrefixedDenom, Denom, DenomTrait, PacketData, TracePrefix, Memo,
@@ -159,22 +159,6 @@ pub mod TokenTransferComponent {
         }
     }
 
-    #[embeddable_as(RecvPacket)]
-    impl RecvPacketImpl<
-        TContractState,
-        +HasComponent<TContractState>,
-        +ITransferrable<TContractState>,
-        +Drop<TContractState>
-    > of IRecvPacket<ComponentState<TContractState>> {
-        fn recv_validate(self: @ComponentState<TContractState>, packet: Packet) {
-            self._recv_validate(packet);
-        }
-
-        fn recv_execute(ref self: ComponentState<TContractState>, packet: Packet) {
-            self._recv_execute(packet);
-        }
-    }
-
     #[embeddable_as(AppCallback)]
     impl AppCallbackImpl<
         TContractState,
@@ -188,7 +172,7 @@ pub mod TokenTransferComponent {
         ) -> Acknowledgement {
             let ownable_comp = get_dep_component!(@self, Ownable);
 
-            assert(ownable_comp.owner() == get_contract_address(), TransferErrors::INVALID_OWNER);
+            assert(ownable_comp.owner() == get_caller_address(), TransferErrors::INVALID_OWNER);
 
             self._recv_execute(packet);
 

--- a/cairo-contracts/packages/apps/src/transfer/interfaces.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/interfaces.cairo
@@ -1,8 +1,7 @@
 mod transfer;
 mod transferrable;
 pub use transfer::{
-    ISendTransfer, ISendTransferDispatcher, ISendTransferDispatcherTrait,
-    ITokenAddress, ITokenAddressDispatcher,
-    ITokenAddressDispatcherTrait,
+    ISendTransfer, ISendTransferDispatcher, ISendTransferDispatcherTrait, ITokenAddress,
+    ITokenAddressDispatcher, ITokenAddressDispatcherTrait,
 };
 pub use transferrable::{ITransferrable, ITransferrableDispatcher, ITransferrableDispatcherTrait};

--- a/cairo-contracts/packages/apps/src/transfer/interfaces.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/interfaces.cairo
@@ -1,8 +1,8 @@
 mod transfer;
 mod transferrable;
 pub use transfer::{
-    ISendTransfer, ISendTransferDispatcher, ISendTransferDispatcherTrait, IRecvPacket,
-    IRecvPacketDispatcher, IRecvPacketDispatcherTrait, ITokenAddress, ITokenAddressDispatcher,
-    ITokenAddressDispatcherTrait
+    ISendTransfer, ISendTransferDispatcher, ISendTransferDispatcherTrait,
+    ITokenAddress, ITokenAddressDispatcher,
+    ITokenAddressDispatcherTrait,
 };
 pub use transferrable::{ITransferrable, ITransferrableDispatcher, ITransferrableDispatcherTrait};

--- a/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
@@ -4,8 +4,7 @@ use starknet_ibc_core::channel::Packet;
 
 #[starknet::interface]
 pub trait ISendTransfer<TContractState> {
-    fn send_validate(self: @TContractState, msg: MsgTransfer);
-    fn send_execute(ref self: TContractState, msg: MsgTransfer);
+    fn send_transfer(ref self: TContractState, msg: MsgTransfer);
 }
 
 #[starknet::interface]

--- a/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
@@ -9,12 +9,6 @@ pub trait ISendTransfer<TContractState> {
 }
 
 #[starknet::interface]
-pub trait IRecvPacket<TContractState> {
-    fn recv_validate(self: @TContractState, packet: Packet);
-    fn recv_execute(ref self: TContractState, packet: Packet);
-}
-
-#[starknet::interface]
 pub trait ITokenAddress<TContractState> {
     /// Returns the contract address of an IBC token given its key.
     ///

--- a/cairo-contracts/packages/contracts/src/apps/transfer.cairo
+++ b/cairo-contracts/packages/contracts/src/apps/transfer.cairo
@@ -35,7 +35,8 @@ pub mod TransferApp {
     impl TokenSendTransferImpl =
         TokenTransferComponent::SendTransfer<ContractState>;
     #[abi(embed_v0)]
-    impl AppCallbackImpl = TokenTransferComponent::AppCallback<ContractState>;
+    impl AppCallbackImpl =
+        TokenTransferComponent::TransferAppCallback<ContractState>;
     #[abi(embed_v0)]
     impl TokenTokenAddressImpl =
         TokenTransferComponent::IBCTokenAddress<ContractState>;

--- a/cairo-contracts/packages/contracts/src/apps/transfer.cairo
+++ b/cairo-contracts/packages/contracts/src/apps/transfer.cairo
@@ -35,7 +35,7 @@ pub mod TransferApp {
     impl TokenSendTransferImpl =
         TokenTransferComponent::SendTransfer<ContractState>;
     #[abi(embed_v0)]
-    impl TokenRecvPacketImpl = TokenTransferComponent::RecvPacket<ContractState>;
+    impl AppCallbackImpl = TokenTransferComponent::AppCallback<ContractState>;
     #[abi(embed_v0)]
     impl TokenTokenAddressImpl =
         TokenTransferComponent::IBCTokenAddress<ContractState>;

--- a/cairo-contracts/packages/contracts/src/apps/transfer.cairo
+++ b/cairo-contracts/packages/contracts/src/apps/transfer.cairo
@@ -35,7 +35,7 @@ pub mod TransferApp {
     impl TokenSendTransferImpl =
         TokenTransferComponent::SendTransfer<ContractState>;
     #[abi(embed_v0)]
-    impl AppCallbackImpl =
+    impl TransferAppCallbackImpl =
         TokenTransferComponent::TransferAppCallback<ContractState>;
     #[abi(embed_v0)]
     impl TokenTokenAddressImpl =

--- a/cairo-contracts/packages/contracts/src/tests/mocks/transfer_mock.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/mocks/transfer_mock.cairo
@@ -35,7 +35,8 @@ pub(crate) mod MockTransferApp {
     impl TokenSendTransferImpl =
         TokenTransferComponent::SendTransfer<ContractState>;
     #[abi(embed_v0)]
-    impl AppCallbackImpl = TokenTransferComponent::AppCallback<ContractState>;
+    impl AppCallbackImpl =
+        TokenTransferComponent::TransferAppCallback<ContractState>;
     #[abi(embed_v0)]
     impl TokenTokenAddressImpl =
         TokenTransferComponent::IBCTokenAddress<ContractState>;

--- a/cairo-contracts/packages/contracts/src/tests/mocks/transfer_mock.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/mocks/transfer_mock.cairo
@@ -41,7 +41,6 @@ pub(crate) mod MockTransferApp {
     impl TokenTokenAddressImpl =
         TokenTransferComponent::IBCTokenAddress<ContractState>;
     impl TransferValidationImpl = TokenTransferComponent::TransferValidationImpl<ContractState>;
-    impl TransferExecutionImpl = TokenTransferComponent::TransferExecutionImpl<ContractState>;
     impl TransferInitializerImpl = TokenTransferComponent::TransferInitializerImpl<ContractState>;
 
     #[storage]

--- a/cairo-contracts/packages/contracts/src/tests/mocks/transfer_mock.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/mocks/transfer_mock.cairo
@@ -35,7 +35,7 @@ pub(crate) mod MockTransferApp {
     impl TokenSendTransferImpl =
         TokenTransferComponent::SendTransfer<ContractState>;
     #[abi(embed_v0)]
-    impl TokenRecvPacketImpl = TokenTransferComponent::RecvPacket<ContractState>;
+    impl AppCallbackImpl = TokenTransferComponent::AppCallback<ContractState>;
     #[abi(embed_v0)]
     impl TokenTokenAddressImpl =
         TokenTransferComponent::IBCTokenAddress<ContractState>;

--- a/cairo-contracts/packages/contracts/src/tests/mocks/transfer_mock.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/mocks/transfer_mock.cairo
@@ -35,12 +35,13 @@ pub(crate) mod MockTransferApp {
     impl TokenSendTransferImpl =
         TokenTransferComponent::SendTransfer<ContractState>;
     #[abi(embed_v0)]
-    impl AppCallbackImpl =
+    impl TransferAppCallbackImpl =
         TokenTransferComponent::TransferAppCallback<ContractState>;
     #[abi(embed_v0)]
     impl TokenTokenAddressImpl =
         TokenTransferComponent::IBCTokenAddress<ContractState>;
     impl TransferValidationImpl = TokenTransferComponent::TransferValidationImpl<ContractState>;
+    impl TransferExecutionImpl = TokenTransferComponent::TransferExecutionImpl<ContractState>;
     impl TransferInitializerImpl = TokenTransferComponent::TransferInitializerImpl<ContractState>;
 
     #[storage]

--- a/cairo-contracts/packages/contracts/src/tests/setups/transfer.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/setups/transfer.cairo
@@ -7,9 +7,10 @@ use starknet_ibc_apps::transfer::components::TokenTransferComponent::{
     Event, SendEvent, RecvEvent, CreateTokenEvent
 };
 use starknet_ibc_apps::transfer::interfaces::{
-    ISendTransferDispatcher, IRecvPacketDispatcher, ITokenAddressDispatcher,
-    ISendTransferDispatcherTrait, IRecvPacketDispatcherTrait, ITokenAddressDispatcherTrait
+    ISendTransferDispatcher, ITokenAddressDispatcher,
+    ISendTransferDispatcherTrait, ITokenAddressDispatcherTrait,
 };
+use starknet_ibc_core::channel::{IAppCallback, IAppCallbackDispatcher, IAppCallbackDispatcherTrait};
 use starknet_ibc_apps::transfer::types::{MsgTransfer, Participant, PrefixedDenom, Memo};
 use starknet_ibc_contracts::tests::constants::OWNER;
 use starknet_ibc_core::channel::Packet;
@@ -22,10 +23,10 @@ pub struct TransferAppHandle {
 
 #[generate_trait]
 pub impl TransferAppHandleImpl of TransferAppHandleTrait {
-    fn setup(erc20_class: ContractClass) -> TransferAppHandle {
+    fn setup(owner: ContractAddress, erc20_class: ContractClass) -> TransferAppHandle {
         let mut call_data = array![];
 
-        call_data.append_serde(OWNER());
+        call_data.append_serde(owner);
         call_data.append_serde(erc20_class.class_hash);
 
         let contract_address = declare_and_deploy("TransferApp", call_data);
@@ -39,8 +40,8 @@ pub impl TransferAppHandleImpl of TransferAppHandleTrait {
         ISendTransferDispatcher { contract_address: *self.contract_address }
     }
 
-    fn recv_dispatcher(self: @TransferAppHandle) -> IRecvPacketDispatcher {
-        IRecvPacketDispatcher { contract_address: *self.contract_address }
+    fn callback_dispatcher(self: @TransferAppHandle) -> IAppCallbackDispatcher {
+        IAppCallbackDispatcher { contract_address: *self.contract_address }
     }
 
     fn ibc_token_address(self: @TransferAppHandle, token_key: felt252) -> Option<ContractAddress> {
@@ -52,8 +53,8 @@ pub impl TransferAppHandleImpl of TransferAppHandleTrait {
         self.send_dispatcher().send_execute(msg);
     }
 
-    fn recv_execute(self: @TransferAppHandle, packet: Packet) {
-        self.recv_dispatcher().recv_execute(packet);
+    fn on_recv_packet(self: @TransferAppHandle, packet: Packet) {
+        self.callback_dispatcher().on_recv_packet(packet);
     }
 
     fn assert_send_event(

--- a/cairo-contracts/packages/contracts/src/tests/setups/transfer.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/setups/transfer.cairo
@@ -7,13 +7,13 @@ use starknet_ibc_apps::transfer::components::TokenTransferComponent::{
     Event, SendEvent, RecvEvent, CreateTokenEvent
 };
 use starknet_ibc_apps::transfer::interfaces::{
-    ISendTransferDispatcher, ITokenAddressDispatcher,
-    ISendTransferDispatcherTrait, ITokenAddressDispatcherTrait,
+    ISendTransferDispatcher, ITokenAddressDispatcher, ISendTransferDispatcherTrait,
+    ITokenAddressDispatcherTrait,
 };
-use starknet_ibc_core::channel::{IAppCallback, IAppCallbackDispatcher, IAppCallbackDispatcherTrait};
 use starknet_ibc_apps::transfer::types::{MsgTransfer, Participant, PrefixedDenom, Memo};
 use starknet_ibc_contracts::tests::constants::OWNER;
 use starknet_ibc_core::channel::Packet;
+use starknet_ibc_core::channel::{IAppCallback, IAppCallbackDispatcher, IAppCallbackDispatcherTrait};
 
 #[derive(Drop, Serde)]
 pub struct TransferAppHandle {
@@ -49,8 +49,8 @@ pub impl TransferAppHandleImpl of TransferAppHandleTrait {
             .ibc_token_address(token_key)
     }
 
-    fn send_execute(self: @TransferAppHandle, msg: MsgTransfer) {
-        self.send_dispatcher().send_execute(msg);
+    fn send_transfer(self: @TransferAppHandle, msg: MsgTransfer) {
+        self.send_dispatcher().send_transfer(msg);
     }
 
     fn on_recv_packet(self: @TransferAppHandle, packet: Packet) {

--- a/cairo-contracts/packages/contracts/src/tests/test_transfer.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/test_transfer.cairo
@@ -40,7 +40,7 @@ fn test_escrow_unescrow_roundtrip() {
     let msg_transfer = cfg.dummy_msg_transder(cfg.native_denom.clone(), STARKNET(), COSMOS());
 
     // Submit a `MsgTransfer` to the `TransferApp` contract.
-    ics20.send_execute(msg_transfer);
+    ics20.send_transfer(msg_transfer);
 
     // Assert the `SendEvent` emitted.
     ics20.assert_send_event(STARKNET(), COSMOS(), cfg.native_denom.clone(), cfg.amount);
@@ -135,7 +135,7 @@ fn test_mint_burn_roundtrip() {
     let msg_transfer = cfg.dummy_msg_transder(prefixed_denom.clone(), STARKNET(), COSMOS());
 
     // Owner approves the amount of allowance for the `TransferApp` contract.
-    ics20.send_execute(msg_transfer);
+    ics20.send_transfer(msg_transfer);
 
     // Assert the `SendEvent` emitted.
     ics20.assert_send_event(STARKNET(), COSMOS(), prefixed_denom, cfg.amount);

--- a/cairo-contracts/packages/core/src/channel/interface.cairo
+++ b/cairo-contracts/packages/core/src/channel/interface.cairo
@@ -8,4 +8,6 @@ pub trait IChannelHandler<TContractState> {
 #[starknet::interface]
 pub trait IAppCallback<TContractState> {
     fn on_recv_packet(ref self: TContractState, packet: Packet) -> Acknowledgement;
+    fn on_acknowledgement_packet(ref self: TContractState, packet: Packet, ack: Acknowledgement);
+    fn on_timeout_packet(ref self: TContractState, packet: Packet);
 }

--- a/relayer/crates/starknet-integration-tests/tests/ibc.rs
+++ b/relayer/crates/starknet-integration-tests/tests/ibc.rs
@@ -22,7 +22,6 @@ use hermes_starknet_chain_context::contexts::encoding::event::StarknetEventEncod
 use hermes_starknet_integration_tests::contexts::bootstrap::StarknetBootstrap;
 use hermes_test_components::bootstrap::traits::chain::CanBootstrapChain;
 use starknet::accounts::Call;
-use starknet::core::types::Felt;
 use starknet::macros::selector;
 
 #[test]
@@ -84,7 +83,8 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
         };
 
         let ics20_contract_address = {
-            let owner_call_data = cairo_encoding.encode(&Felt::from(1))?; // dummy owner
+            let owner_call_data =
+                cairo_encoding.encode(&chain_driver.relayer_wallet.account_address)?;
             let erc20_call_data = cairo_encoding.encode(&erc20_class_hash)?;
 
             let contract_address = chain
@@ -140,7 +140,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
 
             Call {
                 to: ics20_contract_address,
-                selector: selector!("recv_execute"),
+                selector: selector!("on_recv_packet"),
                 calldata,
             }
         };


### PR DESCRIPTION
## Description

In this PR, the `IRecvPacket` interface under ICS-20 has been removed. Now, packet processing will only occur when a packet is passed to the ICS-20 contract via application callbacks (methods under the `IAppCallback`).

Additionally, the methods under `ISendTransfer` have been merged, and we will now expose a single `send_transfer` entry point. (cc @soareschen) This change aims for improved contract security by reducing unnecessary exposure.