### PR TITLE
feat: implement query methods for unreceived packets and acks

### DIFF
--- a/cairo-contracts/packages/core/src/channel/errors.cairo
+++ b/cairo-contracts/packages/core/src/channel/errors.cairo
@@ -6,6 +6,7 @@ pub mod ChannelErrors {
     pub const EMPTY_ACK: felt252 = 'ICS04: empty acknowledgement';
     pub const EMPTY_UNRECEIVED_PROOF: felt252 = 'ICS04: empty unreceived proof';
     pub const EMPTY_ACK_PROOF: felt252 = 'ICS04: empty ack proof';
+    pub const EMPTY_SEQUENCE_LIST: felt252 = 'ICS04: empty sequence list';
     pub const ZERO_PROOF_HEIGHT: felt252 = 'ICS04: zero proof height';
     pub const UNSUPPORTED_ORDERING: felt252 = 'ICS04: unsupported ordering';
     pub const INVALID_CHANNEL_STATE: felt252 = 'ICS04: invalid channel state';

--- a/cairo-contracts/packages/core/src/channel/interface.cairo
+++ b/cairo-contracts/packages/core/src/channel/interface.cairo
@@ -70,6 +70,12 @@ pub trait IChannelQuery<TContractState> {
     fn is_packet_received(
         self: @TContractState, port_id: PortId, channel_id: ChannelId, sequence: Sequence
     ) -> bool;
+    fn unreceived_packet_sequences(
+        self: @TContractState, port_id: PortId, channel_id: ChannelId, sequences: Array<Sequence>
+    ) -> Array<Sequence>;
+    fn unreceived_ack_sequences(
+        self: @TContractState, port_id: PortId, channel_id: ChannelId, sequences: Array<Sequence>
+    ) -> Array<Sequence>;
     fn next_sequence_send(
         self: @TContractState, port_id: PortId, channel_id: ChannelId
     ) -> Sequence;


### PR DESCRIPTION
Closes: #219

## Description
This PR introduces two new methods, `unreceived_packet_sequences` and `unreceived_ack_sequences` to the `IChannelQuery` interface. These methods filter pending packets based on a provided list of sequences. 

If an empty array of sequences is passed, the methods throw an error. This behavior differs from the typical implementation in Cosmos chains, where passing an empty array would return all unreceived packets. The decision to deviate from this convention is intentional. Otherwise it requires the Cairo contract to maintain and update a list of received commitment and acknowledgment keys (computed from paths using Poseidon hashing), where the size of list only can be up to the 255 elements. This also would necessitate to deal with deletion upon packet processing completion, adding significant on-chain costs. Thus, for each packet, this would involve:

- Computing the storage key based on the IBC path string.
- Iterating through the list of keys to remove the record upon completion.

For these, providing query endpoints that return comprehensive lists of packet commitments and acknowledgments isn't efficient as well. Similarly, for the send packet endpoint, our internal discussions concluded that maintaining such data on-chain would unnecessarily bloat Cairo storage. Plus, implementing a robust on-chain query language would also be burdensome.

Instead, Starknet nodes offer a `get_events` endpoint with adequate filtering options. Leveraging `get_events` should be a more efficient for obtaining a list of packet commitments or acknowledgments when relayers need them.