### PR TITLE
Run background relayer in test

### DIFF
--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -1970,7 +1970,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hermes-any-counterparty"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-cosmos-chain-components",
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "hermes-async-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "async-trait",
  "cgp 0.3.1",
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-type-components",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-type-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
 ]
@@ -2029,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "clap",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "clap",
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-type-components",
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-context"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "eyre",
@@ -2133,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-encoding-components",
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-integration-tests"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "eyre",
@@ -2233,7 +2233,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "dirs-next",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hdpath",
@@ -2309,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-wasm-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "eyre",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "hermes-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
 ]
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "hermes-error"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "eyre",
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "hermes-ibc-test-suite"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-logging-components",
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "hermes-logger"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-logging-components",
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "hermes-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
 ]
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "hermes-protobuf-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-encoding-components",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-components",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components-extra"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-type-components",
@@ -2443,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-async-runtime-components",
@@ -2455,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
 ]
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "hermes-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-type-components",
@@ -2657,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "hermes-tokio-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "futures",
@@ -2671,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "hermes-tracing-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-logging-components",
@@ -2683,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-cosmos-chain-components",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-cosmos-encoding-components",
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#61b94d9d043ba40c814807f3a9e95e754258360e"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-type-components",
@@ -4586,7 +4586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -1970,7 +1970,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hermes-any-counterparty"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-cosmos-chain-components",
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "hermes-async-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "async-trait",
  "cgp 0.3.1",
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-type-components",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-type-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
 ]
@@ -2029,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "clap",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "clap",
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-type-components",
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-context"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "eyre",
@@ -2133,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-encoding-components",
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-integration-tests"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "eyre",
@@ -2233,7 +2233,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "dirs-next",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hdpath",
@@ -2309,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-wasm-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "eyre",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "hermes-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
 ]
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "hermes-error"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "eyre",
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "hermes-ibc-test-suite"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-logging-components",
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "hermes-logger"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-logging-components",
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "hermes-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
 ]
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "hermes-protobuf-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-encoding-components",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-components",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components-extra"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-type-components",
@@ -2443,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-async-runtime-components",
@@ -2455,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
 ]
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "hermes-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-type-components",
@@ -2657,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "hermes-tokio-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "futures",
@@ -2671,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "hermes-tracing-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-logging-components",
@@ -2683,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-cosmos-chain-components",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-cosmos-encoding-components",
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8e6266805b2ea057d3b40c0af648b9630a0288ee"
+source = "git+https://github.com/informalsystems/hermes-sdk.git?branch=soares/20250124#82c856afead0cad90970711a284e5358e8ebf795"
 dependencies = [
  "cgp 0.3.1",
  "hermes-chain-type-components",

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -136,33 +136,33 @@ poseidon = { path = "./crates/poseidon" }
 # cgp-run                 = { git = "https://github.com/contextgeneric/cgp.git" }
 # cgp-inner               = { git = "https://github.com/contextgeneric/cgp.git" }
 
-hermes-chain-components              = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-chain-type-components         = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-relayer-components            = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-relayer-components-extra      = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-runtime-components            = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-async-runtime-components      = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-tokio-runtime-components      = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-runtime                       = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-error                         = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-encoding-components           = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-protobuf-encoding-components  = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-logging-components            = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-tracing-logging-components    = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-logger                        = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-test-components               = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-ibc-test-suite                = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-any-counterparty              = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-cosmos-chain-components       = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-cosmos-relayer                = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-cosmos-wasm-relayer           = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-cosmos-test-components        = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-cosmos-encoding-components    = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-cosmos-integration-tests      = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-comet-light-client-components = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-comet-light-client-context    = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-wasm-test-components          = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-wasm-client-components        = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-wasm-encoding-components      = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-cli-components                = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
-hermes-cli                           = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-chain-components              = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-chain-type-components         = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-relayer-components            = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-relayer-components-extra      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-runtime-components            = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-async-runtime-components      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-tokio-runtime-components      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-runtime                       = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-error                         = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-encoding-components           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-protobuf-encoding-components  = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-logging-components            = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-tracing-logging-components    = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-logger                        = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-test-components               = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-ibc-test-suite                = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-any-counterparty              = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-cosmos-chain-components       = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-cosmos-relayer                = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-cosmos-wasm-relayer           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-cosmos-test-components        = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-cosmos-encoding-components    = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-cosmos-integration-tests      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-comet-light-client-components = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-comet-light-client-context    = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-wasm-test-components          = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-wasm-client-components        = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-wasm-encoding-components      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-cli-components                = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-cli                           = { git = "https://github.com/informalsystems/hermes-sdk.git" }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -136,33 +136,33 @@ poseidon = { path = "./crates/poseidon" }
 # cgp-run                 = { git = "https://github.com/contextgeneric/cgp.git" }
 # cgp-inner               = { git = "https://github.com/contextgeneric/cgp.git" }
 
-hermes-chain-components              = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-chain-type-components         = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-relayer-components            = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-relayer-components-extra      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-runtime-components            = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-async-runtime-components      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-tokio-runtime-components      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-runtime                       = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-error                         = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-encoding-components           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-protobuf-encoding-components  = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-logging-components            = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-tracing-logging-components    = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-logger                        = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-test-components               = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-ibc-test-suite                = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-any-counterparty              = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-chain-components       = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-relayer                = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-wasm-relayer           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-test-components        = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-encoding-components    = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cosmos-integration-tests      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-comet-light-client-components = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-comet-light-client-context    = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-wasm-test-components          = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-wasm-client-components        = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-wasm-encoding-components      = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cli-components                = { git = "https://github.com/informalsystems/hermes-sdk.git" }
-hermes-cli                           = { git = "https://github.com/informalsystems/hermes-sdk.git" }
+hermes-chain-components              = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-chain-type-components         = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-relayer-components            = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-relayer-components-extra      = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-runtime-components            = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-async-runtime-components      = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-tokio-runtime-components      = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-runtime                       = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-error                         = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-encoding-components           = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-protobuf-encoding-components  = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-logging-components            = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-tracing-logging-components    = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-logger                        = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-test-components               = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-ibc-test-suite                = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-any-counterparty              = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-cosmos-chain-components       = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-cosmos-relayer                = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-cosmos-wasm-relayer           = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-cosmos-test-components        = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-cosmos-encoding-components    = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-cosmos-integration-tests      = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-comet-light-client-components = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-comet-light-client-context    = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-wasm-test-components          = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-wasm-client-components        = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-wasm-encoding-components      = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-cli-components                = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }
+hermes-cli                           = { git = "https://github.com/informalsystems/hermes-sdk.git", branch = "soares/20250124" }

--- a/relayer/crates/starknet-chain-components/src/components/chain.rs
+++ b/relayer/crates/starknet-chain-components/src/components/chain.rs
@@ -47,6 +47,7 @@ use hermes_test_components::chain::impls::assert::poll_assert_eventual_amount::P
 use hermes_test_components::chain::impls::ibc_transfer::SendIbcTransferMessage;
 pub use hermes_test_components::chain::traits::assert::eventual_amount::EventualAmountAsserterComponent;
 pub use hermes_test_components::chain::traits::assert::poll_assert::PollAssertDurationGetterComponent;
+use hermes_test_components::chain::traits::messages::ibc_transfer::IbcTokenTransferMessageBuilderComponent;
 use hermes_test_components::chain::traits::queries::balance::BalanceQuerierComponent;
 use hermes_test_components::chain::traits::transfer::ibc_transfer::TokenIbcTransferrerComponent;
 use hermes_test_components::chain::traits::transfer::string_memo::ProvideStringMemoType;
@@ -67,6 +68,7 @@ use crate::impls::events::UseStarknetEvents;
 use crate::impls::messages::channel::BuildStarknetChannelHandshakeMessages;
 use crate::impls::messages::connection::BuildStarknetConnectionHandshakeMessages;
 use crate::impls::messages::create_client::BuildCreateCometClientMessage;
+use crate::impls::messages::ibc_transfer::BuildStarknetIbcTransferMessage;
 use crate::impls::messages::packet::BuildStarknetPacketMessages;
 use crate::impls::messages::update_client::BuildUpdateCometClientMessage;
 use crate::impls::packet_fields::ReadPacketSrcStarknetFields;
@@ -399,5 +401,7 @@ cgp_preset! {
             PollAssertEventualAmount,
         PollAssertDurationGetterComponent:
             ProvideDefaultPollAssertDuration,
+        IbcTokenTransferMessageBuilderComponent:
+            BuildStarknetIbcTransferMessage,
     }
 }

--- a/relayer/crates/starknet-chain-components/src/components/chain.rs
+++ b/relayer/crates/starknet-chain-components/src/components/chain.rs
@@ -42,7 +42,11 @@ pub use hermes_relayer_components::transaction::traits::submit_tx::TxSubmitterCo
 pub use hermes_relayer_components::transaction::traits::types::transaction::TransactionTypeComponent;
 pub use hermes_relayer_components::transaction::traits::types::tx_hash::TransactionHashTypeComponent;
 pub use hermes_relayer_components::transaction::traits::types::tx_response::TxResponseTypeComponent;
+use hermes_test_components::chain::impls::assert::default_assert_duration::ProvideDefaultPollAssertDuration;
+use hermes_test_components::chain::impls::assert::poll_assert_eventual_amount::PollAssertEventualAmount;
 use hermes_test_components::chain::impls::ibc_transfer::SendIbcTransferMessage;
+pub use hermes_test_components::chain::traits::assert::eventual_amount::EventualAmountAsserterComponent;
+pub use hermes_test_components::chain::traits::assert::poll_assert::PollAssertDurationGetterComponent;
 use hermes_test_components::chain::traits::queries::balance::BalanceQuerierComponent;
 use hermes_test_components::chain::traits::transfer::ibc_transfer::TokenIbcTransferrerComponent;
 use hermes_test_components::chain::traits::transfer::string_memo::ProvideStringMemoType;
@@ -391,5 +395,9 @@ cgp_preset! {
             QueryPacketIsReceivedOnStarknet,
         CounterpartyChainIdQuerierComponent:
             QueryCosmosChainIdFromStarknetChannelId,
+        EventualAmountAsserterComponent:
+            PollAssertEventualAmount,
+        PollAssertDurationGetterComponent:
+            ProvideDefaultPollAssertDuration,
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
@@ -1,0 +1,37 @@
+use cgp::prelude::HasAsyncErrorType;
+use hermes_chain_components::traits::types::height::HasHeightType;
+use hermes_chain_components::traits::types::ibc::HasIbcChainTypes;
+use hermes_chain_components::traits::types::message::HasMessageType;
+use hermes_chain_components::traits::types::timestamp::HasTimeoutType;
+use hermes_chain_type_components::traits::types::address::HasAddressType;
+use hermes_test_components::chain::traits::messages::ibc_transfer::IbcTokenTransferMessageBuilder;
+use hermes_test_components::chain::traits::types::amount::HasAmountType;
+use hermes_test_components::chain::traits::types::memo::HasMemoType;
+
+pub struct BuildStarknetIbcTransferMessage;
+
+impl<Chain, Counterparty> IbcTokenTransferMessageBuilder<Chain, Counterparty>
+    for BuildStarknetIbcTransferMessage
+where
+    Chain: HasAsyncErrorType
+        + HasAmountType
+        + HasMemoType
+        + HasMessageType
+        + HasHeightType
+        + HasTimeoutType
+        + HasIbcChainTypes<Counterparty>,
+    Counterparty: HasAddressType,
+{
+    async fn build_ibc_token_transfer_message(
+        chain: &Chain,
+        channel_id: &Chain::ChannelId,
+        port_id: &Chain::PortId,
+        recipient_address: &Counterparty::Address,
+        amount: &Chain::Amount,
+        memo: &Chain::Memo,
+        timeout_height: Option<&Chain::Height>,
+        timeout_time: Option<&Chain::Timeout>,
+    ) -> Result<Chain::Message, Chain::Error> {
+        todo!()
+    }
+}

--- a/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
@@ -13,7 +13,6 @@ use ibc::primitives::Timestamp;
 use crate::impls::types::message::StarknetMessage;
 use crate::types::amount::StarknetAmount;
 use crate::types::channel_id::ChannelId;
-use crate::types::messages::ibc::ibc_transfer::{MsgTransfer, TransferPacketData};
 
 pub struct BuildStarknetIbcTransferMessage;
 
@@ -31,39 +30,16 @@ where
     Counterparty: HasAddressType,
 {
     async fn build_ibc_token_transfer_message(
-        chain: &Chain,
-        channel_id: &ChannelId,
-        port_id: &PortId,
-        recipient_address: &Counterparty::Address,
-        amount: &StarknetAmount,
-        memo: &Option<String>,
-        timeout_height: Option<&u64>,
-        timeout_time: Option<&Timestamp>,
+        _chain: &Chain,
+        _channel_id: &ChannelId,
+        _port_id: &PortId,
+        _recipient_address: &Counterparty::Address,
+        _amount: &StarknetAmount,
+        _memo: &Option<String>,
+        _timeout_height: Option<&u64>,
+        _timeout_time: Option<&Timestamp>,
     ) -> Result<Chain::Message, Chain::Error> {
-        // let packet_data =
-        //     TransferPacketData {
-        //         denom,
-        //         amount,
-        //         sender,
-        //         receiver,
-        //         memo,
-        //     };
-
-        // let message =
-        //     MsgTransfer {
-        //         port_id_on_a: port_id.clone(),
-        //         chan_id_on_a: channel_id.clone(),
-        //         packet_data: starknet_ic20_packet_data,
-        //         timeout_height_on_b: Height {
-        //             revision_number: 0,
-        //             revision_height: 0,
-        //         },
-        //         timeout_timestamp_on_b: Timestamp {
-        //             timestamp: u64::try_from(current_starknet_time.unix_timestamp()).unwrap()
-        //                 + 1800,
-        //         },
-        //     };
-
+        // FIXME: Implement the logic to build the token transfer message
         todo!()
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
@@ -1,12 +1,19 @@
 use cgp::prelude::HasAsyncErrorType;
 use hermes_chain_components::traits::types::height::HasHeightType;
-use hermes_chain_components::traits::types::ibc::HasIbcChainTypes;
+use hermes_chain_components::traits::types::ibc::{HasChannelIdType, HasPortIdType};
 use hermes_chain_components::traits::types::message::HasMessageType;
 use hermes_chain_components::traits::types::timestamp::HasTimeoutType;
 use hermes_chain_type_components::traits::types::address::HasAddressType;
 use hermes_test_components::chain::traits::messages::ibc_transfer::IbcTokenTransferMessageBuilder;
 use hermes_test_components::chain::traits::types::amount::HasAmountType;
 use hermes_test_components::chain::traits::types::memo::HasMemoType;
+use ibc::core::host::types::identifiers::PortId;
+use ibc::primitives::Timestamp;
+
+use crate::impls::types::message::StarknetMessage;
+use crate::types::amount::StarknetAmount;
+use crate::types::channel_id::ChannelId;
+use crate::types::messages::ibc::ibc_transfer::{MsgTransfer, TransferPacketData};
 
 pub struct BuildStarknetIbcTransferMessage;
 
@@ -14,24 +21,49 @@ impl<Chain, Counterparty> IbcTokenTransferMessageBuilder<Chain, Counterparty>
     for BuildStarknetIbcTransferMessage
 where
     Chain: HasAsyncErrorType
-        + HasAmountType
-        + HasMemoType
-        + HasMessageType
-        + HasHeightType
-        + HasTimeoutType
-        + HasIbcChainTypes<Counterparty>,
+        + HasAmountType<Amount = StarknetAmount>
+        + HasMemoType<Memo = Option<String>>
+        + HasMessageType<Message = StarknetMessage>
+        + HasHeightType<Height = u64>
+        + HasTimeoutType<Timeout = Timestamp>
+        + HasChannelIdType<Counterparty, ChannelId = ChannelId>
+        + HasPortIdType<Counterparty, PortId = PortId>,
     Counterparty: HasAddressType,
 {
     async fn build_ibc_token_transfer_message(
         chain: &Chain,
-        channel_id: &Chain::ChannelId,
-        port_id: &Chain::PortId,
+        channel_id: &ChannelId,
+        port_id: &PortId,
         recipient_address: &Counterparty::Address,
-        amount: &Chain::Amount,
-        memo: &Chain::Memo,
-        timeout_height: Option<&Chain::Height>,
-        timeout_time: Option<&Chain::Timeout>,
+        amount: &StarknetAmount,
+        memo: &Option<String>,
+        timeout_height: Option<&u64>,
+        timeout_time: Option<&Timestamp>,
     ) -> Result<Chain::Message, Chain::Error> {
+        // let packet_data =
+        //     TransferPacketData {
+        //         denom,
+        //         amount,
+        //         sender,
+        //         receiver,
+        //         memo,
+        //     };
+
+        // let message =
+        //     MsgTransfer {
+        //         port_id_on_a: port_id.clone(),
+        //         chan_id_on_a: channel_id.clone(),
+        //         packet_data: starknet_ic20_packet_data,
+        //         timeout_height_on_b: Height {
+        //             revision_number: 0,
+        //             revision_height: 0,
+        //         },
+        //         timeout_timestamp_on_b: Timestamp {
+        //             timestamp: u64::try_from(current_starknet_time.unix_timestamp()).unwrap()
+        //                 + 1800,
+        //         },
+        //     };
+
         todo!()
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/mod.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/mod.rs
@@ -1,5 +1,6 @@
 pub mod channel;
 pub mod connection;
 pub mod create_client;
+pub mod ibc_transfer;
 pub mod packet;
 pub mod update_client;

--- a/relayer/crates/starknet-chain-components/src/impls/send_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/send_message.rs
@@ -31,7 +31,7 @@ where
         + HasTxResponseType<TxResponse = TxResponse>
         + HasMessageResponseType<MessageResponse = StarknetMessageResponse>
         + CanPollTxResponse
-        + CanExtracMessageResponsesFromTxResponse
+        + CanExtractMessageResponsesFromTxResponse
         + CanRaiseAsyncError<RevertedInvocation>
         + CanRaiseAsyncError<UnexpectedTransactionTraceType>,
 {
@@ -51,7 +51,7 @@ where
     }
 }
 
-pub trait CanExtracMessageResponsesFromTxResponse:
+pub trait CanExtractMessageResponsesFromTxResponse:
     HasTxResponseType + HasMessageResponseType + HasAsyncErrorType
 {
     fn extract_message_responses_from_tx_response(
@@ -59,7 +59,7 @@ pub trait CanExtracMessageResponsesFromTxResponse:
     ) -> Result<Vec<Self::MessageResponse>, Self::Error>;
 }
 
-impl<Chain> CanExtracMessageResponsesFromTxResponse for Chain
+impl<Chain> CanExtractMessageResponsesFromTxResponse for Chain
 where
     Chain: HasTxResponseType<TxResponse = TxResponse>
         + HasMessageResponseType<MessageResponse = StarknetMessageResponse>

--- a/relayer/crates/starknet-chain-components/src/impls/send_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/send_message.rs
@@ -1,6 +1,7 @@
 use core::fmt::Debug;
 
 use cgp::core::error::CanRaiseAsyncError;
+use cgp::prelude::HasAsyncErrorType;
 use hermes_chain_type_components::traits::types::message_response::HasMessageResponseType;
 use hermes_relayer_components::chain::traits::send_message::MessageSender;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
@@ -30,6 +31,7 @@ where
         + HasTxResponseType<TxResponse = TxResponse>
         + HasMessageResponseType<MessageResponse = StarknetMessageResponse>
         + CanPollTxResponse
+        + CanExtracMessageResponsesFromTxResponse
         + CanRaiseAsyncError<RevertedInvocation>
         + CanRaiseAsyncError<UnexpectedTransactionTraceType>,
 {
@@ -45,6 +47,28 @@ where
 
         let tx_response = chain.poll_tx_response(&tx_hash).await?;
 
+        Chain::extract_message_responses_from_tx_response(tx_response)
+    }
+}
+
+pub trait CanExtracMessageResponsesFromTxResponse:
+    HasTxResponseType + HasMessageResponseType + HasAsyncErrorType
+{
+    fn extract_message_responses_from_tx_response(
+        tx_response: Self::TxResponse,
+    ) -> Result<Vec<Self::MessageResponse>, Self::Error>;
+}
+
+impl<Chain> CanExtracMessageResponsesFromTxResponse for Chain
+where
+    Chain: HasTxResponseType<TxResponse = TxResponse>
+        + HasMessageResponseType<MessageResponse = StarknetMessageResponse>
+        + CanRaiseAsyncError<RevertedInvocation>
+        + CanRaiseAsyncError<UnexpectedTransactionTraceType>,
+{
+    fn extract_message_responses_from_tx_response(
+        tx_response: TxResponse,
+    ) -> Result<Vec<StarknetMessageResponse>, Chain::Error> {
         match tx_response.trace {
             TransactionTrace::Invoke(trace) => match trace.execute_invocation {
                 ExecuteInvocation::Success(invocation) => {

--- a/relayer/crates/starknet-chain-context/src/contexts/chain.rs
+++ b/relayer/crates/starknet-chain-context/src/contexts/chain.rs
@@ -166,6 +166,7 @@ use hermes_starknet_chain_components::types::message_response::StarknetMessageRe
 use hermes_starknet_chain_components::types::payloads::client::StarknetCreateClientPayloadOptions;
 use hermes_starknet_test_components::impls::types::wallet::ProvideStarknetWalletType;
 use hermes_test_components::chain::traits::assert::eventual_amount::CanAssertEventualAmount;
+use hermes_test_components::chain::traits::messages::ibc_transfer::CanBuildIbcTokenTransferMessage;
 use hermes_test_components::chain::traits::queries::balance::CanQueryBalance;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use hermes_test_components::chain::traits::types::memo::HasMemoType;
@@ -426,6 +427,7 @@ pub trait CanUseStarknetChain:
     + HasPacketDstChannelId<CosmosChain>
     + HasPacketDstPortId<CosmosChain>
     + CanAssertEventualAmount
+    + CanBuildIbcTokenTransferMessage<CosmosChain>
 // TODO(rano): need this to <Starknet as CanIbcTransferToken<CosmosChain>>::ibc_transfer_token
 // + CanIbcTransferToken<CosmosChain>
 {

--- a/relayer/crates/starknet-chain-context/src/contexts/chain.rs
+++ b/relayer/crates/starknet-chain-context/src/contexts/chain.rs
@@ -165,6 +165,7 @@ use hermes_starknet_chain_components::types::events::packet::WriteAcknowledgemen
 use hermes_starknet_chain_components::types::message_response::StarknetMessageResponse;
 use hermes_starknet_chain_components::types::payloads::client::StarknetCreateClientPayloadOptions;
 use hermes_starknet_test_components::impls::types::wallet::ProvideStarknetWalletType;
+use hermes_test_components::chain::traits::assert::eventual_amount::CanAssertEventualAmount;
 use hermes_test_components::chain::traits::queries::balance::CanQueryBalance;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use hermes_test_components::chain::traits::types::memo::HasMemoType;
@@ -424,6 +425,7 @@ pub trait CanUseStarknetChain:
     + CanQueryCounterpartyChainId<CosmosChain>
     + HasPacketDstChannelId<CosmosChain>
     + HasPacketDstPortId<CosmosChain>
+    + CanAssertEventualAmount
 // TODO(rano): need this to <Starknet as CanIbcTransferToken<CosmosChain>>::ibc_transfer_token
 // + CanIbcTransferToken<CosmosChain>
 {

--- a/relayer/crates/starknet-chain-context/src/impls/error.rs
+++ b/relayer/crates/starknet-chain-context/src/impls/error.rs
@@ -11,6 +11,7 @@ use hermes_cairo_encoding_components::impls::encode_mut::bool::DecodeBoolError;
 use hermes_cairo_encoding_components::impls::encode_mut::end::NonEmptyBuffer;
 use hermes_cairo_encoding_components::impls::encode_mut::felt::UnexpectedEndOfBuffer;
 use hermes_cairo_encoding_components::impls::encode_mut::variant::VariantIndexOutOfBound;
+use hermes_chain_type_components::traits::types::address::HasAddressType;
 use hermes_chain_type_components::traits::types::height::HasHeightType;
 use hermes_error::handlers::debug::DebugError;
 use hermes_error::handlers::display::DisplayError;
@@ -38,6 +39,8 @@ use hermes_starknet_chain_components::impls::queries::consensus_state::Consensus
 use hermes_starknet_chain_components::impls::queries::contract_address::ContractAddressNotFound;
 use hermes_starknet_chain_components::impls::send_message::UnexpectedTransactionTraceType;
 use hermes_starknet_chain_components::types::event::UnknownEvent;
+use hermes_test_components::chain::impls::assert::poll_assert_eventual_amount::EventualAmountTimeoutError;
+use hermes_test_components::chain::traits::types::amount::HasAmountType;
 use ibc::core::channel::types::error::ChannelError;
 use ibc::core::client::types::error::ClientError;
 use ibc::core::host::types::error::{DecodingError, IdentifierError};
@@ -98,6 +101,7 @@ delegate_components! {
             EmptyMessageResponse,
             ConsensusStateNotFound,
             <'a> UnknownEvent<'a>,
+            <'a, Chain: HasAddressType + HasAmountType> EventualAmountTimeoutError<'a, Chain>,
             <'a, Chain: HasTransactionHashType> TxNoResponseError<'a, Chain>,
             <'a, Chain: HasClientIdType<Counterparty>, Counterparty: HasHeightType>
                 NoConsensusStateAtLessThanHeight<'a, Chain, Counterparty>,


### PR DESCRIPTION
This PR modifies the ICS20 test to run with a background relayer that relay packets through event subscription. We also modify the test to use a separate user wallet on Starknet to perform token transfer, to avoid nonce conflict when the relayer relays the packet.

A stubbed implementation of `IbcTokenTransferMessageBuilder` is added, but we cannot implement it yet, due to some mismatch in the transfer API offered by the ICS20 Cairo contract.