### PR TITLE
fix(lc/starknet): use `ibc-rs` patch for empty `revision_number` in `ibc-go-wasm-v8`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
 
           rust-1_79 = nixpkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain-1.79.toml;
 
-          wasm-simapp = cosmos-nix.ibc-go-v9-wasm-simapp;
+          wasm-simapp = cosmos-nix.ibc-go-v8-wasm-simapp;
 
           osmosis = cosmos-nix.osmosis;
 

--- a/light-client/Cargo.lock
+++ b/light-client/Cargo.lock
@@ -1092,8 +1092,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e841f00c9cffe4d33e958f52d1c6acb80b54098bae89977f3f9c0646f416dbe"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1106,8 +1105,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75531659e169d3ebb19989db2cd1947ef3fa7edfe72f428019581f01e40292ef"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1116,8 +1114,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae830456d370da1adecb2a403d5bd3cdbefd4b6530617b86a908080d296e2041"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1130,8 +1127,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8fe3f724b57a830833c36449403b7bd3420075ce9bf6b39ed58690724a8e83"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-app-transfer",
 ]
@@ -1196,8 +1192,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b02fb5248a9fdf1b8242792fbd5528f2d51aded7cb1a7a9c016b4e9df49610"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
@@ -1213,8 +1208,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095aeba9bc93be2346151a9bdb616498939ae1dd43eb361be9d2fa04eaf308d"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1230,8 +1224,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bd8f0ed74bbccce9e322bf337a886b028c2db4f4c484a8e245040a9605e5a7"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -1246,8 +1239,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ba4feffe97a8ff8ac465e618a9fa29700fa8c17db13419c05f4282e607a900"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1256,8 +1248,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aebe44c654b28872c5578601d0c1b934f58272ab439603a13d66ac98ba59b3d"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1273,8 +1264,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015c77b37581ee4448ade586ca5a7531e5285577306feb1b268555e964770a5d"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1289,8 +1279,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd8a7707fad74232cc5a306382a2c60a43346ea13bf6acc08b6b5289508b0c8"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1311,8 +1300,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5397f176e100ea3023734d9deb2ae1cc9e19b4561bf1aba2ae38a4d49272c6ad"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1325,8 +1313,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46639dacb4915502a5f22417ed2b5759919ea52b24906d139903d557555ca2c6"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1342,8 +1329,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b656b53813af821488f12af135efe9e1e51727a9588601021af3f6113576b5"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1361,8 +1347,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6287fd1458abd2ba03d8aaad8aa37fdf0d7a678d2dd94a2d0ec587abe689a33c"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1379,8 +1364,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783a2a7719608cd2c3ca6dccd7d8f56f3706c31e45ac261462ba064a0c0b27f4"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -1394,8 +1378,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f851d007b1c269eb849208e080a8790a2a5b37546b3e741d835316a739483492"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1414,8 +1397,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c783b32affbcf3298a656e9ba3fc5c46d53a57c808b21870387925c0c8406f00"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1430,8 +1412,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69ac81e331c0740b0ee47ef9cbbf5f6f5c9cbbe4ca620d156224b653e63ac21"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1453,8 +1434,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48b932c262deb91616535a690f5c9e31182d32f1d8d0cf1caf01b1a7d370277"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1472,8 +1452,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6ce9f8b6f4ace0df28f82d8872bd65eb5fc117e32629c26663ee5e859716bd"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1495,8 +1474,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bbb8e65d5cafa6ab46f202344e34d9727717a1479dd8ad8fde03410ad235cc"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -1511,8 +1489,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f202f536a5acb839743be8b4af646c7a41b10d7f8315c971f8c3479ac12df131"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1526,8 +1503,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e4fe4d5f146a06ba7fe9de72643edb92140297cbe639b457fe6a6863c9763c"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1544,8 +1520,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2bbdb8c5306e4b53545026d6ecbdbf6f9fc5a6459749c60017b99cf895fed4"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1555,8 +1530,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca1c435942806567a4bec4fa6a936f32cc5333e8118d91fb7e001d9d75001c3"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",

--- a/light-client/Cargo.lock
+++ b/light-client/Cargo.lock
@@ -1092,7 +1092,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-app-transfer",
 ]
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1224,7 +1224,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1264,7 +1264,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1279,7 +1279,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1313,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1329,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1364,7 +1364,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -1378,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1397,7 +1397,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1412,7 +1412,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1452,7 +1452,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1503,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1520,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.10.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1530,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -63,6 +63,17 @@ ibc-client-starknet-types = { path = "./ibc-client-starknet-types" }
 
 ibc-client-cw = { git = "https://github.com/informalsystems/cosmwasm-ibc.git", branch = "luca_joss/add-cw-client-extension-trait" }
 
+ibc                         = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core                    = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core-client-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core-host-cosmos        = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-client-tendermint-types = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core-channel-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core-handler-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+
 cgp                     = { git = "https://github.com/contextgeneric/cgp.git" }
 cgp-core                = { git = "https://github.com/contextgeneric/cgp.git" }
 cgp-extra               = { git = "https://github.com/contextgeneric/cgp.git" }

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -63,16 +63,16 @@ ibc-client-starknet-types = { path = "./ibc-client-starknet-types" }
 
 ibc-client-cw = { git = "https://github.com/informalsystems/cosmwasm-ibc.git", branch = "luca_joss/add-cw-client-extension-trait" }
 
-ibc                         = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core                    = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core-client-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core-host-cosmos        = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-client-tendermint-types = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core-channel-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core-handler-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc                         = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core                    = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core-client-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core-host-cosmos        = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-client-tendermint-types = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core-channel-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core-handler-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
 
 cgp                     = { git = "https://github.com/contextgeneric/cgp.git" }
 cgp-core                = { git = "https://github.com/contextgeneric/cgp.git" }

--- a/nix/ibc-starknet-cw.nix
+++ b/nix/ibc-starknet-cw.nix
@@ -13,6 +13,7 @@ let
         "hermes-cosmos-encoding-components-0.1.0" = "sha256-uxXpzxVc89DkAC4VqC/Au3cpBzUbxiSS2KiFKZ+rqdg=";
         "cgp-0.3.1" = "sha256-AOQ+WVQWPlF2ZfYYc5Eq3t7XAljd5P2qExWLYZWNnd8=";
         "ibc-client-cw-0.56.0" = "sha256-EkLxuJfr3vf0busmSZD7DwOS9GfgfhT+sdopi1nNiCs=";
+        "ibc-0.56.0" = "sha256-Lw0rwumJ17J/KLtZNJ7KeWdqNUkHtKghcJSkyr0Qn/s=";
       };
     };
 

--- a/nix/ibc-starknet-cw.nix
+++ b/nix/ibc-starknet-cw.nix
@@ -13,7 +13,7 @@ let
         "hermes-cosmos-encoding-components-0.1.0" = "sha256-uxXpzxVc89DkAC4VqC/Au3cpBzUbxiSS2KiFKZ+rqdg=";
         "cgp-0.3.1" = "sha256-AOQ+WVQWPlF2ZfYYc5Eq3t7XAljd5P2qExWLYZWNnd8=";
         "ibc-client-cw-0.56.0" = "sha256-EkLxuJfr3vf0busmSZD7DwOS9GfgfhT+sdopi1nNiCs=";
-        "ibc-0.56.0" = "sha256-Lw0rwumJ17J/KLtZNJ7KeWdqNUkHtKghcJSkyr0Qn/s=";
+        "ibc-0.56.0" = "sha256-7DPIqu/zs0szjmtJTfXI2eQ0HEkRyvGjArcMZsFWMT4=";
       };
     };
 

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -2989,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -3002,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -3012,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -3043,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3061,7 +3061,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "displaydoc",
@@ -3120,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -3135,7 +3135,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -3144,7 +3144,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3160,7 +3160,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -3175,7 +3175,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -3211,7 +3211,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3227,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3247,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -3280,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3301,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3340,7 +3340,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3358,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3382,7 +3382,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.10.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3442,7 +3442,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
+source = "git+https://github.com/cosmos/ibc-rs?branch=main#230e7a5e6a5f4e22784924b6c36a9044551096ee"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -2989,8 +2989,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e841f00c9cffe4d33e958f52d1c6acb80b54098bae89977f3f9c0646f416dbe"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -3003,8 +3002,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387a3784dcc32d20744ed21a0d986d28e35c9fb81c5a8c4d7b58075872f39b7d"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -3014,8 +3012,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f59d8c245dafa63584c5dede89d2df8bef2aebd2b2be7372f2f3273e1ae9ddf"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -3036,8 +3033,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75531659e169d3ebb19989db2cd1947ef3fa7edfe72f428019581f01e40292ef"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -3047,8 +3043,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae830456d370da1adecb2a403d5bd3cdbefd4b6530617b86a908080d296e2041"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3066,8 +3061,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8fe3f724b57a830833c36449403b7bd3420075ce9bf6b39ed58690724a8e83"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -3091,8 +3085,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b02fb5248a9fdf1b8242792fbd5528f2d51aded7cb1a7a9c016b4e9df49610"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
@@ -3109,8 +3102,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095aeba9bc93be2346151a9bdb616498939ae1dd43eb361be9d2fa04eaf308d"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "displaydoc",
@@ -3128,8 +3120,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bd8f0ed74bbccce9e322bf337a886b028c2db4f4c484a8e245040a9605e5a7"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -3144,8 +3135,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ba4feffe97a8ff8ac465e618a9fa29700fa8c17db13419c05f4282e607a900"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -3154,8 +3144,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aebe44c654b28872c5578601d0c1b934f58272ab439603a13d66ac98ba59b3d"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3171,8 +3160,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015c77b37581ee4448ade586ca5a7531e5285577306feb1b268555e964770a5d"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -3187,8 +3175,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd8a7707fad74232cc5a306382a2c60a43346ea13bf6acc08b6b5289508b0c8"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3211,8 +3198,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5397f176e100ea3023734d9deb2ae1cc9e19b4561bf1aba2ae38a4d49272c6ad"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -3225,8 +3211,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46639dacb4915502a5f22417ed2b5759919ea52b24906d139903d557555ca2c6"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3242,8 +3227,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b656b53813af821488f12af135efe9e1e51727a9588601021af3f6113576b5"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3263,8 +3247,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6287fd1458abd2ba03d8aaad8aa37fdf0d7a678d2dd94a2d0ec587abe689a33c"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3283,8 +3266,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783a2a7719608cd2c3ca6dccd7d8f56f3706c31e45ac261462ba064a0c0b27f4"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -3298,8 +3280,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f851d007b1c269eb849208e080a8790a2a5b37546b3e741d835316a739483492"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3320,8 +3301,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c783b32affbcf3298a656e9ba3fc5c46d53a57c808b21870387925c0c8406f00"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3336,8 +3316,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69ac81e331c0740b0ee47ef9cbbf5f6f5c9cbbe4ca620d156224b653e63ac21"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3361,8 +3340,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48b932c262deb91616535a690f5c9e31182d32f1d8d0cf1caf01b1a7d370277"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3380,8 +3358,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6ce9f8b6f4ace0df28f82d8872bd65eb5fc117e32629c26663ee5e859716bd"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3405,8 +3382,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bbb8e65d5cafa6ab46f202344e34d9727717a1479dd8ad8fde03410ad235cc"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -3423,8 +3399,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f202f536a5acb839743be8b4af646c7a41b10d7f8315c971f8c3479ac12df131"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3438,8 +3413,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e4fe4d5f146a06ba7fe9de72643edb92140297cbe639b457fe6a6863c9763c"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3458,8 +3432,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2bbdb8c5306e4b53545026d6ecbdbf6f9fc5a6459749c60017b99cf895fed4"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3469,8 +3442,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca1c435942806567a4bec4fa6a936f32cc5333e8118d91fb7e001d9d75001c3"
+source = "git+https://github.com/cosmos/ibc-rs?branch=rano/empty-rev-number-in-height#5a0b3f7ead307f7f4ee406f6c3d3bbd9d8875623"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -102,6 +102,17 @@ hermes-starknet-relayer           = { path = "./crates/starknet-relayer" }
 hermes-starknet-cli               = { path = "./crates/starknet-cli" }
 hermes-starknet-integration-tests = { path = "./crates/starknet-integration-tests" }
 
+ibc                         = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core                    = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core-client-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core-host-cosmos        = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-client-tendermint-types = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core-channel-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc-core-handler-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+
 ibc-client-starknet-types = { path = "../light-client/ibc-client-starknet-types" }
 
 poseidon = { path = "./crates/poseidon" }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -102,16 +102,16 @@ hermes-starknet-relayer           = { path = "./crates/starknet-relayer" }
 hermes-starknet-cli               = { path = "./crates/starknet-cli" }
 hermes-starknet-integration-tests = { path = "./crates/starknet-integration-tests" }
 
-ibc                         = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core                    = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core-client-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core-host-cosmos        = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-client-tendermint-types = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core-channel-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
-ibc-core-handler-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "rano/empty-rev-number-in-height" }
+ibc                         = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core                    = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core-client-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core-host-cosmos        = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-client-tendermint       = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-client-tendermint-types = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-client-wasm-types       = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core-client             = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core-channel-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
+ibc-core-handler-types      = { git = "https://github.com/cosmos/ibc-rs", branch = "main" }
 
 ibc-client-starknet-types = { path = "../light-client/ibc-client-starknet-types" }
 


### PR DESCRIPTION
closes #233

patch at ibc-rs: https://github.com/cosmos/ibc-rs/compare/rano/empty-rev-number-in-height