### PR TITLE
Introduce `StarknetMessage` type containing counterparty Cosmos height

### DIFF
--- a/relayer/crates/starknet-chain-components/src/impls/contract/message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/message.rs
@@ -29,9 +29,6 @@ where
             calldata: calldata.clone(),
         };
 
-        StarknetMessage {
-            call,
-            counterparty_height: None,
-        }
+        StarknetMessage::new(call)
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/contract/message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/message.rs
@@ -3,6 +3,7 @@ use hermes_test_components::chain::traits::types::address::HasAddressType;
 use starknet::accounts::Call;
 use starknet::core::types::Felt;
 
+use crate::impls::types::message::StarknetMessage;
 use crate::traits::contract::message::InvokeContractMessageBuilder;
 use crate::traits::types::blob::HasBlobType;
 use crate::traits::types::method::HasSelectorType;
@@ -14,18 +15,23 @@ where
     Chain: HasAddressType<Address = Felt>
         + HasSelectorType<Selector = Felt>
         + HasBlobType<Blob = Vec<Felt>>
-        + HasMessageType<Message = Call>,
+        + HasMessageType<Message = StarknetMessage>,
 {
     fn build_invoke_contract_message(
         _chain: &Chain,
         contract_address: &Felt,
         entry_point_selector: &Felt,
         calldata: &Vec<Felt>,
-    ) -> Call {
-        Call {
+    ) -> StarknetMessage {
+        let call = Call {
             to: *contract_address,
             selector: *entry_point_selector,
             calldata: calldata.clone(),
+        };
+
+        StarknetMessage {
+            call,
+            counterparty_height: None,
         }
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/counterparty_message_height.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/counterparty_message_height.rs
@@ -1,20 +1,21 @@
 use hermes_chain_components::traits::types::height::HasHeightType;
 use hermes_chain_components::traits::types::ibc::CounterpartyMessageHeightGetter;
 use hermes_chain_components::traits::types::message::HasMessageType;
+use ibc::core::client::types::Height;
+
+use crate::impls::types::message::StarknetMessage;
 
 pub struct GetCounterpartyCosmosHeightFromStarknetMessage;
 
 impl<Chain, Counterparty> CounterpartyMessageHeightGetter<Chain, Counterparty>
     for GetCounterpartyCosmosHeightFromStarknetMessage
 where
-    Chain: HasMessageType,
-    Counterparty: HasHeightType,
+    Chain: HasMessageType<Message = StarknetMessage>,
+    Counterparty: HasHeightType<Height = Height>,
 {
     fn counterparty_message_height_for_update_client(
-        _message: &Chain::Message,
+        message: &Chain::Message,
     ) -> Option<Counterparty::Height> {
-        // TODO: Define a `StarknetMessage` type that wraps around `Call`
-        // and provide counterparty height
-        None
+        message.counterparty_height
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
@@ -30,6 +30,7 @@ use starknet::accounts::Call;
 use starknet::core::types::Felt;
 use starknet::macros::selector;
 
+use crate::impls::types::message::StarknetMessage;
 use crate::traits::queries::address::CanQueryContractAddress;
 use crate::types::channel_id::ChannelId as StarknetChannelId;
 use crate::types::connection_id::ConnectionId as StarknetConnectionId;
@@ -44,7 +45,7 @@ pub struct BuildStarknetChannelHandshakeMessages;
 impl<Chain, Counterparty, Encoding> ChannelOpenInitMessageBuilder<Chain, Counterparty>
     for BuildStarknetChannelHandshakeMessages
 where
-    Chain: HasMessageType<Message = Call>
+    Chain: HasMessageType<Message = StarknetMessage>
         + HasAddressType<Address = Felt>
         + HasEncoding<AsFelt, Encoding = Encoding>
         + CanQueryContractAddress<symbol!("ibc_core_contract_address")>
@@ -106,10 +107,15 @@ where
             .encode(&chan_open_init_msg)
             .map_err(Chain::raise_error)?;
 
-        let message = Call {
+        let call = Call {
             to: ibc_core_address,
             selector: selector!("chan_open_init"),
             calldata,
+        };
+
+        let message = StarknetMessage {
+            call,
+            counterparty_height: None,
         };
 
         Ok(message)
@@ -119,7 +125,7 @@ where
 impl<Chain, Counterparty, Encoding> ChannelOpenTryMessageBuilder<Chain, Counterparty>
     for BuildStarknetChannelHandshakeMessages
 where
-    Chain: HasMessageType<Message = Call>
+    Chain: HasMessageType<Message = StarknetMessage>
         + HasAddressType<Address = Felt>
         + HasEncoding<AsFelt, Encoding = Encoding>
         + CanQueryContractAddress<symbol!("ibc_core_contract_address")>
@@ -205,10 +211,15 @@ where
             .encode(&chan_open_try_msg)
             .map_err(Chain::raise_error)?;
 
-        let message = Call {
+        let call = Call {
             to: ibc_core_address,
             selector: selector!("chan_open_try"),
             calldata,
+        };
+
+        let message = StarknetMessage {
+            call,
+            counterparty_height: Some(counterparty_payload.update_height),
         };
 
         Ok(message)
@@ -219,7 +230,7 @@ impl<Chain, Counterparty, Encoding> ChannelOpenAckMessageBuilder<Chain, Counterp
     for BuildStarknetChannelHandshakeMessages
 where
     Chain: HasChannelIdType<Counterparty, ChannelId = StarknetChannelId>
-        + HasMessageType<Message = Call>
+        + HasMessageType<Message = StarknetMessage>
         + HasAddressType<Address = Felt>
         + HasEncoding<AsFelt, Encoding = Encoding>
         + CanQueryContractAddress<symbol!("ibc_core_contract_address")>
@@ -279,10 +290,15 @@ where
             .encode(&chan_open_ack_msg)
             .map_err(Chain::raise_error)?;
 
-        let message = Call {
+        let call = Call {
             to: ibc_core_address,
             selector: selector!("chan_open_ack"),
             calldata,
+        };
+
+        let message = StarknetMessage {
+            call,
+            counterparty_height: Some(counterparty_payload.update_height),
         };
 
         Ok(message)
@@ -294,7 +310,7 @@ impl<Chain, Counterparty, Encoding> ChannelOpenConfirmMessageBuilder<Chain, Coun
 where
     Chain: HasPortIdType<Counterparty, PortId = IbcPortId>
         + HasChannelIdType<Counterparty, ChannelId = StarknetChannelId>
-        + HasMessageType<Message = Call>
+        + HasMessageType<Message = StarknetMessage>
         + HasAddressType<Address = Felt>
         + HasEncoding<AsFelt, Encoding = Encoding>
         + CanQueryContractAddress<symbol!("ibc_core_contract_address")>
@@ -340,10 +356,15 @@ where
             .encode(&chan_open_confirm_msg)
             .map_err(Chain::raise_error)?;
 
-        let message = Call {
+        let call = Call {
             to: ibc_core_address,
             selector: selector!("chan_open_confirm"),
             calldata,
+        };
+
+        let message = StarknetMessage {
+            call,
+            counterparty_height: Some(counterparty_payload.update_height),
         };
 
         Ok(message)

--- a/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
@@ -113,10 +113,7 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: None,
-        };
+        let message = StarknetMessage::new(call);
 
         Ok(message)
     }
@@ -217,10 +214,8 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: Some(counterparty_payload.update_height),
-        };
+        let message =
+            StarknetMessage::new(call).with_counterparty_height(counterparty_payload.update_height);
 
         Ok(message)
     }
@@ -296,10 +291,8 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: Some(counterparty_payload.update_height),
-        };
+        let message =
+            StarknetMessage::new(call).with_counterparty_height(counterparty_payload.update_height);
 
         Ok(message)
     }
@@ -362,10 +355,8 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: Some(counterparty_payload.update_height),
-        };
+        let message =
+            StarknetMessage::new(call).with_counterparty_height(counterparty_payload.update_height);
 
         Ok(message)
     }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/connection.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/connection.rs
@@ -194,7 +194,7 @@ where
         client_id: &StarknetClientId,
         counterparty_client_id: &CosmosClientId,
         counterparty_connection_id: &CosmosConnectionId,
-        payload: ConnectionOpenTryPayload<Counterparty, Chain>,
+        counterparty_payload: ConnectionOpenTryPayload<Counterparty, Chain>,
     ) -> Result<Chain::Message, Chain::Error> {
         // FIXME: Cairo IBC should accept counterparty client ID as string value
         let cosmos_client_id_as_cairo = {
@@ -211,7 +211,7 @@ where
 
         // FIXME: Cairo IBC should use bytes for commitment prefix
         let commitment_prefix =
-            from_utf8(&payload.commitment_prefix).map_err(Chain::raise_error)?;
+            from_utf8(&counterparty_payload.commitment_prefix).map_err(Chain::raise_error)?;
 
         // FIXME: Use the connection version from the payload
         let connection_version = ConnectionVersion {
@@ -225,8 +225,8 @@ where
         };
 
         let proof_height = CairoHeight {
-            revision_number: payload.update_height.revision_number(),
-            revision_height: payload.update_height.revision_height(),
+            revision_number: counterparty_payload.update_height.revision_number(),
+            revision_height: counterparty_payload.update_height.revision_height(),
         };
 
         let conn_open_init_msg: MsgConnOpenTry = MsgConnOpenTry {

--- a/relayer/crates/starknet-chain-components/src/impls/messages/connection.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/connection.rs
@@ -157,10 +157,7 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: None,
-        };
+        let message = StarknetMessage::new(call);
 
         Ok(message)
     }
@@ -260,10 +257,8 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: Some(payload.update_height),
-        };
+        let message =
+            StarknetMessage::new(call).with_counterparty_height(counterparty_payload.update_height);
 
         Ok(message)
     }
@@ -339,10 +334,8 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: Some(counterparty_payload.update_height),
-        };
+        let message =
+            StarknetMessage::new(call).with_counterparty_height(counterparty_payload.update_height);
 
         Ok(message)
     }
@@ -401,10 +394,8 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: Some(counterparty_payload.update_height),
-        };
+        let message =
+            StarknetMessage::new(call).with_counterparty_height(counterparty_payload.update_height);
 
         Ok(message)
     }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/connection.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/connection.rs
@@ -38,6 +38,7 @@ use starknet::accounts::Call;
 use starknet::core::types::Felt;
 use starknet::macros::selector;
 
+use crate::impls::types::message::StarknetMessage;
 use crate::traits::queries::address::CanQueryContractAddress;
 use crate::types::client_id::ClientId as StarknetClientId;
 use crate::types::connection_id::ConnectionId as StarknetConnectionId;
@@ -58,7 +59,7 @@ where
             InitConnectionOptions = CosmosInitConnectionOptions,
         > + HasClientIdType<Counterparty, ClientId = StarknetClientId>
         + HasAddressType<Address = Felt>
-        + HasMessageType<Message = Call>
+        + HasMessageType<Message = StarknetMessage>
         + HasEncoding<AsFelt, Encoding = Encoding>
         + CanQueryContractAddress<symbol!("ibc_core_contract_address")>
         + CanRaiseError<&'static str>
@@ -150,10 +151,15 @@ where
             .encode(&conn_open_init_msg)
             .map_err(Chain::raise_error)?;
 
-        let message = Call {
+        let call = Call {
             to: ibc_core_address,
             selector: selector!("conn_open_init"),
             calldata,
+        };
+
+        let message = StarknetMessage {
+            call,
+            counterparty_height: None,
         };
 
         Ok(message)
@@ -164,7 +170,7 @@ impl<Chain, Counterparty, Encoding> ConnectionOpenTryMessageBuilder<Chain, Count
     for BuildStarknetConnectionHandshakeMessages
 where
     Chain: HasHeightType
-        + HasMessageType<Message = Call>
+        + HasMessageType<Message = StarknetMessage>
         + HasClientIdType<Counterparty, ClientId = StarknetClientId>
         + HasClientStateType<Counterparty>
         + HasAddressType<Address = Felt>
@@ -248,10 +254,15 @@ where
             .encode(&conn_open_init_msg)
             .map_err(Chain::raise_error)?;
 
-        let message = Call {
+        let call = Call {
             to: ibc_core_address,
             selector: selector!("conn_open_init"),
             calldata,
+        };
+
+        let message = StarknetMessage {
+            call,
+            counterparty_height: Some(payload.update_height),
         };
 
         Ok(message)
@@ -265,7 +276,7 @@ where
         + HasClientStateType<Counterparty>
         + HasConnectionIdType<Counterparty, ConnectionId = StarknetConnectionId>
         + HasAddressType<Address = Felt>
-        + HasMessageType<Message = Call>
+        + HasMessageType<Message = StarknetMessage>
         + HasEncoding<AsFelt, Encoding = Encoding>
         + CanQueryContractAddress<symbol!("ibc_core_contract_address")>
         + CanRaiseError<Encoding::Error>,
@@ -322,10 +333,15 @@ where
             .encode(&conn_open_ack_msg)
             .map_err(Chain::raise_error)?;
 
-        let message = Call {
+        let call = Call {
             to: ibc_core_address,
             selector: selector!("conn_open_ack"),
             calldata,
+        };
+
+        let message = StarknetMessage {
+            call,
+            counterparty_height: Some(counterparty_payload.update_height),
         };
 
         Ok(message)
@@ -337,7 +353,7 @@ impl<Chain, Counterparty, Encoding> ConnectionOpenConfirmMessageBuilder<Chain, C
 where
     Chain: HasConnectionIdType<Counterparty, ConnectionId = StarknetConnectionId>
         + HasAddressType<Address = Felt>
-        + HasMessageType<Message = Call>
+        + HasMessageType<Message = StarknetMessage>
         + HasEncoding<AsFelt, Encoding = Encoding>
         + CanQueryContractAddress<symbol!("ibc_core_contract_address")>
         + CanRaiseError<Encoding::Error>,
@@ -379,10 +395,15 @@ where
             .encode(&conn_open_confirm_msg)
             .map_err(Chain::raise_error)?;
 
-        let message = Call {
+        let call = Call {
             to: ibc_core_address,
             selector: selector!("conn_open_confirm"),
             calldata,
+        };
+
+        let message = StarknetMessage {
+            call,
+            counterparty_height: Some(counterparty_payload.update_height),
         };
 
         Ok(message)

--- a/relayer/crates/starknet-chain-components/src/impls/messages/create_client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/create_client.rs
@@ -17,6 +17,7 @@ use starknet::accounts::Call;
 use starknet::core::types::Felt;
 use starknet::macros::{selector, short_string};
 
+use crate::impls::types::message::StarknetMessage;
 use crate::traits::queries::address::CanQueryContractAddress;
 use crate::types::cosmos::client_state::{ClientStatus, CometClientState};
 use crate::types::cosmos::consensus_state::CometConsensusState;
@@ -28,7 +29,7 @@ impl<Chain, Counterparty, Encoding> CreateClientMessageBuilder<Chain, Counterpar
     for BuildCreateCometClientMessage
 where
     Chain: HasCreateClientMessageOptionsType<Counterparty>
-        + HasMessageType<Message = Call>
+        + HasMessageType<Message = StarknetMessage>
         + HasAddressType<Address = Felt>
         + HasEncoding<AsFelt, Encoding = Encoding>
         + CanQueryContractAddress<symbol!("ibc_core_contract_address")>
@@ -88,6 +89,11 @@ where
             calldata,
         };
 
-        Ok(call)
+        let message = StarknetMessage {
+            call,
+            counterparty_height: Some(payload.client_state.latest_height),
+        };
+
+        Ok(message)
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/create_client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/create_client.rs
@@ -89,10 +89,7 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: Some(payload.client_state.latest_height),
-        };
+        let message = StarknetMessage::new(call);
 
         Ok(message)
     }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/update_client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/update_client.rs
@@ -16,6 +16,7 @@ use starknet::accounts::Call;
 use starknet::core::types::Felt;
 use starknet::macros::selector;
 
+use crate::impls::types::message::StarknetMessage;
 use crate::traits::queries::address::CanQueryContractAddress;
 use crate::types::client_id::ClientId;
 use crate::types::cosmos::update::CometUpdateHeader;
@@ -26,7 +27,7 @@ impl<Chain, Counterparty, Encoding> UpdateClientMessageBuilder<Chain, Counterpar
     for BuildUpdateCometClientMessage
 where
     Chain: HasCreateClientMessageOptionsType<Counterparty>
-        + HasMessageType<Message = Call>
+        + HasMessageType<Message = StarknetMessage>
         + HasAddressType<Address = Felt>
         + HasClientIdType<Counterparty, ClientId = ClientId>
         + HasEncoding<AsFelt, Encoding = Encoding>
@@ -60,6 +61,11 @@ where
             calldata,
         };
 
-        Ok(vec![call])
+        let message = StarknetMessage {
+            call,
+            counterparty_height: None, // TODO: Get ibc core Height
+        };
+
+        Ok(vec![message])
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/update_client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/update_client.rs
@@ -61,10 +61,7 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: None, // TODO: Get ibc core Height
-        };
+        let message = StarknetMessage::new(call);
 
         Ok(vec![message])
     }

--- a/relayer/crates/starknet-chain-components/src/impls/types/message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/message.rs
@@ -1,9 +1,16 @@
 use cgp::core::Async;
 use hermes_relayer_components::chain::traits::types::message::ProvideMessageType;
+use ibc::core::client::types::Height as CosmosHeight;
 use starknet::accounts::Call;
+
+#[derive(Clone)]
+pub struct StarknetMessage {
+    pub call: Call,
+    pub counterparty_height: Option<CosmosHeight>,
+}
 
 pub struct ProvideCallMessage;
 
 impl<Chain: Async> ProvideMessageType<Chain> for ProvideCallMessage {
-    type Message = Call;
+    type Message = StarknetMessage;
 }

--- a/relayer/crates/starknet-chain-components/src/impls/types/message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/message.rs
@@ -9,6 +9,25 @@ pub struct StarknetMessage {
     pub counterparty_height: Option<CosmosHeight>,
 }
 
+impl StarknetMessage {
+    pub fn new(call: Call) -> Self {
+        Self {
+            call,
+            counterparty_height: None,
+        }
+    }
+
+    pub fn with_counterparty_height(mut self, height: CosmosHeight) -> Self {
+        self.counterparty_height = Some(height);
+        self
+    }
+
+    pub fn without_counterparty_height(mut self) -> Self {
+        self.counterparty_height = None;
+        self
+    }
+}
+
 pub struct ProvideCallMessage;
 
 impl<Chain: Async> ProvideMessageType<Chain> for ProvideCallMessage {

--- a/relayer/crates/starknet-chain-components/src/types/messages/erc20/transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/erc20/transfer.rs
@@ -13,6 +13,7 @@ use starknet::accounts::Call;
 use starknet::core::types::{Felt, U256};
 use starknet::macros::selector;
 
+use crate::impls::types::message::StarknetMessage;
 use crate::traits::messages::transfer::TransferTokenMessageBuilder;
 use crate::traits::types::blob::HasBlobType;
 use crate::traits::types::method::HasSelectorType;
@@ -41,7 +42,7 @@ where
         + HasAmountType<Amount = StarknetAmount>
         + HasBlobType<Blob = Vec<Felt>>
         + HasSelectorType<Selector = Felt>
-        + HasMessageType<Message = Call>
+        + HasMessageType<Message = StarknetMessage>
         + HasEncoding<AsFelt, Encoding = Encoding>
         + CanRaiseError<Encoding::Error>,
     Encoding: CanEncode<ViaCairo, TransferErc20TokenMessage, Encoded = Vec<Felt>>,
@@ -50,7 +51,7 @@ where
         chain: &Chain,
         recipient: &Felt,
         amount: &StarknetAmount,
-    ) -> Result<Call, Chain::Error> {
+    ) -> Result<StarknetMessage, Chain::Error> {
         let message = TransferErc20TokenMessage {
             recipient: *recipient,
             amount: amount.quantity,
@@ -67,6 +68,11 @@ where
             calldata,
         };
 
-        Ok(call)
+        let message = StarknetMessage {
+            call,
+            counterparty_height: None,
+        };
+
+        Ok(message)
     }
 }

--- a/relayer/crates/starknet-chain-components/src/types/messages/erc20/transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/erc20/transfer.rs
@@ -68,10 +68,7 @@ where
             calldata,
         };
 
-        let message = StarknetMessage {
-            call,
-            counterparty_height: None,
-        };
+        let message = StarknetMessage::new(call);
 
         Ok(message)
     }

--- a/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
@@ -17,6 +17,7 @@ use hermes_relayer_components::relay::traits::client_creator::CanCreateClient;
 use hermes_relayer_components::relay::traits::target::{DestinationTarget, SourceTarget};
 use hermes_runtime_components::traits::fs::read_file::CanReadFileAsString;
 use hermes_starknet_chain_components::impls::encoding::events::CanFilterDecodeEvents;
+use hermes_starknet_chain_components::impls::types::message::StarknetMessage;
 use hermes_starknet_chain_components::traits::contract::declare::CanDeclareContract;
 use hermes_starknet_chain_components::traits::contract::deploy::CanDeployContract;
 use hermes_starknet_chain_components::traits::queries::token_balance::CanQueryTokenBalance;
@@ -213,7 +214,12 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata,
             };
 
-            let response = starknet_chain.send_message(call).await?;
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
+            };
+
+            let response = starknet_chain.send_message(message).await?;
 
             info!("IBC register client response: {:?}", response);
         }
@@ -299,10 +305,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
 
             info!("selector: {:?}", selector!("conn_open_init"));
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("conn_open_init"),
                 calldata: cairo_encoding.encode(&conn_open_init_msg)?,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message).await?;
@@ -343,10 +354,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 delay_period: 0,
             };
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("conn_open_try"),
                 calldata: cairo_encoding.encode(&conn_open_try_msg)?,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message).await?;
@@ -383,10 +399,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 version: connection_version.clone(),
             };
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("conn_open_ack"),
                 calldata: cairo_encoding.encode(&conn_open_ack_msg)?,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message).await?;
@@ -421,10 +442,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 proof_height_on_a: starknet_client_state.latest_height.clone(),
             };
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("conn_open_confirm"),
                 calldata: cairo_encoding.encode(&conn_open_confirm_msg)?,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message).await?;
@@ -476,10 +502,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
 
             let register_call_data = cairo_encoding.encode(&register_app)?;
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("bind_port_id"),
                 calldata: register_call_data,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message).await?;
@@ -496,10 +527,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 ordering: ChannelOrdering::Unordered,
             };
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("chan_open_init"),
                 calldata: cairo_encoding.encode(&chan_open_init_msg)?,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message).await?;
@@ -542,10 +578,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 ordering: ChannelOrdering::Unordered,
             };
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("chan_open_try"),
                 calldata: cairo_encoding.encode(&chan_open_try_msg)?,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message).await?;
@@ -583,10 +624,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 proof_height_on_b: starknet_client_state.latest_height.clone(),
             };
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("chan_open_ack"),
                 calldata: cairo_encoding.encode(&chan_open_ack_msg)?,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message).await?;
@@ -623,10 +669,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 proof_height_on_a: starknet_client_state.latest_height.clone(),
             };
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("chan_open_confirm"),
                 calldata: cairo_encoding.encode(&chan_open_confirm_msg)?,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message).await?;
@@ -707,10 +758,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
         let token_address = {
             let calldata = cairo_encoding.encode(&msg_recv_packet)?;
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("recv_packet"),
                 calldata,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message.clone()).await?;
@@ -792,10 +848,15 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
 
             let calldata = cairo_encoding.encode(&msg_recv_packet)?;
 
-            let message = Call {
+            let call = Call {
                 to: ibc_core_address,
                 selector: selector!("recv_packet"),
                 calldata,
+            };
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: None,
             };
 
             let response = starknet_chain.send_message(message.clone()).await?;

--- a/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
@@ -214,10 +214,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 
@@ -311,10 +308,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata: cairo_encoding.encode(&conn_open_init_msg)?,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 
@@ -360,10 +354,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata: cairo_encoding.encode(&conn_open_try_msg)?,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 
@@ -405,10 +396,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata: cairo_encoding.encode(&conn_open_ack_msg)?,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 
@@ -448,10 +436,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata: cairo_encoding.encode(&conn_open_confirm_msg)?,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 
@@ -508,10 +493,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata: register_call_data,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 
@@ -533,10 +515,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata: cairo_encoding.encode(&chan_open_init_msg)?,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 
@@ -584,10 +563,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata: cairo_encoding.encode(&chan_open_try_msg)?,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 
@@ -630,10 +606,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata: cairo_encoding.encode(&chan_open_ack_msg)?,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 
@@ -675,10 +648,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata: cairo_encoding.encode(&chan_open_confirm_msg)?,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 
@@ -764,10 +734,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message.clone()).await?;
 
@@ -854,10 +821,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
                 calldata,
             };
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: None,
-            };
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message.clone()).await?;
 

--- a/relayer/crates/starknet-integration-tests/src/tests/light_client.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/light_client.rs
@@ -211,7 +211,7 @@ fn test_starknet_light_client() -> Result<(), Error> {
 
             let cosmos_chain_height = cosmos_chain.query_chain_height().await?;
 
-            let message = StarknetMessage::new(call).with_counterparty_height(cosmos_chain_height);
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 

--- a/relayer/crates/starknet-integration-tests/src/tests/light_client.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/light_client.rs
@@ -211,10 +211,7 @@ fn test_starknet_light_client() -> Result<(), Error> {
 
             let cosmos_chain_height = cosmos_chain.query_chain_height().await?;
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: Some(cosmos_chain_height),
-            };
+            let message = StarknetMessage::new(call).with_counterparty_height(cosmos_chain_height);
 
             let response = starknet_chain.send_message(message).await?;
 

--- a/relayer/crates/starknet-integration-tests/src/tests/light_client.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/light_client.rs
@@ -36,6 +36,7 @@ use hermes_relayer_components::relay::traits::target::{DestinationTarget, Source
 use hermes_relayer_components::relay::traits::update_client_message_builder::CanSendTargetUpdateClientMessage;
 use hermes_runtime_components::traits::fs::read_file::CanReadFileAsString;
 use hermes_runtime_components::traits::sleep::CanSleep;
+use hermes_starknet_chain_components::impls::types::message::StarknetMessage;
 use hermes_starknet_chain_components::traits::contract::declare::CanDeclareContract;
 use hermes_starknet_chain_components::traits::contract::deploy::CanDeployContract;
 use hermes_starknet_chain_components::types::payloads::client::StarknetCreateClientPayloadOptions;
@@ -208,7 +209,14 @@ fn test_starknet_light_client() -> Result<(), Error> {
                 calldata,
             };
 
-            let response = starknet_chain.send_message(call).await?;
+            let cosmos_chain_height = cosmos_chain.query_chain_height().await?;
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: Some(cosmos_chain_height),
+            };
+
+            let response = starknet_chain.send_message(message).await?;
 
             info!("IBC register client response: {:?}", response);
         }

--- a/relayer/crates/starknet-integration-tests/src/tests/light_client.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/light_client.rs
@@ -209,8 +209,6 @@ fn test_starknet_light_client() -> Result<(), Error> {
                 calldata,
             };
 
-            let cosmos_chain_height = cosmos_chain.query_chain_height().await?;
-
             let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;

--- a/relayer/crates/starknet-integration-tests/src/tests/update_clients.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/update_clients.rs
@@ -157,8 +157,6 @@ fn test_relay_update_clients() -> Result<(), Error> {
                 calldata,
             };
 
-            let cosmos_chain_height = cosmos_chain.query_chain_height().await?;
-
             let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;

--- a/relayer/crates/starknet-integration-tests/src/tests/update_clients.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/update_clients.rs
@@ -159,10 +159,7 @@ fn test_relay_update_clients() -> Result<(), Error> {
 
             let cosmos_chain_height = cosmos_chain.query_chain_height().await?;
 
-            let message = StarknetMessage {
-                call,
-                counterparty_height: Some(cosmos_chain_height),
-            };
+            let message = StarknetMessage::new(call).with_counterparty_height(cosmos_chain_height);
 
             let response = starknet_chain.send_message(message).await?;
 

--- a/relayer/crates/starknet-integration-tests/src/tests/update_clients.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/update_clients.rs
@@ -20,6 +20,7 @@ use hermes_relayer_components::relay::traits::target::{DestinationTarget, Source
 use hermes_relayer_components::relay::traits::update_client_message_builder::CanSendTargetUpdateClientMessage;
 use hermes_runtime_components::traits::fs::read_file::CanReadFileAsString;
 use hermes_runtime_components::traits::sleep::CanSleep;
+use hermes_starknet_chain_components::impls::types::message::StarknetMessage;
 use hermes_starknet_chain_components::traits::contract::declare::CanDeclareContract;
 use hermes_starknet_chain_components::traits::contract::deploy::CanDeployContract;
 use hermes_starknet_chain_components::types::payloads::client::StarknetCreateClientPayloadOptions;
@@ -156,7 +157,14 @@ fn test_relay_update_clients() -> Result<(), Error> {
                 calldata,
             };
 
-            let response = starknet_chain.send_message(call).await?;
+            let cosmos_chain_height = cosmos_chain.query_chain_height().await?;
+
+            let message = StarknetMessage {
+                call,
+                counterparty_height: Some(cosmos_chain_height),
+            };
+
+            let response = starknet_chain.send_message(message).await?;
 
             info!("IBC register client response: {:?}", response);
         }

--- a/relayer/crates/starknet-integration-tests/src/tests/update_clients.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/update_clients.rs
@@ -159,7 +159,7 @@ fn test_relay_update_clients() -> Result<(), Error> {
 
             let cosmos_chain_height = cosmos_chain.query_chain_height().await?;
 
-            let message = StarknetMessage::new(call).with_counterparty_height(cosmos_chain_height);
+            let message = StarknetMessage::new(call);
 
             let response = starknet_chain.send_message(message).await?;
 


### PR DESCRIPTION
Closes: #141

This PR adds a `StarknetMessage` which contains the counterparty Cosmos height and uses this type instead of `Call` for messages