### PR TITLE
deps: upgrade `cairo`, `scarb` and `snforge` versions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ ICS20_CONTRACT_SRC=${CONTRACT_SRC:-$(pwd)/cairo-contracts/target/dev/starknet_ib
 RPC_URL=https://starknet-sepolia.public.blastapi.io/rpc/v0_7
 ACCOUNT_SRC="${HOME}/.starkli-wallets/deployer/account.json"
 KEYSTORE_SRC="${HOME}/.starkli-wallets/deployer/keystore.json"
-COMPILER_VERSION=2.6.2
+COMPILER_VERSION=2.7.1
 KEYSTORE_PASS=<KEYSTORE_PASSWORD>
 
 ERC20_CLASS_HASH=""

--- a/.github/workflows/cairo-contracts.yaml
+++ b/.github/workflows/cairo-contracts.yaml
@@ -41,4 +41,4 @@ jobs:
         working-directory: ./cairo-contracts
         run: |
           nix develop -c \
-            snforge test -w
+            scarb test -w

--- a/cairo-contracts/.tool-versions
+++ b/cairo-contracts/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.7.0
-starknet-foundry 0.26.0
+scarb 2.8.0
+starknet-foundry 0.27.0

--- a/cairo-contracts/Scarb.lock
+++ b/cairo-contracts/Scarb.lock
@@ -3,8 +3,8 @@ version = 1
 
 [[package]]
 name = "openzeppelin_access"
-version = "0.15.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.15.1#2f8a93d762858714095a1d391afffa9e21df6983"
+version = "0.16.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -12,8 +12,8 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_account"
-version = "0.15.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.15.1#2f8a93d762858714095a1d391afffa9e21df6983"
+version = "0.16.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -21,8 +21,8 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_governance"
-version = "0.15.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.15.1#2f8a93d762858714095a1d391afffa9e21df6983"
+version = "0.16.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_introspection",
@@ -30,21 +30,21 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_introspection"
-version = "0.15.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.15.1#2f8a93d762858714095a1d391afffa9e21df6983"
+version = "0.16.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 
 [[package]]
 name = "openzeppelin_testing"
-version = "0.15.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.15.1#2f8a93d762858714095a1d391afffa9e21df6983"
+version = "0.16.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "snforge_std",
 ]
 
 [[package]]
 name = "openzeppelin_token"
-version = "0.15.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.15.1#2f8a93d762858714095a1d391afffa9e21df6983"
+version = "0.16.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "openzeppelin_account",
  "openzeppelin_governance",
@@ -53,13 +53,13 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_utils"
-version = "0.15.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.15.1#2f8a93d762858714095a1d391afffa9e21df6983"
+version = "0.16.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 
 [[package]]
 name = "snforge_std"
-version = "0.26.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.26.0#50eb589db65e113efe4f09241feb59b574228c7e"
+version = "0.27.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.27.0#2d99b7c00678ef0363881ee0273550c44a9263de"
 
 [[package]]
 name = "starknet_ibc"

--- a/cairo-contracts/Scarb.toml
+++ b/cairo-contracts/Scarb.toml
@@ -10,8 +10,8 @@ members = [
 [workspace.package]
 version       = "0.1.0"
 edition       = "2023_11"
-cairo-version = "2.7.0"
-scarb-version = "2.7.0"
+cairo-version = "2.8.0"
+scarb-version = "2.8.0"
 license       = "Apache-2.0"
 authors       = [ "Informal Systems <hello@informal.systems>" ]
 repository    = "https://github.com/informalsystems/ibc-starknet"
@@ -24,13 +24,13 @@ test = "snforge test"
 
 [workspace.dependencies]
 # external dependencies
-cairo_test           = "2.7.0"
-starknet             = "2.7.0"
-openzeppelin_access  = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.15.1" }
-openzeppelin_token   = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.15.1" }
-openzeppelin_testing = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.15.1" }
-openzeppelin_utils   = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.15.1" }
-snforge_std          = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.26.0" }
+cairo_test           = "2.8.0"
+starknet             = "2.8.0"
+openzeppelin_access  = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.16.0" }
+openzeppelin_token   = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.16.0" }
+openzeppelin_testing = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.16.0" }
+openzeppelin_utils   = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.16.0" }
+snforge_std          = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.27.0" }
 
 # ibc dependencies
 starknet_ibc_apps      = { path = "packages/apps" }

--- a/cairo-contracts/packages/apps/src/lib.cairo
+++ b/cairo-contracts/packages/apps/src/lib.cairo
@@ -37,6 +37,8 @@ pub mod tests {
     mod extend_spy;
     #[cfg(test)]
     mod test_transfer;
+    #[cfg(test)]
+    pub use mocks::mock_transfer::MockTransferApp;
     pub use config::{TransferAppConfig, TransferAppConfigImpl, TransferAppConfigTrait};
     pub use dummy::{
         NAME, SYMBOL, PUBKEY, AMOUNT, SUPPLY, OWNER, STARKNET, COSMOS, SALT, DECIMALS, CLASS_HASH,
@@ -44,8 +46,8 @@ pub mod tests {
     };
 
     pub use extend_spy::{TransferEventSpyExtImpl, TransferEventSpyExt};
-    pub(crate) use mocks::mock_transfer::MockTransferApp;
+    #[cfg(test)]
     mod mocks {
-        pub(crate) mod mock_transfer;
+        pub mod mock_transfer;
     }
 }

--- a/cairo-contracts/packages/apps/src/tests/config.cairo
+++ b/cairo-contracts/packages/apps/src/tests/config.cairo
@@ -1,13 +1,12 @@
 use starknet::ContractAddress;
-use starknet_ibc_apps::tests::{PUBKEY, NAME, AMOUNT, SUPPLY, EMPTY_MEMO};
-use starknet_ibc_apps::transfer::TRANSFER_PORT_ID;
+use starknet_ibc_apps::tests::{PUBKEY, NAME, AMOUNT, EMPTY_MEMO};
 use starknet_ibc_apps::transfer::types::PrefixedDenomTrait;
 use starknet_ibc_apps::transfer::types::{
-    MsgTransfer, PacketData, PrefixedDenom, Denom, Memo, TracePrefixTrait, Participant
+    MsgTransfer, PacketData, PrefixedDenom, Denom, TracePrefixTrait, Participant
 };
 use starknet_ibc_core::channel::{Packet, MsgRecvPacket};
 use starknet_ibc_core::client::Timestamp;
-use starknet_ibc_core::host::{PortId, ChannelId, Sequence};
+use starknet_ibc_core::host::{ChannelId, Sequence};
 use starknet_ibc_core::tests::{PORT_ID, CHANNEL_ID, HEIGHT};
 
 #[derive(Clone, Debug, Drop, Serde)]

--- a/cairo-contracts/packages/apps/src/tests/extend_spy.cairo
+++ b/cairo-contracts/packages/apps/src/tests/extend_spy.cairo
@@ -5,7 +5,7 @@ use starknet_ibc_apps::tests::EMPTY_MEMO;
 use starknet_ibc_apps::transfer::TokenTransferComponent::{
     Event, SendEvent, RecvEvent, CreateTokenEvent
 };
-use starknet_ibc_apps::transfer::types::{Participant, PrefixedDenom, Memo};
+use starknet_ibc_apps::transfer::types::{Participant, PrefixedDenom};
 
 #[generate_trait]
 pub impl TransferEventSpyExtImpl of TransferEventSpyExt {

--- a/cairo-contracts/packages/apps/src/tests/mocks/mock_transfer.cairo
+++ b/cairo-contracts/packages/apps/src/tests/mocks/mock_transfer.cairo
@@ -3,13 +3,10 @@ pub(crate) mod MockTransferApp {
     use openzeppelin_access::ownable::OwnableComponent;
     use starknet::ClassHash;
     use starknet::ContractAddress;
-    use starknet_ibc_apps::transfer::types::{
-        PrefixedDenom, Denom, DenomTrait, PacketData, TracePrefix, Memo, TracePrefixTrait,
-        PrefixedDenomTrait
-    };
-    use starknet_ibc_apps::transfer::{ERC20Contract, ERC20ContractTrait};
+    use starknet_ibc_apps::transfer::ERC20Contract;
+    use starknet_ibc_apps::transfer::types::{PrefixedDenom, Memo};
     use starknet_ibc_apps::transfer::{TokenTransferComponent, TransferrableComponent};
-    use starknet_ibc_core::host::{PortId, ChannelId, ChannelIdTrait};
+    use starknet_ibc_core::host::{PortId, ChannelId};
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     component!(path: TransferrableComponent, storage: transferrable, event: TransferrableEvent);

--- a/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
@@ -4,7 +4,6 @@ pub mod TokenTransferComponent {
     use core::clone::Clone;
     use core::num::traits::Zero;
     use core::option::OptionTrait;
-    use core::starknet::SyscallResultTrait;
     use core::traits::TryInto;
     use openzeppelin_access::ownable::OwnableComponent;
     use openzeppelin_access::ownable::interface::IOwnable;
@@ -13,13 +12,13 @@ pub mod TokenTransferComponent {
     use starknet::storage::Map;
     use starknet::{get_contract_address, get_caller_address};
     use starknet_ibc_apps::transfer::types::{
-        MsgTransfer, PrefixedDenom, Denom, DenomTrait, PacketData, TracePrefix, Memo,
-        TracePrefixTrait, PrefixedDenomTrait, Participant
+        MsgTransfer, PrefixedDenom, Denom, DenomTrait, PacketData, Memo, TracePrefixTrait,
+        PrefixedDenomTrait, Participant
     };
     use starknet_ibc_apps::transfer::{ERC20Contract, ERC20ContractTrait, TransferErrors};
     use starknet_ibc_apps::transfer::{ITransferrable, ISendTransfer, ITokenAddress};
     use starknet_ibc_core::channel::{Packet, Acknowledgement, IAppCallback};
-    use starknet_ibc_core::host::{PortId, ChannelId, ChannelIdTrait};
+    use starknet_ibc_core::host::{PortId, ChannelId};
     use starknet_ibc_utils::{ComputeKeyTrait, ValidateBasicTrait};
 
     #[storage]

--- a/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
@@ -1,6 +1,5 @@
 use starknet::ContractAddress;
-use starknet_ibc_apps::transfer::types::{MsgTransfer, PrefixedDenom};
-use starknet_ibc_core::channel::Packet;
+use starknet_ibc_apps::transfer::types::MsgTransfer;
 
 #[starknet::interface]
 pub trait ISendTransfer<TContractState> {

--- a/cairo-contracts/packages/apps/src/transfer/types.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/types.cairo
@@ -1,9 +1,6 @@
 use core::array::ArrayTrait;
-use core::hash::{HashStateTrait, HashStateExTrait};
 use core::num::traits::Zero;
-use core::poseidon::PoseidonTrait;
 use starknet::ContractAddress;
-use starknet::contract_address_const;
 use starknet_ibc_apps::transfer::{
     ERC20Contract, ERC20ContractTrait, TransferErrors, TRANSFER_PORT_ID_HASH
 };

--- a/cairo-contracts/packages/clients/src/cometbft/component.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/component.cairo
@@ -1,6 +1,5 @@
 #[starknet::component]
 pub mod CometClientComponent {
-    use core::num::traits::zero::Zero;
     use starknet::storage::Map;
     use starknet::{get_block_timestamp, get_block_number};
     use starknet_ibc_clients::cometbft::{

--- a/cairo-contracts/packages/clients/src/cometbft/consensus_state.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/consensus_state.cairo
@@ -1,6 +1,6 @@
 use core::num::traits::Zero;
 use starknet_ibc_clients::cometbft::CometErrors;
-use starknet_ibc_core::client::{Height, Status};
+use starknet_ibc_core::client::Status;
 
 #[derive(Clone, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
 pub struct CometConsensusState {

--- a/cairo-contracts/packages/clients/src/lib.cairo
+++ b/cairo-contracts/packages/clients/src/lib.cairo
@@ -19,10 +19,12 @@ pub mod tests {
     mod config;
     #[cfg(test)]
     mod test_cometbft;
+    #[cfg(test)]
+    pub use mocks::mock_cometbft::MockCometClient;
 
     pub use config::{CometClientConfig, CometClientConfigImpl, CometClientConfigTrait};
-    pub(crate) use mocks::mock_cometbft::MockCometClient;
+    #[cfg(test)]
     mod mocks {
-        pub(crate) mod mock_cometbft;
+        pub mod mock_cometbft;
     }
 }

--- a/cairo-contracts/packages/clients/src/tests/test_cometbft.cairo
+++ b/cairo-contracts/packages/clients/src/tests/test_cometbft.cairo
@@ -1,4 +1,4 @@
-use snforge_std::cheat_block_timestamp_global;
+use snforge_std::start_cheat_block_timestamp_global;
 use starknet_ibc_clients::cometbft::CometClientComponent::{
     CometClientHandler, CometCommonClientState, ClientReaderImpl
 };
@@ -22,7 +22,7 @@ fn setup() -> ComponentState {
 fn test_create_client_ok() {
     let mut state = setup();
     let mut cfg = CometClientConfigTrait::default();
-    cheat_block_timestamp_global(cfg.latest_timestamp + 1);
+    start_cheat_block_timestamp_global(cfg.latest_timestamp + 1);
     let msg = cfg.dummy_msg_create_client();
     state.create_client(msg);
     assert_eq!(state.client_type(), cfg.client_type);
@@ -35,7 +35,7 @@ fn test_create_client_ok() {
 fn test_client_sequence_ok() {
     let mut state = setup();
     let mut cfg = CometClientConfigTrait::default();
-    cheat_block_timestamp_global(cfg.latest_timestamp + 1);
+    start_cheat_block_timestamp_global(cfg.latest_timestamp + 1);
     let msg = cfg.dummy_msg_create_client();
     state.create_client(msg.clone());
     state.create_client(msg);
@@ -46,7 +46,7 @@ fn test_client_sequence_ok() {
 fn test_update_client_ok() {
     let mut state = setup();
     let mut cfg = CometClientConfigTrait::default();
-    cheat_block_timestamp_global(cfg.latest_timestamp + 1);
+    start_cheat_block_timestamp_global(cfg.latest_timestamp + 1);
     let msg = cfg.dummy_msg_create_client();
     let create_resp = state.create_client(msg);
     let updating_height = cfg.latest_height.clone() + HEIGHT(5);

--- a/cairo-contracts/packages/contracts/src/erc20.cairo
+++ b/cairo-contracts/packages/contracts/src/erc20.cairo
@@ -2,7 +2,7 @@
 pub mod ERC20Mintable {
     use openzeppelin_access::ownable::OwnableComponent;
     use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
-    use starknet::{ContractAddress, ClassHash};
+    use starknet::ContractAddress;
     use starknet_ibc_utils::mintable::ERC20MintableComponent::ERC20MintableInternalTrait;
     use starknet_ibc_utils::mintable::ERC20MintableComponent;
 

--- a/cairo-contracts/packages/contracts/src/tests/handles/app.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/handles/app.cairo
@@ -1,19 +1,14 @@
-use openzeppelin_testing::events::{EventSpyExt, EventSpyExtImpl};
-use openzeppelin_testing::{declare_class, declare_and_deploy};
+use openzeppelin_testing::declare_and_deploy;
+use openzeppelin_testing::events::EventSpyExtImpl;
 use openzeppelin_utils::serde::SerializedAppend;
-use snforge_std::{EventSpy, spy_events, ContractClass};
+use snforge_std::ContractClass;
 use starknet::ContractAddress;
-use starknet_ibc_apps::tests::OWNER;
-use starknet_ibc_apps::transfer::TokenTransferComponent::{
-    Event, SendEvent, RecvEvent, CreateTokenEvent
-};
-use starknet_ibc_apps::transfer::types::{MsgTransfer, Participant, PrefixedDenom, Memo};
+use starknet_ibc_apps::transfer::types::MsgTransfer;
 use starknet_ibc_apps::transfer::{
     ISendTransferDispatcher, ITokenAddressDispatcher, ISendTransferDispatcherTrait,
     ITokenAddressDispatcherTrait,
 };
-use starknet_ibc_core::channel::Packet;
-use starknet_ibc_core::channel::{IAppCallback, IAppCallbackDispatcher, IAppCallbackDispatcherTrait};
+use starknet_ibc_core::channel::{IAppCallbackDispatcher, IAppCallbackDispatcherTrait, Packet};
 
 #[derive(Drop, Serde)]
 pub struct AppContract {

--- a/cairo-contracts/packages/contracts/src/tests/handles/core.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/handles/core.cairo
@@ -1,20 +1,14 @@
-use openzeppelin_testing::{declare_class, declare_and_deploy};
-use openzeppelin_utils::serde::SerializedAppend;
-use snforge_std::ContractClass;
+use openzeppelin_testing::declare_and_deploy;
 use starknet::ContractAddress;
 use starknet_ibc_core::channel::{
     IChannelHandlerDispatcher, IChannelHandlerDispatcherTrait, MsgRecvPacket
 };
-use starknet_ibc_core::client::ClientEventEmitterComponent::{
-    Event, CreateClientEvent, UpdateClientEvent
-};
 use starknet_ibc_core::client::{
     IClientHandlerDispatcher, IClientHandlerDispatcherTrait, IRegisterClientDispatcher,
-    IRegisterClientDispatcherTrait, MsgCreateClient, MsgUpdateClient, CreateResponse,
-    UpdateResponse, Height
+    IRegisterClientDispatcherTrait, MsgCreateClient, MsgUpdateClient, CreateResponse, UpdateResponse
 };
 
-#[derive(Drop, Serde)]
+#[derive(Copy, Drop, Serde)]
 pub struct CoreContract {
     pub address: ContractAddress
 }

--- a/cairo-contracts/packages/contracts/src/tests/handles/erc20.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/handles/erc20.cairo
@@ -1,5 +1,5 @@
 use openzeppelin_testing::deploy;
-use openzeppelin_token::erc20::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
+use openzeppelin_token::erc20::ERC20ABIDispatcherTrait;
 use snforge_std::{ContractClass, start_cheat_caller_address};
 use starknet::ContractAddress;
 use starknet_ibc_apps::tests::{NAME, SYMBOL, SUPPLY, OWNER};

--- a/cairo-contracts/packages/contracts/src/tests/test_client.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/test_client.cairo
@@ -1,11 +1,9 @@
 use openzeppelin_testing::events::EventSpyExt;
-use snforge_std::cheat_block_timestamp_global;
 use snforge_std::spy_events;
+use snforge_std::start_cheat_block_timestamp_global;
 use starknet_ibc_clients::tests::CometClientConfigTrait;
 use starknet_ibc_contracts::tests::{CoreHandle, SetupImpl};
-use starknet_ibc_core::client::{
-    UpdateResponse, Height, StatusTrait, ClientContract, ClientContractTrait
-};
+use starknet_ibc_core::client::{UpdateResponse, StatusTrait, ClientContractTrait};
 use starknet_ibc_core::tests::{ClientEventSpyExt, HEIGHT};
 
 #[test]
@@ -29,7 +27,7 @@ fn test_create_comet_client_ok() {
     // -----------------------------------------------------------
 
     // Cheat the block timestamp to simulate the passage of time.
-    cheat_block_timestamp_global(cfg.latest_timestamp + 1);
+    start_cheat_block_timestamp_global(cfg.latest_timestamp + 1);
 
     let msg = cfg.dummy_msg_create_client();
 
@@ -71,7 +69,7 @@ fn test_update_comet_client_ok() {
     // -----------------------------------------------------------
 
     // Cheat the block timestamp to simulate the passage of time.
-    cheat_block_timestamp_global(cfg.latest_timestamp + 1);
+    start_cheat_block_timestamp_global(cfg.latest_timestamp + 1);
 
     let msg_create_client = cfg.dummy_msg_create_client();
 

--- a/cairo-contracts/packages/contracts/src/tests/test_transfer.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/test_transfer.cairo
@@ -1,7 +1,6 @@
 use openzeppelin_testing::events::EventSpyExt;
 use snforge_std::spy_events;
 use snforge_std::start_cheat_caller_address;
-use starknet::ContractAddress;
 use starknet_ibc_apps::tests::TransferEventSpyExt;
 use starknet_ibc_apps::tests::{
     TransferAppConfigTrait, NAME, SYMBOL, SUPPLY, OWNER, COSMOS, STARKNET

--- a/cairo-contracts/packages/core/src/channel/components/events.cairo
+++ b/cairo-contracts/packages/core/src/channel/components/events.cairo
@@ -1,6 +1,5 @@
 #[starknet::component]
 pub mod ChannelEventEmitterComponent {
-    use starknet::ContractAddress;
     use starknet_ibc_core::channel::{Packet, ChannelOrdering, Acknowledgement};
     use starknet_ibc_core::client::{Height, Timestamp};
     use starknet_ibc_core::host::{PortId, ChannelId, Sequence};

--- a/cairo-contracts/packages/core/src/channel/components/handler.cairo
+++ b/cairo-contracts/packages/core/src/channel/components/handler.cairo
@@ -4,7 +4,6 @@ pub mod ChannelHandlerComponent {
     use ClientHandlerComponent::ClientInternalTrait;
     use RouterHandlerComponent::RouterInternalTrait;
     use core::num::traits::Zero;
-    use starknet::ContractAddress;
     use starknet::storage::Map;
     use starknet::{get_block_timestamp, get_block_number};
     use starknet_ibc_core::channel::{
@@ -12,15 +11,13 @@ pub mod ChannelHandlerComponent {
         ChannelErrors, PacketTrait, ChannelOrdering, Receipt, AcknowledgementTrait, Packet,
         Acknowledgement
     };
-    use starknet_ibc_core::client::{
-        ClientHandlerComponent, ClientContract, ClientContractTrait, StatusTrait
-    };
+    use starknet_ibc_core::client::{ClientHandlerComponent, ClientContract, ClientContractTrait};
     use starknet_ibc_core::host::{
-        PortId, PortIdTrait, ChannelId, ChannelIdTrait, Sequence, SequenceImpl, SequencePartialOrd,
-        channel_end_key, receipt_key, ack_key, commitment_path, next_sequence_recv_key
+        PortId, ChannelId, Sequence, SequenceImpl, SequencePartialOrd, channel_end_key, receipt_key,
+        ack_key, commitment_path, next_sequence_recv_key
     };
     use starknet_ibc_core::router::{
-        RouterHandlerComponent, IRouter, ApplicationContractTrait, ApplicationContract
+        RouterHandlerComponent, ApplicationContractTrait, ApplicationContract
     };
     use starknet_ibc_core::tests::{PORT_ID, CHANNEL_ID, CHANNEL_END};
     use starknet_ibc_utils::{ValidateBasicTrait, ComputeKeyTrait};

--- a/cairo-contracts/packages/core/src/client/client_call.cairo
+++ b/cairo-contracts/packages/core/src/client/client_call.cairo
@@ -1,13 +1,11 @@
-use core::num::traits::Zero;
 use starknet::ContractAddress;
 use starknet_ibc_core::client::{
-    IClientHandler, IClientHandlerDispatcher, IClientStateDispatcher, IClientStateDispatcherTrait,
-    IClientHandlerDispatcherTrait, IClientStateValidation, IClientStateValidationDispatcher,
+    IClientHandlerDispatcher, IClientStateDispatcher, IClientStateDispatcherTrait,
+    IClientHandlerDispatcherTrait, IClientStateValidationDispatcher,
     IClientStateValidationDispatcherTrait, MsgCreateClient, MsgUpdateClient, MsgRecoverClient,
     MsgUpgradeClient, CreateResponse, UpdateResponse, Height, HeightPartialOrd, Status, StatusTrait,
     ClientErrors
 };
-use starknet_ibc_core::host::ClientId;
 
 #[derive(Clone, Debug, Drop, Serde)]
 pub struct ClientContract {

--- a/cairo-contracts/packages/core/src/client/components/events.cairo
+++ b/cairo-contracts/packages/core/src/client/components/events.cairo
@@ -1,11 +1,6 @@
 #[starknet::component]
 pub mod ClientEventEmitterComponent {
-    use starknet::ContractAddress;
-    use starknet_ibc_core::client::{
-        MsgCreateClient, MsgUpdateClient, MsgRecoverClient, MsgUpgradeClient, Height,
-        CreateResponse, UpdateResponse, ClientErrors
-    };
-    use starknet_ibc_core::client::{ClientContract, ClientContractTrait};
+    use starknet_ibc_core::client::{Height, CreateResponse};
     use starknet_ibc_core::host::{ClientId, ClientIdImpl};
 
     #[storage]

--- a/cairo-contracts/packages/core/src/host/identifiers.cairo
+++ b/cairo-contracts/packages/core/src/host/identifiers.cairo
@@ -1,11 +1,7 @@
 use core::byte_array::ByteArrayTrait;
-use core::hash::{HashStateTrait, HashStateExTrait};
 use core::num::traits::Zero;
-use core::poseidon::PoseidonTrait;
 use core::to_byte_array::FormatAsByteArray;
 use core::traits::TryInto;
-use starknet::ContractAddress;
-use starknet::Store;
 use starknet_ibc_core::host::errors::HostErrors;
 use starknet_ibc_utils::{ComputeKeyTrait, poseidon_hash};
 
@@ -151,7 +147,7 @@ pub(crate) fn assert_numeric(char_bytes: u8) {
 
 #[cfg(test)]
 mod tests {
-    use super::{PortId, ChannelId, ChannelIdTrait};
+    use super::{ChannelId, ChannelIdTrait};
 
     #[test]
     fn test_channel_id_validate() {

--- a/cairo-contracts/packages/core/src/host/paths.cairo
+++ b/cairo-contracts/packages/core/src/host/paths.cairo
@@ -1,6 +1,5 @@
 use starknet_ibc_core::host::{
-    COMMITMENTS_PREFIX, ACKS_PREFIX, NEXT_SEQ_RECV_PREFIX, PORTS_PREFIX, CHANNELS_PREFIX,
-    SEQUENCES_PREFIX
+    COMMITMENTS_PREFIX, ACKS_PREFIX, PORTS_PREFIX, CHANNELS_PREFIX, SEQUENCES_PREFIX
 };
 use starknet_ibc_core::host::{ChannelId, PortId, Sequence};
 use starknet_ibc_utils::{RemotePathBuilder, RemotePathBuilderImpl};

--- a/cairo-contracts/packages/core/src/lib.cairo
+++ b/cairo-contracts/packages/core/src/lib.cairo
@@ -5,16 +5,19 @@ pub mod tests {
     mod test_channel;
     #[cfg(test)]
     mod test_client;
+    #[cfg(test)]
+    pub use mocks::mock_channel::MockChannelHandler;
+    #[cfg(test)]
+    pub use mocks::mock_client::MockClientHandler;
 
     pub use dummy::{
         HEIGHT, CLIENT, CLIENT_TYPE, CLIENT_ID, PORT_ID, CHANNEL_ID, SEQUENCE, CHANNEL_END
     };
     pub use extend_spy::ClientEventSpyExt;
-    pub(crate) mod mocks {
-        mod mock_channel;
-        mod mock_client;
-        pub(crate) use mock_channel::MockChannelHandler;
-        pub(crate) use mock_client::MockClientHandler;
+    #[cfg(test)]
+    pub mod mocks {
+        pub mod mock_channel;
+        pub mod mock_client;
     }
 }
 pub mod router {

--- a/cairo-contracts/packages/core/src/router/app_call.cairo
+++ b/cairo-contracts/packages/core/src/router/app_call.cairo
@@ -1,6 +1,6 @@
 use starknet::ContractAddress;
 use starknet_ibc_core::channel::{
-    IAppCallback, IAppCallbackDispatcher, IAppCallbackDispatcherTrait, Packet, Acknowledgement
+    IAppCallbackDispatcher, IAppCallbackDispatcherTrait, Packet, Acknowledgement
 };
 
 #[derive(Clone, Debug, Drop, Serde)]

--- a/cairo-contracts/packages/core/src/tests/test_channel.cairo
+++ b/cairo-contracts/packages/core/src/tests/test_channel.cairo
@@ -1,15 +1,11 @@
 use ChannelHandlerComponent::ChannelReaderTrait;
 use core::num::traits::Zero;
-use snforge_std::{spy_events, test_address, start_cheat_caller_address};
-use starknet::ContractAddress;
-use starknet::contract_address_const;
 use starknet_ibc_core::channel::ChannelHandlerComponent::{
     ChannelInitializerImpl, ChannelWriterTrait
 };
 use starknet_ibc_core::channel::ChannelHandlerComponent;
 use starknet_ibc_core::host::SequenceTrait;
-use starknet_ibc_core::tests::mocks::MockChannelHandler;
-use starknet_ibc_core::tests::{CHANNEL_END, CHANNEL_ID, CLIENT_ID, PORT_ID, SEQUENCE};
+use starknet_ibc_core::tests::{CHANNEL_END, CHANNEL_ID, PORT_ID, SEQUENCE, MockChannelHandler};
 
 type ComponentState = ChannelHandlerComponent::ComponentState<MockChannelHandler::ContractState>;
 

--- a/cairo-contracts/packages/core/src/tests/test_client.cairo
+++ b/cairo-contracts/packages/core/src/tests/test_client.cairo
@@ -1,15 +1,14 @@
 use ClientHandlerComponent::ClientReaderTrait;
 use core::num::traits::Zero;
-use snforge_std::{spy_events, test_address, start_cheat_caller_address};
-use starknet::ContractAddress;
-use starknet::contract_address_const;
+use snforge_std::{spy_events, test_address};
 use starknet_ibc_core::client::ClientHandlerComponent::{
     ClientInitializerImpl, CoreRegisterClientImpl, CoreClientHandlerImpl, EventEmitterImpl,
     ClientInternalImpl
 };
 use starknet_ibc_core::client::{ClientHandlerComponent, CreateResponse};
-use starknet_ibc_core::tests::mocks::MockClientHandler;
-use starknet_ibc_core::tests::{CLIENT, CLIENT_TYPE, CLIENT_ID, HEIGHT, ClientEventSpyExt};
+use starknet_ibc_core::tests::{
+    CLIENT, CLIENT_TYPE, CLIENT_ID, HEIGHT, ClientEventSpyExt, MockClientHandler
+};
 
 type ComponentState = ClientHandlerComponent::ComponentState<MockClientHandler::ContractState>;
 

--- a/cairo-contracts/packages/utils/src/governance/component.cairo
+++ b/cairo-contracts/packages/utils/src/governance/component.cairo
@@ -1,7 +1,6 @@
 #[starknet::component]
 pub mod IBCGovernanceComponent {
-    use starknet::ContractAddress;
-    use starknet::get_caller_address;
+    use starknet::{ContractAddress, get_caller_address};
     use starknet_ibc_utils::governance::IGovernance;
 
     #[storage]

--- a/cairo-contracts/packages/utils/src/mintable/component.cairo
+++ b/cairo-contracts/packages/utils/src/mintable/component.cairo
@@ -1,9 +1,6 @@
 #[starknet::component]
 pub mod ERC20MintableComponent {
-    use core::num::traits::CheckedAdd;
-    use core::num::traits::CheckedSub;
-    use core::num::traits::Zero;
-    use openzeppelin_token::erc20::ERC20Component::InternalTrait;
+    use core::num::traits::{CheckedAdd, CheckedSub, Zero};
     use openzeppelin_token::erc20::ERC20Component;
     use openzeppelin_token::erc20::erc20::ERC20Component::Transfer;
     use starknet::ContractAddress;

--- a/cairo-contracts/packages/utils/src/utils.cairo
+++ b/cairo-contracts/packages/utils/src/utils.cairo
@@ -1,7 +1,5 @@
-use core::hash::{HashStateTrait, HashStateExTrait};
-use core::poseidon::PoseidonTrait;
-use core::poseidon::poseidon_hash_span;
-use starknet_ibc_utils::UtilErrors;
+use core::hash::HashStateTrait;
+use core::poseidon::{PoseidonTrait, poseidon_hash_span};
 
 pub trait ValidateBasicTrait<T> {
     fn validate_basic(self: @T);

--- a/flake.lock
+++ b/flake.lock
@@ -87,16 +87,16 @@
     "cairo-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1723546896,
-        "narHash": "sha256-4nLrTMwpRD6CcQcNqWHbCg3/OHHGMlrkcREX9p8gafE=",
+        "lastModified": 1724756088,
+        "narHash": "sha256-zQ+kc4c8YI9vURUEQNqX55mTJBcc2NLp4K8kab3ZjEs=",
         "owner": "starkware-libs",
         "repo": "cairo",
-        "rev": "964a02d84c6bde5b39d4ef333eeecf7e588da135",
+        "rev": "93221753088d58f54f9a7f35a0bb338cf0bfb952",
         "type": "github"
       },
       "original": {
         "owner": "starkware-libs",
-        "ref": "v2.7.1",
+        "ref": "v2.8.0",
         "repo": "cairo",
         "type": "github"
       }
@@ -1708,16 +1708,16 @@
     "scarb-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1723563370,
-        "narHash": "sha256-ZMxH4EmllvestXh42VxPFLSQhZpgQCajYCYtquJfyAI=",
+        "lastModified": 1724772354,
+        "narHash": "sha256-9BLeGDeJcCi/QpT43EpVZ61gkJ446IjT9kC2MtQazBs=",
         "owner": "software-mansion",
         "repo": "scarb",
-        "rev": "e288874ba65f228ce3ae9aa55eef9f169824e998",
+        "rev": "09590f5fc07365c3e4188b0e8fa2e774a8269d68",
         "type": "github"
       },
       "original": {
         "owner": "software-mansion",
-        "ref": "v2.7.1",
+        "ref": "v2.8.0",
         "repo": "scarb",
         "type": "github"
       }
@@ -1788,16 +1788,16 @@
     "snforge-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1724941386,
-        "narHash": "sha256-lQS47w3XO4/OIqUsdPXinNbhSHChlGgUKLlcS2tUvqk=",
+        "lastModified": 1721815918,
+        "narHash": "sha256-PkgGaJvVibXGWCvwz2IYC5Ow86fH0MAg7D8OJU0nEjo=",
         "owner": "foundry-rs",
         "repo": "starknet-foundry",
-        "rev": "d37d2272ca6c915117646de76cdf26ec06e44f61",
+        "rev": "2d99b7c00678ef0363881ee0273550c44a9263de",
         "type": "github"
       },
       "original": {
         "owner": "foundry-rs",
-        "ref": "v0.29.0",
+        "ref": "v0.27.0",
         "repo": "starknet-foundry",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,17 +14,17 @@
     };
 
     cairo-src = {
-      url = "github:starkware-libs/cairo/v2.7.1";
+      url = "github:starkware-libs/cairo/v2.8.0";
       flake = false;
     };
 
     scarb-src = {
-      url = "github:software-mansion/scarb/v2.7.1";
+      url = "github:software-mansion/scarb/v2.8.0";
       flake = false;
     };
 
     snforge-src = {
-      url = "github:foundry-rs/starknet-foundry/v0.29.0";
+      url = "github:foundry-rs/starknet-foundry/v0.27.0";
       flake = false;
     };
 

--- a/nix/cairo.nix
+++ b/nix/cairo.nix
@@ -2,13 +2,13 @@
 let
   cairo = nixpkgs.rustPlatform.buildRustPackage {
     name = "cairo";
-    version = "2.7.1";
+    version = "2.8.0";
 
     doCheck = false;
 
     src = cairo-src;
 
-    cargoHash = "sha256-piabK7UNyt2hWoqR5IDnCZoo8+VvSthSao3sQXKjE0o=";
+    cargoHash = "sha256-NsnBrzpzIFiF7ujywm6ZyRH/uQscFb/St9PLCvM3ukU=";
 
     OPENSSL_NO_VENDOR = 1;
     PKG_CONFIG_PATH = "${nixpkgs.openssl.dev}/lib/pkgconfig";

--- a/nix/scarb.nix
+++ b/nix/scarb.nix
@@ -6,13 +6,13 @@
 let
   cairo = nixpkgs.rustPlatform.buildRustPackage {
     name = "scarb";
-    version = "2.7.1";
+    version = "2.8.0";
 
     doCheck = false;
 
     src = scarb-src;
 
-    cargoHash = "sha256-cAEwCX1zGJu4+ufdVSqBbksa1FLZWVNt2TLZ5JlGISk=";
+    cargoHash = "sha256-LodT2SCTrIrY8YGJWYbzgawIz3xJn9VH2rst07av2Bw=";
 
     SCARB_CORELIB_LOCAL_PATH = cairo-src + "/corelib";
 

--- a/nix/snforge.nix
+++ b/nix/snforge.nix
@@ -2,7 +2,7 @@
 let
   snforge = nixpkgs.rustPlatform.buildRustPackage {
     pname = "forge";
-    version = "0.29.0";
+    version = "0.27.0";
 
     src = snforge-src;
 
@@ -10,7 +10,7 @@ let
       lockFile = snforge-src + "/Cargo.lock";
       outputHashes = {
         "starknet-0.10.0" = "sha256-/cDjAPsNQNtO/kTUK6PpaxyTgAMc6LhfXxrcfom20fE=";
-        "trace-data-0.4.0" = "sha256-C5rgp+wthWkjNBkY1PlHfLkGexrmjOQpUgbPKPrKf7g=";
+        "trace-data-0.3.0" = "sha256-wtAdQ4Z/p8s9f8T32FXV4TqKmVbCFDBPx/Xjet4UgsI=";
       };
     };
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,7 @@ build() {
 
     cd "$(dirname "$0")/../cairo-contracts"
 
-    output=$(scarb build 1>&2)
+    output=$(scarb build -p starknet_ibc_contracts 1>&2)
 
     if [[ $output == *"Error"* ]]; then
         echo "Error: $output"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -62,7 +62,6 @@ deploy() {
         starkli deploy --not-unique \
         --watch $IC20_CLASS_HASH $ERC20_CLASS_HASH \
         --rpc $RPC_URL \
-        --compiler-version $COMPILER_VERSION \
         --account $ACCOUNT_SRC \
         --keystore $KEYSTORE_SRC \
         --keystore-password $KEYSTORE_PASS \


### PR DESCRIPTION
This PR upgrades following dependencies:
- `cairo` to 2.8.0
- `scarb` to 2.8.0
- `snforge` to 0.27.0
- `openzeppelin` to 0.16.0