### PR TITLE
feat(relayer): reuse `ConnectionEnd` and `ChannelEnd` from `ibc-rs`

### DIFF
--- a/relayer/crates/starknet-chain-components/src/components/encoding/cairo.rs
+++ b/relayer/crates/starknet-chain-components/src/components/encoding/cairo.rs
@@ -1,3 +1,5 @@
+use core::time::Duration;
+
 use cgp::core::component::{UseContext, UseDelegate};
 use cgp::prelude::*;
 use hermes_cairo_encoding_components::components::encode_mut::*;
@@ -21,6 +23,7 @@ use crate::types::client_id::{ClientId, EncodeClientId};
 use crate::types::connection_id::{
     ConnectionCounterparty, ConnectionEnd, ConnectionId, ConnectionState,
     EncodeConnectionCounterparty, EncodeConnectionEnd, EncodeConnectionId, EncodeConnectionState,
+    EncodeDuration,
 };
 use crate::types::cosmos::client_state::{
     ClientStatus, CometClientState, EncodeChainId, EncodeClientStatus, EncodeCometClientState,
@@ -127,6 +130,7 @@ delegate_components! {
         (ViaCairo, ClientId): EncodeClientId,
         (ViaCairo, ChainId): EncodeChainId,
         (ViaCairo, ConnectionId): EncodeConnectionId,
+        (ViaCairo, Duration): EncodeDuration,
         (ViaCairo, ConnectionCounterparty): EncodeConnectionCounterparty,
         (ViaCairo, ConnectionState): EncodeConnectionState,
         (ViaCairo, ConnectionEnd): EncodeConnectionEnd,

--- a/relayer/crates/starknet-chain-components/src/impls/events/ack.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/events/ack.rs
@@ -64,17 +64,9 @@ where
     ) -> Result<Packet, Chain::Error> {
         let packet = Packet {
             seq_on_a: event.sequence_on_a.sequence.into(),
-            port_id_on_a: event
-                .port_id_on_a
-                .port_id
-                .parse()
-                .map_err(Chain::raise_error)?,
+            port_id_on_a: event.port_id_on_a.clone(),
             chan_id_on_a: event.channel_id_on_a.clone(),
-            port_id_on_b: event
-                .port_id_on_b
-                .port_id
-                .parse()
-                .map_err(Chain::raise_error)?,
+            port_id_on_b: event.port_id_on_b.clone(),
             chan_id_on_b: event.channel_id_on_b.clone(),
             // FIXME: make the Cairo contract include these fields in the event
             data: Vec::new(),

--- a/relayer/crates/starknet-chain-components/src/impls/events/ack.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/events/ack.rs
@@ -69,22 +69,13 @@ where
                 .port_id
                 .parse()
                 .map_err(Chain::raise_error)?,
-            chan_id_on_a: event
-                .channel_id_on_a
-                .channel_id
-                .parse()
-                .map_err(Chain::raise_error)?,
+            chan_id_on_a: event.channel_id_on_a.clone(),
             port_id_on_b: event
                 .port_id_on_b
                 .port_id
                 .parse()
                 .map_err(Chain::raise_error)?,
-            chan_id_on_b: event
-                .channel_id_on_b
-                .channel_id
-                .parse()
-                .map_err(Chain::raise_error)?,
-
+            chan_id_on_b: event.channel_id_on_b.clone(),
             // FIXME: make the Cairo contract include these fields in the event
             data: Vec::new(),
             timeout_height_on_b: TimeoutHeight::Never,

--- a/relayer/crates/starknet-chain-components/src/impls/events/send_packet.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/events/send_packet.rs
@@ -112,21 +112,13 @@ where
                 .port_id
                 .parse()
                 .map_err(Chain::raise_error)?,
-            chan_id_on_a: event
-                .channel_id_on_a
-                .channel_id
-                .parse()
-                .map_err(Chain::raise_error)?,
+            chan_id_on_a: event.channel_id_on_a.clone(),
             port_id_on_b: event
                 .port_id_on_b
                 .port_id
                 .parse()
                 .map_err(Chain::raise_error)?,
-            chan_id_on_b: event
-                .channel_id_on_b
-                .channel_id
-                .parse()
-                .map_err(Chain::raise_error)?,
+            chan_id_on_b: event.channel_id_on_b.clone(),
             data: cosmos_packet_data,
             timeout_height_on_b,
             timeout_timestamp_on_b,

--- a/relayer/crates/starknet-chain-components/src/impls/events/send_packet.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/events/send_packet.rs
@@ -107,17 +107,9 @@ where
 
         let packet = Packet {
             seq_on_a: event.sequence_on_a.sequence.into(),
-            port_id_on_a: event
-                .port_id_on_a
-                .port_id
-                .parse()
-                .map_err(Chain::raise_error)?,
+            port_id_on_a: event.port_id_on_a.clone(),
             chan_id_on_a: event.channel_id_on_a.clone(),
-            port_id_on_b: event
-                .port_id_on_b
-                .port_id
-                .parse()
-                .map_err(Chain::raise_error)?,
+            port_id_on_b: event.port_id_on_b.clone(),
             chan_id_on_b: event.channel_id_on_b.clone(),
             data: cosmos_packet_data,
             timeout_height_on_b,

--- a/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
@@ -36,7 +36,7 @@ use crate::types::channel_id::ChannelId as StarknetChannelId;
 use crate::types::cosmos::height::Height as CairoHeight;
 use crate::types::messages::ibc::channel::{
     AppVersion, ChannelOrdering, MsgChanOpenAck, MsgChanOpenConfirm, MsgChanOpenInit,
-    MsgChanOpenTry, PortId as StarknetPortId,
+    MsgChanOpenTry,
 };
 use crate::types::messages::ibc::packet::StateProof;
 pub struct BuildStarknetChannelHandshakeMessages;
@@ -61,14 +61,6 @@ where
         counterparty_port_id: &IbcPortId,
         init_channel_options: &CosmosInitChannelOptions,
     ) -> Result<Chain::Message, Chain::Error> {
-        let port_id_on_a = StarknetPortId {
-            port_id: port_id.to_string(),
-        };
-
-        let port_id_on_b = StarknetPortId {
-            port_id: counterparty_port_id.to_string(),
-        };
-
         if init_channel_options.connection_hops.len() != 1 {
             return Err(Chain::raise_error(
                 "Starknet only supports a single connection hop",
@@ -92,9 +84,9 @@ where
         };
 
         let chan_open_init_msg = MsgChanOpenInit {
-            port_id_on_a,
+            port_id_on_a: port_id.clone(),
             conn_id_on_a,
-            port_id_on_b,
+            port_id_on_b: counterparty_port_id.clone(),
             version_proposal,
             ordering,
         };
@@ -146,10 +138,6 @@ where
         counterparty_channel_id: &ChannelId,
         counterparty_payload: ChannelOpenTryPayload<Counterparty, Chain>,
     ) -> Result<Chain::Message, Chain::Error> {
-        let port_id_on_b = StarknetPortId {
-            port_id: port_id.to_string(),
-        };
-
         if counterparty_payload.channel_end.connection_hops.len() != 1 {
             return Err(Chain::raise_error(
                 "Starknet only supports a single connection hop",
@@ -159,10 +147,6 @@ where
         assert_eq!(counterparty_payload.channel_end.connection_hops.len(), 1);
 
         let conn_id_on_b = counterparty_payload.channel_end.connection_hops[0].clone();
-
-        let port_id_on_a = StarknetPortId {
-            port_id: counterparty_port_id.to_string(),
-        };
 
         let version_on_a = AppVersion {
             version: counterparty_payload.channel_end.version.to_string(),
@@ -186,9 +170,9 @@ where
         };
 
         let chan_open_try_msg = MsgChanOpenTry {
-            port_id_on_b,
+            port_id_on_b: port_id.clone(),
             conn_id_on_b,
-            port_id_on_a,
+            port_id_on_a: counterparty_port_id.clone(),
             chan_id_on_a: counterparty_channel_id.clone(),
             version_on_a,
             proof_chan_end_on_a,
@@ -243,10 +227,6 @@ where
         counterparty_channel_id: &ChannelId,
         counterparty_payload: ChannelOpenAckPayload<Counterparty, Chain>,
     ) -> Result<Chain::Message, Chain::Error> {
-        let port_id_on_a = StarknetPortId {
-            port_id: port_id.to_string(),
-        };
-
         let version_on_b = AppVersion {
             version: counterparty_payload.channel_end.version.to_string(),
         };
@@ -261,7 +241,7 @@ where
         };
 
         let chan_open_ack_msg = MsgChanOpenAck {
-            port_id_on_a,
+            port_id_on_a: port_id.clone(),
             chan_id_on_a: channel_id.clone(),
             chan_id_on_b: counterparty_channel_id.clone(),
             version_on_b,
@@ -313,10 +293,6 @@ where
         channel_id: &StarknetChannelId,
         counterparty_payload: ChannelOpenConfirmPayload<Counterparty>,
     ) -> Result<Chain::Message, Chain::Error> {
-        let port_id_on_b = StarknetPortId {
-            port_id: port_id.to_string(),
-        };
-
         let proof_chan_end_on_a = StateProof {
             proof: vec![Felt::ONE],
         };
@@ -327,7 +303,7 @@ where
         };
 
         let chan_open_confirm_msg = MsgChanOpenConfirm {
-            port_id_on_b,
+            port_id_on_b: port_id.clone(),
             chan_id_on_b: channel_id.clone(),
             proof_chan_end_on_a,
             proof_height_on_a,

--- a/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
@@ -35,8 +35,7 @@ use crate::traits::queries::address::CanQueryContractAddress;
 use crate::types::channel_id::ChannelId as StarknetChannelId;
 use crate::types::cosmos::height::Height as CairoHeight;
 use crate::types::messages::ibc::channel::{
-    AppVersion, ChannelOrdering, MsgChanOpenAck, MsgChanOpenConfirm, MsgChanOpenInit,
-    MsgChanOpenTry,
+    ChannelOrdering, MsgChanOpenAck, MsgChanOpenConfirm, MsgChanOpenInit, MsgChanOpenTry,
 };
 use crate::types::messages::ibc::packet::StateProof;
 pub struct BuildStarknetChannelHandshakeMessages;
@@ -71,10 +70,6 @@ where
 
         let conn_id_on_a = init_channel_options.connection_hops[0].clone();
 
-        let version_proposal = AppVersion {
-            version: init_channel_options.channel_version.to_string(),
-        };
-
         let ordering = match init_channel_options.ordering {
             IbcOrder::None => {
                 return Err(Chain::raise_error("Starknet does not support no ordering"))
@@ -87,7 +82,7 @@ where
             port_id_on_a: port_id.clone(),
             conn_id_on_a,
             port_id_on_b: counterparty_port_id.clone(),
-            version_proposal,
+            version_proposal: init_channel_options.channel_version.clone(),
             ordering,
         };
 
@@ -148,10 +143,6 @@ where
 
         let conn_id_on_b = counterparty_payload.channel_end.connection_hops[0].clone();
 
-        let version_on_a = AppVersion {
-            version: counterparty_payload.channel_end.version.to_string(),
-        };
-
         let proof_chan_end_on_a = StateProof {
             proof: vec![Felt::ONE],
         };
@@ -174,7 +165,7 @@ where
             conn_id_on_b,
             port_id_on_a: counterparty_port_id.clone(),
             chan_id_on_a: counterparty_channel_id.clone(),
-            version_on_a,
+            version_on_a: counterparty_payload.channel_end.version.clone(),
             proof_chan_end_on_a,
             proof_height_on_a,
             ordering,
@@ -227,10 +218,6 @@ where
         counterparty_channel_id: &ChannelId,
         counterparty_payload: ChannelOpenAckPayload<Counterparty, Chain>,
     ) -> Result<Chain::Message, Chain::Error> {
-        let version_on_b = AppVersion {
-            version: counterparty_payload.channel_end.version.to_string(),
-        };
-
         let proof_chan_end_on_b = StateProof {
             proof: vec![Felt::ONE],
         };
@@ -244,7 +231,7 @@ where
             port_id_on_a: port_id.clone(),
             chan_id_on_a: channel_id.clone(),
             chan_id_on_b: counterparty_channel_id.clone(),
-            version_on_b,
+            version_on_b: counterparty_payload.channel_end.version.clone(),
             proof_chan_end_on_b,
             proof_height_on_b,
         };

--- a/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
@@ -164,10 +164,6 @@ where
             port_id: counterparty_port_id.to_string(),
         };
 
-        let chan_id_on_a = StarknetChannelId {
-            channel_id: counterparty_channel_id.to_string(),
-        };
-
         let version_on_a = AppVersion {
             version: counterparty_payload.channel_end.version.to_string(),
         };
@@ -193,7 +189,7 @@ where
             port_id_on_b,
             conn_id_on_b,
             port_id_on_a,
-            chan_id_on_a,
+            chan_id_on_a: counterparty_channel_id.clone(),
             version_on_a,
             proof_chan_end_on_a,
             proof_height_on_a,
@@ -251,10 +247,6 @@ where
             port_id: port_id.to_string(),
         };
 
-        let chan_id_on_b = StarknetChannelId {
-            channel_id: counterparty_channel_id.to_string(),
-        };
-
         let version_on_b = AppVersion {
             version: counterparty_payload.channel_end.version.to_string(),
         };
@@ -271,7 +263,7 @@ where
         let chan_open_ack_msg = MsgChanOpenAck {
             port_id_on_a,
             chan_id_on_a: channel_id.clone(),
-            chan_id_on_b,
+            chan_id_on_b: counterparty_channel_id.clone(),
             version_on_b,
             proof_chan_end_on_b,
             proof_height_on_b,

--- a/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
@@ -66,8 +66,6 @@ where
             ));
         }
 
-        assert_eq!(init_channel_options.connection_hops.len(), 1);
-
         let conn_id_on_a = init_channel_options.connection_hops[0].clone();
 
         let ordering = match init_channel_options.ordering {
@@ -138,8 +136,6 @@ where
                 "Starknet only supports a single connection hop",
             ));
         }
-
-        assert_eq!(counterparty_payload.channel_end.connection_hops.len(), 1);
 
         let conn_id_on_b = counterparty_payload.channel_end.connection_hops[0].clone();
 

--- a/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
@@ -33,7 +33,6 @@ use starknet::macros::selector;
 use crate::impls::types::message::StarknetMessage;
 use crate::traits::queries::address::CanQueryContractAddress;
 use crate::types::channel_id::ChannelId as StarknetChannelId;
-use crate::types::connection_id::ConnectionId as StarknetConnectionId;
 use crate::types::cosmos::height::Height as CairoHeight;
 use crate::types::messages::ibc::channel::{
     AppVersion, ChannelOrdering, MsgChanOpenAck, MsgChanOpenConfirm, MsgChanOpenInit,
@@ -76,9 +75,9 @@ where
             ));
         }
 
-        let conn_id_on_a = StarknetConnectionId {
-            connection_id: init_channel_options.connection_hops[0].to_string(),
-        };
+        assert_eq!(init_channel_options.connection_hops.len(), 1);
+
+        let conn_id_on_a = init_channel_options.connection_hops[0].clone();
 
         let version_proposal = AppVersion {
             version: init_channel_options.channel_version.to_string(),
@@ -157,9 +156,9 @@ where
             ));
         }
 
-        let conn_id_on_b = StarknetConnectionId {
-            connection_id: counterparty_payload.channel_end.connection_hops[0].to_string(),
-        };
+        assert_eq!(counterparty_payload.channel_end.connection_hops.len(), 1);
+
+        let conn_id_on_b = counterparty_payload.channel_end.connection_hops[0].clone();
 
         let port_id_on_a = StarknetPortId {
             port_id: counterparty_port_id.to_string(),

--- a/relayer/crates/starknet-chain-components/src/impls/messages/connection.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/connection.rs
@@ -207,9 +207,7 @@ where
         let conn_open_init_msg: MsgConnOpenTry = MsgConnOpenTry {
             client_id_on_a: counterparty_client_id.clone(),
             client_id_on_b: client_id.clone(),
-            conn_id_on_a: StarknetConnectionId {
-                connection_id: counterparty_connection_id.to_string(),
-            },
+            conn_id_on_a: counterparty_connection_id.clone(),
             prefix_on_a: BasePrefix {
                 prefix: commitment_prefix.into(),
             },
@@ -266,10 +264,6 @@ where
         counterparty_connection_id: &CosmosConnectionId,
         counterparty_payload: ConnectionOpenAckPayload<Counterparty, Chain>,
     ) -> Result<Chain::Message, Chain::Error> {
-        let counterparty_connection_id_as_cairo = StarknetConnectionId {
-            connection_id: counterparty_connection_id.to_string(),
-        };
-
         // TODO(rano): use the connection version from the payload
         let connection_version = ConnectionVersion {
             identifier: "1".into(),
@@ -290,7 +284,7 @@ where
 
         let conn_open_ack_msg = MsgConnOpenAck {
             conn_id_on_a: connection_id.clone(),
-            conn_id_on_b: counterparty_connection_id_as_cairo,
+            conn_id_on_b: counterparty_connection_id.clone(),
             proof_conn_end_on_b: commitment_proof,
             proof_height_on_b: proof_height,
             version: connection_version,

--- a/relayer/crates/starknet-chain-components/src/impls/packet_fields.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/packet_fields.rs
@@ -14,8 +14,6 @@ where
         + HasChannelIdType<Counterparty, ChannelId = ChannelId>,
 {
     fn packet_src_channel_id(packet: &Packet) -> ChannelId {
-        ChannelId {
-            channel_id: packet.chan_id_on_b.to_string(),
-        }
+        packet.chan_id_on_b.clone()
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/queries/ack_commitment.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/ack_commitment.rs
@@ -60,16 +60,16 @@ where
 
         let contract_address = chain.query_contract_address(PhantomData).await?;
 
-        let cairo_port_id = CairoPortId {
-            port_id: port_id.to_string(),
-        };
-
         let cairo_sequence = Sequence {
             sequence: sequence.value(),
         };
 
         let calldata = encoding
-            .encode(&product![cairo_port_id, channel_id.clone(), cairo_sequence])
+            .encode(&product![
+                port_id.clone(),
+                channel_id.clone(),
+                cairo_sequence
+            ])
             .map_err(Chain::raise_error)?;
 
         let output = chain

--- a/relayer/crates/starknet-chain-components/src/impls/queries/channel_end.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/channel_end.rs
@@ -33,7 +33,7 @@ impl<Chain, Counterparty, Encoding> ChannelEndQuerier<Chain, Counterparty>
 where
     Chain: HasHeightType
         + HasChannelIdType<Counterparty, ChannelId = ChannelId>
-        + HasPortIdType<Counterparty>
+        + HasPortIdType<Counterparty, PortId = PortId>
         + HasChannelEndType<Counterparty, ChannelEnd = ChannelEnd>
         + HasBlobType<Blob = Vec<Felt>>
         + HasSelectorType<Selector = Felt>
@@ -57,10 +57,6 @@ where
 
         let contract_address = chain.query_contract_address(PhantomData).await?;
 
-        let port_id = PortId {
-            port_id: port_id.to_string(),
-        };
-
         let calldata = encoding
             .encode(&product![port_id.clone(), channel_id.clone()])
             .map_err(Chain::raise_error)?;
@@ -79,7 +75,7 @@ where
     Chain: HasHeightType<Height = u64>
         + CanQueryChainHeight
         + HasChannelIdType<Counterparty, ChannelId = ChannelId>
-        + HasPortIdType<Counterparty>
+        + HasPortIdType<Counterparty, PortId = PortId>
         + HasChannelEndType<Counterparty, ChannelEnd = ChannelEnd>
         + HasCommitmentProofType<CommitmentProof = StarknetCommitmentProof>
         + HasBlobType<Blob = Vec<Felt>>
@@ -103,10 +99,6 @@ where
         let encoding = chain.encoding();
 
         let contract_address = chain.query_contract_address(PhantomData).await?;
-
-        let port_id = PortId {
-            port_id: port_id.to_string(),
-        };
 
         let calldata = encoding
             .encode(&product![port_id.clone(), channel_id.clone()])

--- a/relayer/crates/starknet-chain-components/src/impls/queries/client_state.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/client_state.rs
@@ -54,8 +54,16 @@ where
 
         let contract_address = chain.query_contract_address(PhantomData).await?;
 
+        let client_id_seq = client_id
+            .as_str()
+            .rsplit_once('-')
+            .expect("valid client id")
+            .1
+            .parse::<u64>()
+            .expect("valid sequence");
+
         let calldata = encoding
-            .encode(&client_id.sequence)
+            .encode(&client_id_seq)
             .map_err(Chain::raise_error)?;
 
         let output = chain

--- a/relayer/crates/starknet-chain-components/src/impls/queries/consensus_state.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/consensus_state.rs
@@ -69,8 +69,16 @@ where
             revision_height: Counterparty::revision_height(consensus_height),
         };
 
+        let client_id_seq = client_id
+            .as_str()
+            .rsplit_once('-')
+            .expect("valid client id")
+            .1
+            .parse::<u64>()
+            .expect("valid sequence");
+
         let calldata = encoding
-            .encode(&(client_id.sequence, height.clone()))
+            .encode(&(client_id_seq, height.clone()))
             .map_err(Chain::raise_error)?;
 
         let output = chain

--- a/relayer/crates/starknet-chain-components/src/impls/queries/counterparty_chain_id.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/counterparty_chain_id.rs
@@ -45,7 +45,7 @@ where
             .await?;
 
         let connection_end = chain
-            .query_connection_end(&channel_end.connection_id, &height)
+            .query_connection_end(&channel_end.connection_hops[0], &height)
             .await?;
 
         let client_state = chain

--- a/relayer/crates/starknet-chain-components/src/impls/queries/counterparty_chain_id.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/counterparty_chain_id.rs
@@ -49,7 +49,7 @@ where
             .await?;
 
         let client_state = chain
-            .query_client_state(PhantomData, &connection_end.client_id, &height)
+            .query_client_state(PhantomData, connection_end.client_id(), &height)
             .await?;
 
         let chain_id = Counterparty::client_state_chain_id(&client_state);

--- a/relayer/crates/starknet-chain-components/src/impls/queries/packet_commitment.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/packet_commitment.rs
@@ -59,16 +59,16 @@ where
 
         let contract_address = chain.query_contract_address(PhantomData).await?;
 
-        let cairo_port_id = CairoPortId {
-            port_id: port_id.to_string(),
-        };
-
         let cairo_sequence = Sequence {
             sequence: sequence.value(),
         };
 
         let calldata = encoding
-            .encode(&product![cairo_port_id, channel_id.clone(), cairo_sequence])
+            .encode(&product![
+                port_id.clone(),
+                channel_id.clone(),
+                cairo_sequence
+            ])
             .map_err(Chain::raise_error)?;
 
         let output = chain

--- a/relayer/crates/starknet-chain-components/src/impls/queries/packet_receipt.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/packet_receipt.rs
@@ -59,16 +59,16 @@ where
 
         let contract_address = chain.query_contract_address(PhantomData).await?;
 
-        let cairo_port_id = CairoPortId {
-            port_id: port_id.to_string(),
-        };
-
         let cairo_sequence = Sequence {
             sequence: sequence.value(),
         };
 
         let calldata = encoding
-            .encode(&product![cairo_port_id, channel_id.clone(), cairo_sequence])
+            .encode(&product![
+                port_id.clone(),
+                channel_id.clone(),
+                cairo_sequence
+            ])
             .map_err(Chain::raise_error)?;
 
         let output = chain

--- a/relayer/crates/starknet-chain-components/src/impls/queries/packet_received.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/packet_received.rs
@@ -60,16 +60,16 @@ where
 
         let contract_address = chain.query_contract_address(PhantomData).await?;
 
-        let cairo_port_id = CairoPortId {
-            port_id: port_id.to_string(),
-        };
-
         let cairo_sequence = Sequence {
             sequence: sequence.value(),
         };
 
         let calldata = encoding
-            .encode(&product![cairo_port_id, channel_id.clone(), cairo_sequence])
+            .encode(&product![
+                port_id.clone(),
+                channel_id.clone(),
+                cairo_sequence
+            ])
             .map_err(Chain::raise_error)?;
 
         let output = chain

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/channel_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/channel_message.rs
@@ -72,22 +72,9 @@ where
             StarknetChannelOrdering::Unordered => IbcChannelOrder::Unordered,
         };
 
-        if !starknet_channel_end.remote.channel_id.channel_id.is_empty() {
-            return Err(Chain::raise_error(
-                "ChannelEnd has non-empty channel_id after chan_open_init",
-            ));
-        }
-
-        let cosmos_channel_seq = counterparty_channel_id
-            .channel_id
-            .strip_prefix("channel-")
-            .ok_or_else(|| Chain::raise_error("ChannelId does not have the expected prefix"))?
-            .parse::<u64>()
-            .map_err(Chain::raise_error)?;
-
         let remote = IbcChannelCounterparty {
             port_id: counterparty_port_id.clone(),
-            channel_id: Some(IbcChannelId::new(cosmos_channel_seq)),
+            channel_id: Some(counterparty_channel_id.clone()),
         };
 
         let connection_id = starknet_channel_end.connection_id;
@@ -150,7 +137,7 @@ where
         let message = CosmosChannelOpenAckMessage {
             port_id: port_id.to_string(),
             channel_id: channel_id.to_string(),
-            counterparty_channel_id: counterparty_channel_id.channel_id.clone(),
+            counterparty_channel_id: counterparty_channel_id.to_string(),
             counterparty_version: counterparty_payload.channel_end.version.version,
             update_height,
             proof_try,

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/channel_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/channel_message.rs
@@ -21,8 +21,7 @@ use hermes_cosmos_chain_components::types::messages::channel::open_ack::CosmosCh
 use hermes_cosmos_chain_components::types::messages::channel::open_confirm::CosmosChannelOpenConfirmMessage;
 use hermes_cosmos_chain_components::types::messages::channel::open_try::CosmosChannelOpenTryMessage;
 use ibc::core::channel::types::channel::{
-    ChannelEnd as IbcChannelEnd, Counterparty as IbcChannelCounterparty, Order as IbcChannelOrder,
-    State as IbcChannelState,
+    ChannelEnd as IbcChannelEnd, Counterparty as IbcChannelCounterparty, State as IbcChannelState,
 };
 use ibc::core::client::types::error::ClientError;
 use ibc::core::client::types::Height as CosmosHeight;
@@ -31,7 +30,6 @@ use ibc::core::host::types::identifiers::{ChannelId as IbcChannelId, PortId as I
 
 use crate::types::channel_id::{ChannelEnd as StarknetChannelEnd, ChannelId as StarknetChannelId};
 use crate::types::commitment_proof::StarknetCommitmentProof;
-use crate::types::messages::ibc::channel::ChannelOrdering as StarknetChannelOrdering;
 
 pub struct BuildStarknetToCosmosChannelHandshakeMessage;
 
@@ -67,11 +65,6 @@ where
 
         let starknet_channel_end = counterparty_payload.channel_end;
 
-        let ordering = match starknet_channel_end.ordering {
-            StarknetChannelOrdering::Ordered => IbcChannelOrder::Ordered,
-            StarknetChannelOrdering::Unordered => IbcChannelOrder::Unordered,
-        };
-
         let remote = IbcChannelCounterparty {
             port_id: counterparty_port_id.clone(),
             channel_id: Some(counterparty_channel_id.clone()),
@@ -87,7 +80,7 @@ where
 
         let channel_end = IbcChannelEnd {
             state: IbcChannelState::TryOpen,
-            ordering,
+            ordering: starknet_channel_end.ordering,
             remote,
             connection_hops: vec![connection_id],
             version,

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/channel_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/channel_message.rs
@@ -90,11 +90,7 @@ where
             channel_id: Some(IbcChannelId::new(cosmos_channel_seq)),
         };
 
-        let connection_id = starknet_channel_end
-            .connection_id
-            .connection_id
-            .parse()
-            .map_err(Chain::raise_error)?;
+        let connection_id = starknet_channel_end.connection_id;
 
         let version = starknet_channel_end
             .version

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/channel_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/channel_message.rs
@@ -72,24 +72,19 @@ where
 
         let connection_id = starknet_channel_end.connection_id;
 
-        let version = starknet_channel_end
-            .version
-            .version
-            .parse()
-            .map_err(Chain::raise_error)?;
-
         let channel_end = IbcChannelEnd {
             state: IbcChannelState::TryOpen,
             ordering: starknet_channel_end.ordering,
             remote,
             connection_hops: vec![connection_id],
-            version,
+            version: starknet_channel_end.version.clone(),
         };
 
         let message = CosmosChannelOpenTryMessage {
             port_id: port_id.to_string(),
             channel: channel_end.into(),
-            counterparty_version: starknet_channel_end.version.version,
+            // FIXME: why this needs to be passed here. it's already in the channel_end
+            counterparty_version: starknet_channel_end.version.to_string(),
             update_height,
             proof_init: counterparty_payload.proof_init.proof_bytes,
         };
@@ -131,7 +126,7 @@ where
             port_id: port_id.to_string(),
             channel_id: channel_id.to_string(),
             counterparty_channel_id: counterparty_channel_id.to_string(),
-            counterparty_version: counterparty_payload.channel_end.version.version,
+            counterparty_version: counterparty_payload.channel_end.version.to_string(),
             update_height,
             proof_try,
         };

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/packet_fields.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/packet_fields.rs
@@ -18,9 +18,7 @@ where
     Counterparty: HasChannelIdType<Chain, ChannelId = ChannelId>,
 {
     fn packet_dst_channel_id(packet: &Packet) -> ChannelId {
-        ChannelId {
-            channel_id: packet.chan_id_on_b.to_string(),
-        }
+        packet.chan_id_on_b.clone()
     }
 }
 

--- a/relayer/crates/starknet-chain-components/src/types/channel_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/channel_id.rs
@@ -104,6 +104,7 @@ impl Transformer for EncodeChannelState {
 #[derive(Debug, PartialEq, Clone, HasField)]
 pub struct ChannelCounterparty {
     pub port_id: PortId,
+    // FIXME: this should be optional
     pub channel_id: ChannelId,
 }
 

--- a/relayer/crates/starknet-chain-components/src/types/channel_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/channel_id.rs
@@ -8,7 +8,9 @@ use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
 use hermes_encoding_components::traits::transform::{Transformer, TransformerRef};
 use hermes_wasm_encoding_components::components::{MutDecoderComponent, MutEncoderComponent};
-pub use ibc::core::channel::types::channel::Counterparty as ChannelCounterparty;
+pub use ibc::core::channel::types::channel::{
+    Counterparty as ChannelCounterparty, State as ChannelState,
+};
 pub use ibc::core::host::types::identifiers::ChannelId;
 
 use super::connection_id::ConnectionId;
@@ -43,15 +45,6 @@ where
             .parse()
             .map_err(|_| Encoding::raise_error("invalid channel id"))
     }
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub enum ChannelState {
-    Uninitialized,
-    Init,
-    TryOpen,
-    Open,
-    Closed,
 }
 
 pub struct EncodeChannelState;

--- a/relayer/crates/starknet-chain-components/src/types/channel_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/channel_id.rs
@@ -141,9 +141,11 @@ where
         } else {
             Ok(ChannelCounterparty::new(
                 port_id,
-                Some(channel_id_str.parse().map_err(|_| {
-                    Encoding::raise_error("invalid channel counterparty channel id")
-                })?),
+                Some(
+                    channel_id_str
+                        .parse()
+                        .map_err(|_| Encoding::raise_error("invalid channel counterparty"))?,
+                ),
             ))
         }
     }

--- a/relayer/crates/starknet-chain-components/src/types/channel_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/channel_id.rs
@@ -37,8 +37,8 @@ where
         encoding: &Encoding,
         buffer: &mut Encoding::DecodeBuffer<'a>,
     ) -> Result<ChannelId, Encoding::Error> {
-        let product![connection_id_str] = encoding.decode_mut(buffer)?;
-        connection_id_str
+        let product![value_str] = encoding.decode_mut(buffer)?;
+        value_str
             .parse()
             .map_err(|_| Encoding::raise_error("invalid channel id"))
     }

--- a/relayer/crates/starknet-chain-components/src/types/client_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/client_id.rs
@@ -17,6 +17,7 @@ where
         value: &ClientId,
         buffer: &mut Encoding::EncodeBuffer,
     ) -> Result<(), Encoding::Error> {
+        // FIXME: add `sequence_number` method at `ibc-rs`
         let (client_type, sequence) = value.as_str().rsplit_once('-').expect("valid client id");
         let seq_u64 = sequence.parse::<u64>().expect("valid sequence");
         let client_type_felt = string_to_felt(client_type).expect("valid client type");

--- a/relayer/crates/starknet-chain-components/src/types/client_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/client_id.rs
@@ -1,86 +1,40 @@
-use core::fmt::{Display, Formatter, Result as FmtResult};
-use core::str::FromStr;
-
-use cgp::core::component::UseContext;
 use cgp::prelude::*;
-use hermes_encoding_components::impls::encode_mut::combine::CombineEncoders;
-use hermes_encoding_components::impls::encode_mut::field::EncodeField;
-use hermes_encoding_components::impls::encode_mut::from::DecodeFrom;
-use hermes_encoding_components::traits::transform::Transformer;
-use hermes_wasm_encoding_components::components::{MutDecoderComponent, MutEncoderComponent};
+use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
+use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+pub use ibc::core::host::types::identifiers::ClientId;
 use starknet::core::types::Felt;
 
-#[derive(Debug, PartialEq, Clone, HasField)]
-pub struct ClientId {
-    pub client_type: Felt,
-    pub sequence: u64,
-}
+use super::utils::{felt_to_string, string_to_felt};
 
 pub struct EncodeClientId;
 
-delegate_components! {
-    EncodeClientId {
-        MutEncoderComponent: CombineEncoders<Product![
-            EncodeField<symbol!("client_type"), UseContext>,
-            EncodeField<symbol!("sequence"), UseContext>,
-        ]>,
-        MutDecoderComponent: DecodeFrom<Self, UseContext>,
+impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ClientId> for EncodeClientId
+where
+    Encoding: CanEncodeMut<Strategy, Product![Felt, u64]>,
+{
+    fn encode_mut(
+        encoding: &Encoding,
+        value: &ClientId,
+        buffer: &mut Encoding::EncodeBuffer,
+    ) -> Result<(), Encoding::Error> {
+        let (client_type, sequence) = value.as_str().rsplit_once('-').expect("valid client id");
+        let seq_u64 = sequence.parse::<u64>().expect("valid sequence");
+        let client_type_felt = string_to_felt(client_type).expect("valid client type");
+        encoding.encode_mut(&product![client_type_felt, seq_u64], buffer)?;
+        Ok(())
     }
 }
 
-impl Transformer for EncodeClientId {
-    type From = (Felt, u64);
-    type To = ClientId;
-
-    fn transform((client_type, sequence): Self::From) -> ClientId {
-        ClientId {
-            client_type,
-            sequence,
-        }
-    }
-}
-
-impl Display for ClientId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        let felt_as_be_bytes = self.client_type.to_bytes_be();
-        let felt_as_string = String::from_utf8_lossy(&felt_as_be_bytes);
-        let trimmed_client_type = felt_as_string.trim_start_matches('\0');
-        write!(f, "{}-{}", trimmed_client_type, self.sequence)
-    }
-}
-
-impl FromStr for ClientId {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // TODO: Verify that the parsing from str is correct
-        let values: Vec<&str> = s.split('-').collect();
-        let felt_str = values.first().ok_or_else(|| format!("client ID doesn't have correct format, expecting `<client_type>-<sequence>, got `{s}`"))?;
-        let sequence_str = values.get(1).ok_or_else(|| format!("client ID doesn't have correct format, expecting `<client_type>-<sequence>, got `{s}`"))?;
-        let client_type = Felt::from_str(felt_str)
-            .map_err(|e| format!("failed to parse {felt_str} to Felt. Cause: {e}"))?;
-        let sequence = sequence_str
-            .parse::<u64>()
-            .map_err(|e| format!("failed to parse {felt_str} to Felt. Cause: {e}"))?;
-        Ok(Self {
-            client_type,
-            sequence,
-        })
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use starknet::macros::short_string;
-
-    use super::*;
-
-    #[test]
-    fn test_client_id_display() {
-        let client_id = ClientId {
-            client_type: short_string!("07-tendermint"),
-            sequence: 1,
-        };
-        assert_eq!(client_id.to_string(), "07-tendermint-1");
+impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ClientId> for EncodeClientId
+where
+    Encoding: CanDecodeMut<Strategy, Product![Felt, u64]> + CanRaiseAsyncError<&'static str>,
+{
+    fn decode_mut<'a>(
+        encoding: &Encoding,
+        buffer: &mut Encoding::DecodeBuffer<'a>,
+    ) -> Result<ClientId, Encoding::Error> {
+        let product![client_type_felt, seq_u64] = encoding.decode_mut(buffer)?;
+        ClientId::new(&felt_to_string(client_type_felt), seq_u64)
+            .map_err(|_| Encoding::raise_error("invalid client id"))
     }
 }

--- a/relayer/crates/starknet-chain-components/src/types/connection_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/connection_id.rs
@@ -37,8 +37,8 @@ where
         encoding: &Encoding,
         buffer: &mut Encoding::DecodeBuffer<'a>,
     ) -> Result<ConnectionId, Encoding::Error> {
-        let product![connection_id_str] = encoding.decode_mut(buffer)?;
-        connection_id_str
+        let product![value_str] = encoding.decode_mut(buffer)?;
+        value_str
             .parse()
             .map_err(|_| Encoding::raise_error("invalid connection id"))
     }

--- a/relayer/crates/starknet-chain-components/src/types/connection_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/connection_id.rs
@@ -10,7 +10,9 @@ use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
 use hermes_encoding_components::traits::transform::{Transformer, TransformerRef};
 use hermes_wasm_encoding_components::components::{MutDecoderComponent, MutEncoderComponent};
-pub use ibc::core::connection::types::Counterparty as ConnectionCounterparty;
+pub use ibc::core::connection::types::{
+    Counterparty as ConnectionCounterparty, State as ConnectionState,
+};
 pub use ibc::core::host::types::identifiers::ConnectionId;
 
 use crate::types::client_id::ClientId;
@@ -121,13 +123,6 @@ impl Transformer for EncodeConnectionEnd {
             delay_period,
         }
     }
-}
-
-pub enum ConnectionState {
-    Uninitialized,
-    Init,
-    TryOpen,
-    Open,
 }
 
 pub struct EncodeConnectionState;

--- a/relayer/crates/starknet-chain-components/src/types/connection_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/connection_id.rs
@@ -250,7 +250,7 @@ where
                 Some(
                     connection_id_str
                         .parse()
-                        .map_err(|_| Encoding::raise_error("invalid connection id"))?,
+                        .map_err(|_| Encoding::raise_error("invalid connection counterparty"))?,
                 ),
                 base_prefix,
             ))

--- a/relayer/crates/starknet-chain-components/src/types/connection_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/connection_id.rs
@@ -1,45 +1,46 @@
-use core::fmt::{Display, Formatter};
-
 use cgp::core::component::UseContext;
 use cgp::prelude::*;
 use hermes_cairo_encoding_components::impls::encode_mut::variant_from::EncodeVariantFrom;
 use hermes_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_encoding_components::impls::encode_mut::field::EncodeField;
 use hermes_encoding_components::impls::encode_mut::from::DecodeFrom;
+use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
+use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
 use hermes_encoding_components::traits::transform::{Transformer, TransformerRef};
 use hermes_wasm_encoding_components::components::{MutDecoderComponent, MutEncoderComponent};
+pub use ibc::core::host::types::identifiers::ConnectionId;
 
 use crate::types::client_id::ClientId;
 use crate::types::messages::ibc::connection::{BasePrefix, ConnectionVersion};
 
-#[derive(Debug, PartialEq, Clone, HasField)]
-pub struct ConnectionId {
-    pub connection_id: String,
-}
-
 pub struct EncodeConnectionId;
 
-delegate_components! {
-    EncodeConnectionId {
-        MutEncoderComponent: CombineEncoders<Product![
-            EncodeField<symbol!("connection_id"), UseContext>,
-        ]>,
-        MutDecoderComponent: DecodeFrom<Self, UseContext>,
+impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ConnectionId> for EncodeConnectionId
+where
+    Encoding: CanEncodeMut<Strategy, Product![String]>,
+{
+    fn encode_mut(
+        encoding: &Encoding,
+        value: &ConnectionId,
+        buffer: &mut Encoding::EncodeBuffer,
+    ) -> Result<(), Encoding::Error> {
+        encoding.encode_mut(&product![value.to_string()], buffer)?;
+        Ok(())
     }
 }
 
-impl Transformer for EncodeConnectionId {
-    type From = String;
-    type To = ConnectionId;
-
-    fn transform(connection_id: Self::From) -> ConnectionId {
-        ConnectionId { connection_id }
-    }
-}
-
-impl Display for ConnectionId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        self.connection_id.fmt(f)
+impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ConnectionId> for EncodeConnectionId
+where
+    Encoding: CanDecodeMut<Strategy, Product![String]> + CanRaiseAsyncError<&'static str>,
+{
+    fn decode_mut<'a>(
+        encoding: &Encoding,
+        buffer: &mut Encoding::DecodeBuffer<'a>,
+    ) -> Result<ConnectionId, Encoding::Error> {
+        let product![connection_id_str] = encoding.decode_mut(buffer)?;
+        connection_id_str
+            .parse()
+            .map_err(|_| Encoding::raise_error("invalid connection id"))
     }
 }
 

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/channel.rs
@@ -45,9 +45,7 @@ where
         buffer: &mut Encoding::DecodeBuffer<'a>,
     ) -> Result<PortId, Encoding::Error> {
         let product![value_str] = encoding.decode_mut(buffer)?;
-        value_str
-            .parse()
-            .map_err(|_| Encoding::raise_error("invalid channel id"))
+        PortId::new(value_str).map_err(|_| Encoding::raise_error("invalid port id"))
     }
 }
 pub struct EncodeAppVersion;

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/channel.rs
@@ -12,6 +12,7 @@ use hermes_encoding_components::traits::encode_mut::{
 };
 use hermes_encoding_components::traits::transform::{Transformer, TransformerRef};
 pub use ibc::core::channel::types::channel::Order as ChannelOrdering;
+pub use ibc::core::channel::types::Version as AppVersion;
 pub use ibc::core::host::types::identifiers::PortId;
 
 use super::packet::StateProof;
@@ -49,28 +50,32 @@ where
             .map_err(|_| Encoding::raise_error("invalid channel id"))
     }
 }
-#[derive(HasField, Debug, PartialEq, Clone)]
-pub struct AppVersion {
-    pub version: String,
-}
-
 pub struct EncodeAppVersion;
 
-delegate_components! {
-    EncodeAppVersion {
-        MutEncoderComponent: CombineEncoders<Product![
-            EncodeField<symbol!("version"), UseContext>,
-        ]>,
-        MutDecoderComponent: DecodeFrom<Self, UseContext>,
+impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, AppVersion> for EncodeAppVersion
+where
+    Encoding: CanEncodeMut<Strategy, Product![String]>,
+{
+    fn encode_mut(
+        encoding: &Encoding,
+        value: &AppVersion,
+        buffer: &mut Encoding::EncodeBuffer,
+    ) -> Result<(), Encoding::Error> {
+        encoding.encode_mut(&product![value.to_string()], buffer)?;
+        Ok(())
     }
 }
 
-impl Transformer for EncodeAppVersion {
-    type From = String;
-    type To = AppVersion;
-
-    fn transform(version: Self::From) -> AppVersion {
-        AppVersion { version }
+impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, AppVersion> for EncodeAppVersion
+where
+    Encoding: CanDecodeMut<Strategy, Product![String]> + CanRaiseAsyncError<&'static str>,
+{
+    fn decode_mut<'a>(
+        encoding: &Encoding,
+        buffer: &mut Encoding::DecodeBuffer<'a>,
+    ) -> Result<AppVersion, Encoding::Error> {
+        let product![value_str] = encoding.decode_mut(buffer)?;
+        Ok(AppVersion::new(value_str))
     }
 }
 

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/channel.rs
@@ -11,6 +11,7 @@ use hermes_encoding_components::traits::encode_mut::{
     CanEncodeMut, MutEncoder, MutEncoderComponent,
 };
 use hermes_encoding_components::traits::transform::{Transformer, TransformerRef};
+pub use ibc::core::channel::types::channel::Order as ChannelOrdering;
 pub use ibc::core::host::types::identifiers::PortId;
 
 use super::packet::StateProof;
@@ -73,12 +74,6 @@ impl Transformer for EncodeAppVersion {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum ChannelOrdering {
-    Unordered,
-    Ordered,
-}
-
 pub struct EncodeChannelOrdering;
 
 delegate_components! {
@@ -98,6 +93,7 @@ impl TransformerRef for EncodeChannelOrdering {
         match value {
             ChannelOrdering::Unordered => Either::Left(()),
             ChannelOrdering::Ordered => Either::Right(Either::Left(())),
+            ChannelOrdering::None => unimplemented!("ChannelOrdering::None is not supported"),
         }
     }
 }

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/channel.rs
@@ -4,40 +4,50 @@ use hermes_cairo_encoding_components::impls::encode_mut::variant_from::EncodeVar
 use hermes_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_encoding_components::impls::encode_mut::field::EncodeField;
 use hermes_encoding_components::impls::encode_mut::from::DecodeFrom;
-use hermes_encoding_components::traits::decode_mut::MutDecoderComponent;
-use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
+use hermes_encoding_components::traits::decode_mut::{
+    CanDecodeMut, MutDecoder, MutDecoderComponent,
+};
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 use hermes_encoding_components::traits::transform::{Transformer, TransformerRef};
+pub use ibc::core::host::types::identifiers::PortId;
 
 use super::packet::StateProof;
 use crate::types::channel_id::ChannelId;
 use crate::types::connection_id::ConnectionId;
 use crate::types::cosmos::height::Height;
 
-#[derive(HasField, Debug, PartialEq, Clone)]
-pub struct PortId {
-    pub port_id: String,
-}
-
 pub struct EncodePortId;
 
-delegate_components! {
-    EncodePortId {
-        MutEncoderComponent: CombineEncoders<Product![
-            EncodeField<symbol!("port_id"), UseContext>,
-        ]>,
-        MutDecoderComponent: DecodeFrom<Self, UseContext>,
+impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, PortId> for EncodePortId
+where
+    Encoding: CanEncodeMut<Strategy, Product![String]>,
+{
+    fn encode_mut(
+        encoding: &Encoding,
+        value: &PortId,
+        buffer: &mut Encoding::EncodeBuffer,
+    ) -> Result<(), Encoding::Error> {
+        encoding.encode_mut(&product![value.to_string()], buffer)?;
+        Ok(())
     }
 }
 
-impl Transformer for EncodePortId {
-    type From = String;
-    type To = PortId;
-
-    fn transform(port_id: Self::From) -> PortId {
-        PortId { port_id }
+impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, PortId> for EncodePortId
+where
+    Encoding: CanDecodeMut<Strategy, Product![String]> + CanRaiseAsyncError<&'static str>,
+{
+    fn decode_mut<'a>(
+        encoding: &Encoding,
+        buffer: &mut Encoding::DecodeBuffer<'a>,
+    ) -> Result<PortId, Encoding::Error> {
+        let product![value_str] = encoding.decode_mut(buffer)?;
+        value_str
+            .parse()
+            .map_err(|_| Encoding::raise_error("invalid channel id"))
     }
 }
-
 #[derive(HasField, Debug, PartialEq, Clone)]
 pub struct AppVersion {
     pub version: String,

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/connection.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/connection.rs
@@ -62,7 +62,7 @@ where
     ) -> Result<ConnectionVersion, Encoding::Error> {
         let product![identifier, features] = encoding.decode_mut(buffer)?;
 
-        // FIXME: ibc-rs type doesn't have public fields
+        // FIXME: ibc-rs type doesn't new method
         #[derive(serde::Serialize)]
         struct DummyConnectionVersion {
             pub identifier: String,

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/connection.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/connection.rs
@@ -93,7 +93,7 @@ where
     ) -> Result<(), Encoding::Error> {
         encoding.encode_mut(
             &product![String::from_utf8(value.clone().into_vec())
-                .map_err(|_| Encoding::raise_error("invalid utf8 string"))?],
+                .map_err(|_| Encoding::raise_error("invalid utf8 string for commitment prefix"))?],
             buffer,
         )?;
 

--- a/relayer/crates/starknet-chain-components/src/types/mod.rs
+++ b/relayer/crates/starknet-chain-components/src/types/mod.rs
@@ -15,4 +15,5 @@ pub mod payloads;
 pub mod register;
 pub mod status;
 pub mod tx_response;
+pub mod utils;
 pub mod wallet;

--- a/relayer/crates/starknet-chain-components/src/types/utils.rs
+++ b/relayer/crates/starknet-chain-components/src/types/utils.rs
@@ -1,0 +1,29 @@
+use starknet::core::types::Felt;
+
+pub fn felt_to_string(felt: Felt) -> String {
+    let felt_as_be_bytes = felt.to_bytes_be();
+    let felt_as_string = String::from_utf8_lossy(&felt_as_be_bytes);
+    felt_as_string.trim_start_matches('\0').to_string()
+}
+
+pub fn string_to_felt(value: &str) -> Option<Felt> {
+    (value.len() <= 32).then(|| {
+        let mut buf = [0u8; 32];
+        buf[32 - value.len()..].copy_from_slice(value.as_bytes());
+        Felt::from_bytes_be(&buf)
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use starknet::macros::short_string;
+
+    use super::*;
+
+    #[test]
+    fn test_felt_to_string() {
+        let felt = short_string!("hello world");
+        assert_eq!(felt_to_string(felt), "hello world");
+        assert_eq!(string_to_felt("hello world"), Some(felt));
+    }
+}

--- a/relayer/crates/starknet-chain-context/src/contexts/encoding/cairo.rs
+++ b/relayer/crates/starknet-chain-context/src/contexts/encoding/cairo.rs
@@ -1,5 +1,6 @@
 use core::iter::Peekable;
 use core::slice::Iter;
+use core::time::Duration;
 
 use cgp::core::component::UseDelegate;
 use cgp::core::error::{ErrorRaiserComponent, ErrorTypeComponent};
@@ -148,6 +149,7 @@ pub trait CanUseCairoEncoding:
     + CanEncodeAndDecode<ViaCairo, MsgChanOpenTry>
     + CanEncodeAndDecode<ViaCairo, MsgChanOpenAck>
     + CanEncodeAndDecode<ViaCairo, MsgChanOpenConfirm>
+    + CanEncodeAndDecode<ViaCairo, Duration>
     + CanEncode<ViaCairo, CometUpdateHeader>
     + CanDecode<ViaCairo, CreateClientResponse>
 {

--- a/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
@@ -41,7 +41,6 @@ use hermes_starknet_chain_components::traits::contract::deploy::CanDeployContrac
 use hermes_starknet_chain_components::traits::queries::token_balance::CanQueryTokenBalance;
 use hermes_starknet_chain_components::types::cosmos::height::Height;
 use hermes_starknet_chain_components::types::cosmos::timestamp::Timestamp;
-use hermes_starknet_chain_components::types::messages::ibc::channel::PortId;
 use hermes_starknet_chain_components::types::messages::ibc::denom::{
     Denom, PrefixedDenom, TracePrefix,
 };
@@ -374,12 +373,8 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
         {
             // register the ICS20 contract with the IBC core contract
 
-            let port_id_on_starknet = PortId {
-                port_id: ics20_port.to_string(),
-            };
-
             let register_app = MsgRegisterApp {
-                port_id: port_id_on_starknet.clone(),
+                port_id: ics20_port.clone(),
                 contract_address: ics20_contract_address,
             };
 
@@ -531,9 +526,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
             };
 
             MsgTransfer {
-                port_id_on_a: PortId {
-                    port_id: ics20_port.to_string(),
-                },
+                port_id_on_a: ics20_port.clone(),
                 chan_id_on_a: starknet_channel_id.clone(),
                 denom,
                 amount: transfer_quantity.into(),
@@ -625,9 +618,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
             };
 
             MsgTransfer {
-                port_id_on_a: PortId {
-                    port_id: ics20_port.to_string(),
-                },
+                port_id_on_a: ics20_port.clone(),
                 chan_id_on_a: starknet_channel_id.clone(),
                 denom,
                 amount: transfer_quantity.into(),

--- a/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
@@ -472,7 +472,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
             let ibc_prefixed_denom = PrefixedDenom {
                 trace_path: vec![TracePrefix {
                     port_id: ics20_port.to_string(),
-                    channel_id: starknet_channel_id.channel_id.clone(),
+                    channel_id: starknet_channel_id.to_string(),
                 }],
                 base: Denom::Hosted(denom_cosmos.to_string()),
             };
@@ -525,7 +525,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
             let denom = PrefixedDenom {
                 trace_path: vec![TracePrefix {
                     port_id: ics20_port.to_string(),
-                    channel_id: starknet_channel_id.channel_id.clone(),
+                    channel_id: starknet_channel_id.to_string(),
                 }],
                 base: Denom::Hosted(denom_cosmos.to_string()),
             };

--- a/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
@@ -58,7 +58,7 @@ use hermes_test_components::chain::traits::assert::eventual_amount::CanAssertEve
 use hermes_test_components::chain::traits::queries::balance::CanQueryBalance;
 use hermes_test_components::chain::traits::transfer::ibc_transfer::CanIbcTransferToken;
 use ibc::core::connection::types::version::Version as IbcConnectionVersion;
-use ibc::core::host::types::identifiers::{ConnectionId, PortId as IbcPortId};
+use ibc::core::host::types::identifiers::PortId as IbcPortId;
 use poseidon::Poseidon3Hasher;
 use sha2::{Digest, Sha256};
 use starknet::accounts::{Account, Call, ExecutionEncoding, SingleOwnerAccount};
@@ -398,14 +398,7 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
             info!("register ics20 response: {:?}", response);
         }
 
-        let starknet_connection_id_seq = starknet_connection_id
-            .connection_id
-            .strip_prefix("connection-")
-            .unwrap()
-            .parse::<u64>()?;
-
-        let init_channel_options =
-            CosmosInitChannelOptions::new(ConnectionId::new(starknet_connection_id_seq));
+        let init_channel_options = CosmosInitChannelOptions::new(starknet_connection_id);
 
         let (starknet_channel_id, cosmos_channel_id) = starknet_to_cosmos_relay
             .bootstrap_channel(

--- a/relayer/crates/starknet-integration-tests/src/tests/light_client.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/light_client.rs
@@ -50,22 +50,14 @@ use hermes_test_components::bootstrap::traits::chain::CanBootstrapChain;
 use hermes_test_components::chain_driver::traits::types::chain::HasChain;
 use ibc::core::channel::types::channel::State;
 use ibc::core::client::types::Height;
-use ibc::core::host::types::identifiers::ClientId;
 use ibc_proto::ibc::core::channel::v1::{Channel, Counterparty};
 use sha2::{Digest, Sha256};
 use starknet::accounts::Call;
-use starknet::core::types::Felt;
 use starknet::macros::{selector, short_string};
 use tracing::info;
 
 use crate::contexts::bootstrap::StarknetBootstrap;
 use crate::contexts::osmosis_bootstrap::OsmosisBootstrap;
-
-fn felt_to_trimmed_string(v: &Felt) -> String {
-    String::from_utf8_lossy(&v.to_bytes_be())
-        .trim_start_matches('\0')
-        .to_string()
-}
 
 #[test]
 fn test_starknet_light_client() -> Result<(), Error> {
@@ -365,7 +357,7 @@ fn test_starknet_light_client() -> Result<(), Error> {
         let cosmos_connection_id = {
             let open_init_message = CosmosConnectionOpenInitMessage {
                 client_id: cosmos_client_id.to_string(),
-                counterparty_client_id: ClientId::new(&felt_to_trimmed_string(&starknet_client_id.client_type), starknet_client_id.sequence)?.to_string(),
+                counterparty_client_id: starknet_client_id.to_string(),
                 counterparty_commitment_prefix: "ibc".into(),
                 version: default_connection_version(),
                 delay_period: Duration::from_secs(0),


### PR DESCRIPTION
Use `ConnectionEnd` and `ChannelEnd` from `ibc-rs` and all other dependent types.

I am rexporting `ibc-rs` types as Starknet/Cairo types to avoid too many changes in the imports. So, you see `StarknetChannelId` and `IbcChannelId` (as similar) at some places. These are actually the same types. 

linked to #150