### PR TITLE
feat: add endpoint to query latest updated height at or below target height

### DIFF
--- a/cairo-contracts/Scarb.lock
+++ b/cairo-contracts/Scarb.lock
@@ -2,10 +2,18 @@
 version = 1
 
 [[package]]
-name = "alexandria_data_structures"
+name = "alexandria_bytes"
 version = "0.1.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:906bf52e0bb87bbcd169f5757883f1552115f18f90080b8ce356f59c7e50f9b8"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
+dependencies = [
+ "alexandria_data_structures",
+ "alexandria_math",
+]
+
+[[package]]
+name = "alexandria_data_structures"
+version = "0.2.0"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_encoding",
 ]
@@ -13,29 +21,41 @@ dependencies = [
 [[package]]
 name = "alexandria_encoding"
 version = "0.1.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:01c8de70af7c9c9753128f65e3d4fefa8cd2d6f9c1e65330717e83bbceb1f8eb"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
+ "alexandria_bytes",
  "alexandria_math",
  "alexandria_numeric",
 ]
 
 [[package]]
 name = "alexandria_math"
+version = "0.2.1"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
+
+[[package]]
+name = "alexandria_numeric"
 version = "0.1.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:45d8d6d732eac737488ae5883556827bf9fe7d5b566d31560220d1c3ed6b71df"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
+dependencies = [
+ "alexandria_math",
+ "alexandria_searching",
+]
+
+[[package]]
+name = "alexandria_searching"
+version = "0.1.0"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
  "alexandria_data_structures",
 ]
 
 [[package]]
-name = "alexandria_numeric"
+name = "alexandria_sorting"
 version = "0.1.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:8df67e3e26d240ed164f279ffb3afa88441fa2eeb7894bfe918ea9c63336f3d9"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
 dependencies = [
- "alexandria_math",
+ "alexandria_data_structures",
 ]
 
 [[package]]
@@ -138,6 +158,7 @@ dependencies = [
 name = "starknet_ibc_clients"
 version = "0.1.0"
 dependencies = [
+ "alexandria_sorting",
  "starknet_ibc_core",
  "starknet_ibc_testkit",
 ]

--- a/cairo-contracts/Scarb.toml
+++ b/cairo-contracts/Scarb.toml
@@ -25,7 +25,8 @@ test = "snforge test"
 
 [workspace.dependencies]
 # external dependencies
-alexandria_numeric   = "0.1.0"
+alexandria_numeric   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
+alexandria_sorting   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
 assert_macros        = "2.8.4"
 starknet             = "2.8.4"
 openzeppelin_access  = "0.18.0"

--- a/cairo-contracts/packages/clients/Scarb.toml
+++ b/cairo-contracts/packages/clients/Scarb.toml
@@ -23,6 +23,8 @@ test = { workspace = true }
 fmt = { workspace = true }
 
 [dependencies]
+alexandria_sorting = { workspace = true }
+
 # external dependencies
 starknet = { workspace = true }
 

--- a/cairo-contracts/packages/clients/src/cometbft/component.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/component.cairo
@@ -518,17 +518,22 @@ pub mod CometClientComponent {
                 return;
             }
 
-            if update_heights.len() == 255 {
+            let len = update_heights.len();
+
+            if len == 255 {
                 update_heights.pop_front().unwrap();
             }
 
             update_heights.append(update_height);
 
-            let mut update_heights_span = update_heights.span();
+            let new_update_heights = if len.is_non_zero()
+                && update_heights.at(len - 1) > @update_height {
+                MergeSort::sort(update_heights.span())
+            } else {
+                update_heights
+            };
 
-            let sorted_update_heights = MergeSort::sort(update_heights_span);
-
-            self.update_heights.write(client_sequence, sorted_update_heights);
+            self.update_heights.write(client_sequence, new_update_heights);
         }
 
         fn write_client_state(

--- a/cairo-contracts/packages/clients/src/cometbft/component.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/component.cairo
@@ -3,8 +3,8 @@ pub mod CometClientComponent {
     use alexandria_sorting::MergeSort;
     use core::num::traits::Zero;
     use starknet::storage::{
-        StoragePathEntry, Map, StorageMapReadAccess, StorageMapWriteAccess,
-        StoragePointerReadAccess, StoragePointerWriteAccess,
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
     };
     use starknet::{get_block_timestamp, get_block_number};
     use starknet_ibc_clients::cometbft::{

--- a/cairo-contracts/packages/clients/src/cometbft/component.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/component.cairo
@@ -520,7 +520,7 @@ pub mod CometClientComponent {
 
             let len = update_heights.len();
 
-            if len == 255 {
+            if len == 100 {
                 update_heights.pop_front().unwrap();
             }
 

--- a/cairo-contracts/packages/clients/src/cometbft/component.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/component.cairo
@@ -1,5 +1,6 @@
 #[starknet::component]
 pub mod CometClientComponent {
+    use alexandria_data_structures::array_ext::ArrayTraitExt;
     use alexandria_sorting::MergeSort;
     use core::num::traits::Zero;
     use starknet::storage::{
@@ -512,6 +513,10 @@ pub mod CometClientComponent {
             ref self: ComponentState<TContractState>, client_sequence: u64, update_height: Height
         ) {
             let mut update_heights = self.update_heights.read(client_sequence);
+
+            if update_heights.contains(@update_height) {
+                return;
+            }
 
             if update_heights.len() == 255 {
                 update_heights.pop_front().unwrap();

--- a/cairo-contracts/packages/clients/src/cometbft/component.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/component.cairo
@@ -496,7 +496,7 @@ pub mod CometClientComponent {
         fn read_update_heights(
             self: @ComponentState<TContractState>, client_sequence: u64
         ) -> Array<Height> {
-            self.update_heights.entry(client_sequence).read()
+            self.update_heights.read(client_sequence)
         }
     }
 

--- a/cairo-contracts/packages/clients/src/cometbft/errors.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/errors.cairo
@@ -9,4 +9,5 @@ pub mod CometErrors {
     pub const MISSING_CONSENSUS_STATE: felt252 = 'ICS07: missing consensus state';
     pub const MISSING_CLIENT_PROCESSED_TIME: felt252 = 'ICS07: missing processed time';
     pub const MISSING_CLIENT_PROCESSED_HEIGHT: felt252 = 'ICS07: missing processed height';
+    pub const ZERO_UPDATE_HEIGHTS: felt252 = 'ICS07: zero update heights';
 }

--- a/cairo-contracts/packages/clients/src/tests/cometbft.cairo
+++ b/cairo-contracts/packages/clients/src/tests/cometbft.cairo
@@ -99,6 +99,15 @@ fn test_empty_update_heights() {
 }
 
 #[test]
+fn test_write_duplicate_update_height() {
+    let mut state = setup();
+    state.write_update_height(0, HEIGHT(5));
+    state.write_update_height(0, HEIGHT(5));
+    let heights = state.read_update_heights(0);
+    assert_eq!(heights, array![HEIGHT(5)]);
+}
+
+#[test]
 fn test_update_heights_sort() {
     let mut state = setup();
     state.write_update_height(0, HEIGHT(1));

--- a/cairo-contracts/packages/clients/src/tests/cometbft.cairo
+++ b/cairo-contracts/packages/clients/src/tests/cometbft.cairo
@@ -112,17 +112,21 @@ fn test_update_heights() {
 #[test]
 fn test_update_height_before() {
     let mut state = setup();
-    state.write_update_height(0, HEIGHT(1));
-    let height = state.update_height_before(0, HEIGHT(2));
-    assert_eq!(height, HEIGHT(1));
+    state.write_update_height(0, HEIGHT(5));
+    let height = state.update_height_before(0, HEIGHT(3));
+    assert_eq!(height, HEIGHT(3));
 
     state.write_update_height(0, HEIGHT(2));
-    let height = state.update_height_before(0, HEIGHT(2));
+    let height = state.update_height_before(0, HEIGHT(3));
     assert_eq!(height, HEIGHT(2));
 
     state.write_update_height(0, HEIGHT(4));
-    let height = state.update_height_before(0, HEIGHT(3));
-    assert_eq!(height, HEIGHT(2));
+    let height = state.update_height_before(0, HEIGHT(4));
+    assert_eq!(height, HEIGHT(4));
+
+    state.write_update_height(0, HEIGHT(6));
+    let height = state.update_height_before(0, HEIGHT(7));
+    assert_eq!(height, HEIGHT(6));
 }
 
 #[test]

--- a/cairo-contracts/packages/clients/src/tests/cometbft.cairo
+++ b/cairo-contracts/packages/clients/src/tests/cometbft.cairo
@@ -139,6 +139,19 @@ fn test_update_height_before() {
 }
 
 #[test]
+fn test_update_heights_max_size() {
+    let mut state = setup();
+    let mut i = 0;
+    while i < 101 {
+        state.write_update_height(0, HEIGHT(i));
+        i += 1;
+    };
+    let heights = state.read_update_heights(0);
+    assert_eq!(heights.len(), 100);
+    assert_eq!(heights.at(99), @HEIGHT(100));
+}
+
+#[test]
 #[should_panic(expected: 'ICS07: zero update heights')]
 fn test_update_height_before_empty() {
     let mut state = setup();

--- a/cairo-contracts/packages/clients/src/tests/cometbft.cairo
+++ b/cairo-contracts/packages/clients/src/tests/cometbft.cairo
@@ -94,19 +94,19 @@ fn test_missing_client_processed_height() {
 #[test]
 fn test_empty_update_heights() {
     let mut state = setup();
-    state.read_update_heights(0);
+    let heights = state.read_update_heights(0);
+    assert!(heights.len() == 0);
 }
 
 #[test]
-fn test_update_heights() {
+fn test_update_heights_sort() {
     let mut state = setup();
-    let heights = state.read_update_heights(0);
-    assert!(heights.len() == 0);
-
     state.write_update_height(0, HEIGHT(1));
+    state.write_update_height(0, HEIGHT(4));
     state.write_update_height(0, HEIGHT(2));
+    state.write_update_height(0, HEIGHT(3));
     let heights = state.read_update_heights(0);
-    assert_eq!(heights, array![HEIGHT(2), HEIGHT(1)]);
+    assert_eq!(heights, array![HEIGHT(1), HEIGHT(2), HEIGHT(3), HEIGHT(4)]);
 }
 
 #[test]

--- a/cairo-contracts/packages/clients/src/tests/cometbft.cairo
+++ b/cairo-contracts/packages/clients/src/tests/cometbft.cairo
@@ -1,3 +1,4 @@
+use CometClientComponent::ClientWriterTrait;
 use snforge_std::start_cheat_block_timestamp_global;
 use starknet_ibc_clients::cometbft::CometClientComponent::{
     CometClientHandler, CometClientQuery, ClientReaderImpl
@@ -88,4 +89,45 @@ fn test_missing_client_processed_time() {
 fn test_missing_client_processed_height() {
     let mut state = setup();
     state.read_client_processed_height(0, HEIGHT(5));
+}
+
+#[test]
+fn test_empty_update_heights() {
+    let mut state = setup();
+    state.read_update_heights(0);
+}
+
+#[test]
+fn test_update_heights() {
+    let mut state = setup();
+    let heights = state.read_update_heights(0);
+    assert!(heights.len() == 0);
+
+    state.write_update_height(0, HEIGHT(1));
+    state.write_update_height(0, HEIGHT(2));
+    let heights = state.read_update_heights(0);
+    assert_eq!(heights, array![HEIGHT(2), HEIGHT(1)]);
+}
+
+#[test]
+fn test_update_height_before() {
+    let mut state = setup();
+    state.write_update_height(0, HEIGHT(1));
+    let height = state.update_height_before(0, HEIGHT(2));
+    assert_eq!(height, HEIGHT(1));
+
+    state.write_update_height(0, HEIGHT(2));
+    let height = state.update_height_before(0, HEIGHT(2));
+    assert_eq!(height, HEIGHT(2));
+
+    state.write_update_height(0, HEIGHT(4));
+    let height = state.update_height_before(0, HEIGHT(3));
+    assert_eq!(height, HEIGHT(2));
+}
+
+#[test]
+#[should_panic(expected: 'ICS07: zero update heights')]
+fn test_update_height_before_empty() {
+    let mut state = setup();
+    state.update_height_before(0, HEIGHT(3));
 }

--- a/cairo-contracts/packages/core/src/client/interface.cairo
+++ b/cairo-contracts/packages/core/src/client/interface.cairo
@@ -95,6 +95,12 @@ pub trait IClientQuery<TContractState> {
 
     fn latest_height(self: @TContractState, client_sequence: u64) -> Height;
 
+    /// Returns the latest update height that is less than or equal to the
+    /// target height.
+    fn update_height_before(
+        self: @TContractState, client_sequence: u64, target_height: Height
+    ) -> Height;
+
     fn latest_timestamp(self: @TContractState, client_sequence: u64) -> Timestamp;
 
     fn status(self: @TContractState, client_sequence: u64) -> Status;

--- a/cairo-contracts/packages/core/src/client/types.cairo
+++ b/cairo-contracts/packages/core/src/client/types.cairo
@@ -187,7 +187,7 @@ pub impl StoreHeightArray of Store<Array<Height>> {
     }
 
     fn size() -> u8 {
-        255 * Store::<Height>::size()
+        100 * Store::<Height>::size()
     }
 }
 

--- a/cairo-contracts/packages/core/src/commitment/types.cairo
+++ b/cairo-contracts/packages/core/src/commitment/types.cairo
@@ -1,7 +1,5 @@
 use core::num::traits::Zero;
 use core::sha256::{compute_sha256_byte_array, compute_sha256_u32_array};
-use starknet::SyscallResult;
-use starknet::storage_access::{Store, StorageBaseAddress};
 use starknet_ibc_core::channel::Acknowledgement;
 use starknet_ibc_core::client::{Height, Timestamp};
 use starknet_ibc_core::commitment::{U32CollectorImpl, IntoArrayU32, array_u32_into_array_u8};
@@ -10,7 +8,7 @@ use starknet_ibc_core::commitment::{U32CollectorImpl, IntoArrayU32, array_u32_in
 // Commitment Value
 // -----------------------------------------------------------
 
-#[derive(Clone, Debug, Drop, PartialEq, Serde)]
+#[derive(Clone, Debug, Drop, PartialEq, Serde, starknet::Store)]
 pub struct Commitment {
     pub value: [u32; 8],
 }
@@ -47,40 +45,6 @@ pub impl CommitmentIntoStateValue of Into<Commitment, StateValue> {
     fn into(self: Commitment) -> StateValue {
         let value = array_u32_into_array_u8(self.into());
         StateValue { value }
-    }
-}
-
-pub impl DigestStore of Store<Commitment> {
-    fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<Commitment> {
-        match Store::<[u32; 8]>::read(address_domain, base) {
-            Result::Ok(value) => Result::Ok(Commitment { value }),
-            Result::Err(err) => Result::Err(err),
-        }
-    }
-
-    fn write(
-        address_domain: u32, base: StorageBaseAddress, value: Commitment
-    ) -> SyscallResult<()> {
-        Store::<[u32; 8]>::write(address_domain, base, value.value)
-    }
-
-    fn read_at_offset(
-        address_domain: u32, base: StorageBaseAddress, offset: u8
-    ) -> SyscallResult<Commitment> {
-        match Store::<[u32; 8]>::read_at_offset(address_domain, base, offset) {
-            Result::Ok(value) => Result::Ok(Commitment { value }),
-            Result::Err(err) => Result::Err(err),
-        }
-    }
-
-    fn write_at_offset(
-        address_domain: u32, base: StorageBaseAddress, offset: u8, value: Commitment
-    ) -> SyscallResult<()> {
-        Store::<[u32; 8]>::write_at_offset(address_domain, base, offset, value.value)
-    }
-
-    fn size() -> u8 {
-        Store::<[u32; 8]>::size()
     }
 }
 

--- a/cairo-contracts/packages/core/src/lib.cairo
+++ b/cairo-contracts/packages/core/src/lib.cairo
@@ -80,8 +80,8 @@ pub mod client {
     pub use msgs::{MsgCreateClient, MsgRecoverClient, MsgUpdateClient, MsgUpgradeClient};
     pub use types::{
         CreateResponse, CreateResponseImpl, UpdateResponse, Status, StatusImpl, StatusTrait, Height,
-        HeightImpl, HeightTrait, HeightZero, HeightPartialOrd, HeightsIntoUpdateResponse, Timestamp,
-        TimestampZero, TimestampPartialOrd, U64IntoTimestamp,
+        HeightImpl, HeightTrait, HeightZero, HeightPartialOrd, HeightsIntoUpdateResponse,
+        StoreHeightArray, Timestamp, TimestampZero, TimestampPartialOrd, U64IntoTimestamp,
     };
     mod components {
         pub mod events;


### PR DESCRIPTION
## Context

Requested by @soareschen 
> We need a query method from the client contract for [finding the consensus state height](https://github.com/informalsystems/hermes-sdk/blob/main/crates/chain/chain-components/src/traits/queries/consensus_state_height.rs#L24-L28) before a given target height.
This is needed to determine which trusted height to be used on the Cosmos chain to build the UpdateClient header. In the Cosmos chain implementation, we had to get a list of all consensus heights and then sort and find the trusted height, which is not very efficient. It would be good if there are ways to implement this more efficiently on the chain side.


## Description

This PR introduces the `update_height_before` method to the `IClientQuery` interface, and make the comet client to keep track of the heights at which a client is updated. More context: https://github.com/informalsystems/ibc-starknet/pull/106#discussion_r1833314395