### PR TITLE
fix: use correct port and channel IDs during channel end retrieval in `ack_packet`

### DIFF
--- a/cairo-contracts/packages/apps/src/tests/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/tests/transfer.cairo
@@ -121,7 +121,7 @@ fn test_unescrow_ok() {
 
     let prefixed_denom = cfg.prefix_native_denom();
 
-    let recv_packet = cfg.dummy_packet(prefixed_denom.clone(), COSMOS(), STARKNET());
+    let recv_packet = cfg.dummy_incoming_packet(prefixed_denom.clone(), COSMOS(), STARKNET());
 
     // Submit a `RecvPacket` to the `TransferApp` contract.
     ics20.on_recv_packet(recv_packet);
@@ -139,7 +139,7 @@ fn test_unescrow_ok() {
 fn test_mint_ok() {
     let (ics20, _, cfg, mut spy) = setup();
 
-    let recv_packet = cfg.dummy_packet(cfg.hosted_denom.clone(), COSMOS(), STARKNET());
+    let recv_packet = cfg.dummy_incoming_packet(cfg.hosted_denom.clone(), COSMOS(), STARKNET());
 
     // Submit a `RecvPacket`, which will create a new ERC20 contract.
     ics20.on_recv_packet(recv_packet.clone());
@@ -181,7 +181,7 @@ fn test_mint_ok() {
 fn test_burn_ok() {
     let (ics20, _, cfg, mut spy) = setup();
 
-    let recv_packet = cfg.dummy_packet(cfg.hosted_denom.clone(), COSMOS(), STARKNET());
+    let recv_packet = cfg.dummy_incoming_packet(cfg.hosted_denom.clone(), COSMOS(), STARKNET());
 
     // Submit a `RecvPacket`, which will create a new ERC20 contract.
     ics20.on_recv_packet(recv_packet);

--- a/cairo-contracts/packages/contracts/src/tests/channel.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/channel.cairo
@@ -155,7 +155,7 @@ fn test_send_packet_ok() {
     // -----------------------------------------------------------
 
     let mut packet = transfer_cfg
-        .dummy_packet(transfer_cfg.native_denom.clone(), STARKNET(), COSMOS());
+        .dummy_outgoing_packet(transfer_cfg.native_denom.clone(), STARKNET(), COSMOS());
 
     core.send_packet(packet.clone());
 
@@ -233,7 +233,7 @@ fn test_recv_packet_ok() {
 
     // Retrieve the packet receipt.
     let receipt = core
-        .packet_receipt(msg.packet.port_id_on_b, msg.packet.chan_id_on_b, msg.packet.seq_on_a,);
+        .packet_receipt(msg.packet.port_id_on_b, msg.packet.chan_id_on_b, msg.packet.seq_on_a);
 
     // Assert the packet receipt is true.
     assert!(receipt);

--- a/cairo-contracts/packages/core/src/channel/components/handler.cairo
+++ b/cairo-contracts/packages/core/src/channel/components/handler.cairo
@@ -119,7 +119,7 @@ pub mod ChannelHandlerComponent {
         fn ack_packet(ref self: ComponentState<TContractState>, msg: MsgAckPacket) {
             self.assert_authorized_relayer();
             let chan_end_on_a = self
-                .read_channel_end(@msg.packet.port_id_on_a, @msg.packet.chan_id_on_b);
+                .read_channel_end(@msg.packet.port_id_on_a, @msg.packet.chan_id_on_a);
             self.ack_packet_validate(msg.clone(), chan_end_on_a.clone());
             self.ack_packet_execute(msg, chan_end_on_a);
         }
@@ -754,7 +754,7 @@ pub mod ChannelHandlerComponent {
 
             let packet = @msg.packet;
 
-            chan_end_on_a.validate(packet.port_id_on_a, packet.chan_id_on_a);
+            chan_end_on_a.validate(packet.port_id_on_b, packet.chan_id_on_b);
 
             let conn_end_on_a = self.get_connection(chan_end_on_a.connection_id.clone());
 

--- a/cairo-contracts/packages/testkit/src/configs/core.cairo
+++ b/cairo-contracts/packages/testkit/src/configs/core.cairo
@@ -26,13 +26,11 @@ pub impl CoreConfigImpl of CoreConfigTrait {
             conn_sequence_on_a: 0,
             conn_sequence_on_b: 0,
             chan_sequence_on_a: 0,
-            chan_sequence_on_b: 0,
+            // This represents channel sequence of counterparty chains. It's set to sufficiently
+            // high value to prevent low values (especially 0 or 1) hiding ID misuse cases.
+            chan_sequence_on_b: 10,
             channel_ordering: ChannelOrdering::Unordered
         }
-    }
-
-    fn set_chan_sequence_on_b(ref self: CoreConfig, sequence: u64) {
-        self.chan_sequence_on_b = sequence;
     }
 
     fn dummy_msg_conn_open_init(self: @CoreConfig) -> MsgConnOpenInit {
@@ -91,7 +89,9 @@ pub impl CoreConfigImpl of CoreConfigTrait {
             port_id_on_b: PORT_ID(),
             conn_id_on_b: CONNECTION_ID(0),
             port_id_on_a: PORT_ID(),
-            chan_id_on_a: CHANNEL_ID(*self.chan_sequence_on_b),
+            chan_id_on_a: CHANNEL_ID(
+                *self.chan_sequence_on_a
+            ), // Set to `*_on_a` since dummy messages are meant to be submitted to Starknet (source chain).
             version_on_a: VERSION(),
             proof_chan_end_on_a: STATE_PROOF(),
             proof_height_on_a: HEIGHT(10),
@@ -113,7 +113,9 @@ pub impl CoreConfigImpl of CoreConfigTrait {
     fn dummy_msg_chan_open_confirm(self: @CoreConfig) -> MsgChanOpenConfirm {
         MsgChanOpenConfirm {
             port_id_on_b: PORT_ID(),
-            chan_id_on_b: CHANNEL_ID(*self.chan_sequence_on_b),
+            chan_id_on_b: CHANNEL_ID(
+                *self.chan_sequence_on_a
+            ), // Set to `*_on_a` since dummy messages are meant to be submitted to Starknet (source chain).
             proof_chan_end_on_a: STATE_PROOF(),
             proof_height_on_a: HEIGHT(10),
         }


### PR DESCRIPTION
Closes: #270