### PR TITLE
Test performing dummy IBC handshake with Wasm Starknet light client on Cosmos

### DIFF
--- a/light-client/Cargo.lock
+++ b/light-client/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "ark-bls12-381"
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -273,18 +273,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#6e231ae01e02c45acd3c2dd5a8fc3a40430aa130"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#f8f9d9299415503df3a8e28f1809b4dccd67f743"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "hermes-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#6e231ae01e02c45acd3c2dd5a8fc3a40430aa130"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#f8f9d9299415503df3a8e28f1809b4dccd67f743"
 dependencies = [
  "cgp",
 ]
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "hermes-protobuf-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#6e231ae01e02c45acd3c2dd5a8fc3a40430aa130"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#f8f9d9299415503df3a8e28f1809b4dccd67f743"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -1609,6 +1609,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,7 +1845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -2295,9 +2304,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2324,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-xid"

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -2156,6 +2156,8 @@ dependencies = [
  "hermes-test-components",
  "ibc",
  "ibc-proto",
+ "ibc-relayer",
+ "ibc-relayer-types",
  "prost",
  "prost-types",
  "rand",

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -42,6 +42,7 @@ cairo-lang-starknet-classes = { version = "2.7.0" }
 
 ibc                       = { version = "0.54.0" }
 ibc-proto                 = { version = "0.47.0" }
+ibc-relayer               = { version = "0.29.2" }
 ibc-relayer-types         = { version = "0.29.2" }
 ibc-client-starknet-types = { version = "0.1.0" }
 

--- a/relayer/crates/starknet-integration-tests/Cargo.toml
+++ b/relayer/crates/starknet-integration-tests/Cargo.toml
@@ -27,8 +27,10 @@ hermes-cosmos-integration-tests  = { workspace = true }
 hermes-cosmos-relayer            = { workspace = true }
 hermes-cosmos-wasm-relayer       = { workspace = true }
 
-ibc       = { workspace = true }
-ibc-proto = { workspace = true }
+ibc               = { workspace = true }
+ibc-proto         = { workspace = true }
+ibc-relayer       = { workspace = true }
+ibc-relayer-types = { workspace = true }
 
 starknet    = { workspace = true }
 url         = { workspace = true }

--- a/relayer/crates/starknet-integration-tests/tests/light_client.rs
+++ b/relayer/crates/starknet-integration-tests/tests/light_client.rs
@@ -199,6 +199,8 @@ fn test_starknet_light_client() -> Result<(), Error> {
         };
 
         {
+            // Pretend that we have relayed ConnectionOpenTry to Starknet, and then send ConnectionOpenAck.
+
             let create_client_settings = Settings {
                 max_clock_drift: Duration::from_secs(40),
                 trusting_period: None,
@@ -218,7 +220,7 @@ fn test_starknet_light_client() -> Result<(), Error> {
                 version: Version::compatibles().pop().unwrap(),
                 client_state,
                 update_height: Height::new(0, 1).unwrap(),
-                proof_try: [0; 32].into(),
+                proof_try: [0; 32].into(), // dummy proofs
                 proof_client: [0; 32].into(),
                 proof_consensus: [0; 32].into(),
                 proof_consensus_height: payload.client_state.latest_height,
@@ -232,7 +234,7 @@ fn test_starknet_light_client() -> Result<(), Error> {
                 state: State::Init as i32,
                 ordering: Ordering::Unordered as i32,
                 counterparty: Some(Counterparty {
-                    port_id: "transfer".to_string(),
+                    port_id: "11b7f9bfa43d3facae74efa5dfe0030df98273271278291d67c16a4e6cd5f7c".to_string(), // stub application contract on Starknet as port ID
                     channel_id: "".to_string(),
                 }),
                 connection_hops: vec![connection_id.to_string()],
@@ -261,13 +263,15 @@ fn test_starknet_light_client() -> Result<(), Error> {
         };
 
         {
+            // Pretend that we have already done ChannelOpenTry on Starknet, and then continue with ChannelOpenAck
+
             let open_ack_message = CosmosChannelOpenAckMessage {
                 port_id: "transfer".into(),
                 channel_id: channel_id.to_string(),
-                counterparty_channel_id: "channel-0".into(),
+                counterparty_channel_id: "63c350000c404581a3385ec7b4324008b2965dd8fc5af768b87329d25e57cfa".into(), // stub channel contract on Starknet as channel ID
                 counterparty_version: "ics20-1".into(),
                 update_height: Height::new(0, 1).unwrap(),
-                proof_try: [0; 32].into(),
+                proof_try: [0; 32].into(), // dummy proofs
             };
 
             cosmos_chain.send_message(open_ack_message.to_cosmos_message()).await?;

--- a/relayer/crates/starknet-integration-tests/tests/light_client.rs
+++ b/relayer/crates/starknet-integration-tests/tests/light_client.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use hermes_cosmos_chain_components::traits::message::ToCosmosMessage;
+use hermes_cosmos_chain_components::types::messages::channel::open_ack::CosmosChannelOpenAckMessage;
 use hermes_cosmos_chain_components::types::messages::channel::open_init::CosmosChannelOpenInitMessage;
 use hermes_cosmos_chain_components::types::messages::connection::open_ack::CosmosConnectionOpenAckMessage;
 use hermes_cosmos_chain_components::types::messages::connection::open_init::CosmosConnectionOpenInitMessage;
@@ -258,6 +259,19 @@ fn test_starknet_light_client() -> Result<(), Error> {
 
             channel_id
         };
+
+        {
+            let open_ack_message = CosmosChannelOpenAckMessage {
+                port_id: "transfer".into(),
+                channel_id: channel_id.to_string(),
+                counterparty_channel_id: "channel-0".into(),
+                counterparty_version: "ics20-1".into(),
+                update_height: Height::new(0, 1).unwrap(),
+                proof_try: [0; 32].into(),
+            };
+
+            cosmos_chain.send_message(open_ack_message.to_cosmos_message()).await?;
+        }
 
         Ok(())
     })


### PR DESCRIPTION
This PR adds some tests for performing one-sided handshake with the Wasm light client on Cosmos, without actually relaying anything to Starknet. We simply submit dummy proofs to the Cosmos chain, which the light client currently always validate successfully.