### PR TITLE
build(cairo): update scarb to 2.9.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ ICS20_CONTRACT_SRC=${CONTRACT_SRC:-$(pwd)/cairo-contracts/target/dev/starknet_ib
 RPC_URL=https://starknet-sepolia.public.blastapi.io/rpc/v0_7
 ACCOUNT_SRC="${HOME}/.starkli-wallets/deployer/account.json"
 KEYSTORE_SRC="${HOME}/.starkli-wallets/deployer/keystore.json"
-COMPILER_VERSION=2.7.1
+COMPILER_VERSION=2.9.1
 KEYSTORE_PASS=<KEYSTORE_PASSWORD>
 
 ERC20_CLASS_HASH=""

--- a/.github/workflows/cairo.yaml
+++ b/.github/workflows/cairo.yaml
@@ -9,8 +9,8 @@ on:
       - main
 
 jobs:
-  test-cairo:
-    name: Test Cairo libs and contracts
+  test-cairo-libs:
+    name: Test Cairo libraries
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -20,40 +20,59 @@ jobs:
         with:
           toolchain: nightly
 
-      - name: Extract Scarb version
-        working-directory: ./cairo-contracts
-        run: |
-          SCARB_VERSION=$(grep 'scarb-version' Scarb.toml | sed 's/.*= "\(.*\)"/\1/')
-          echo "SCARB_VERSION=$SCARB_VERSION" >> "$GITHUB_ENV"
-
       - name: Install Scarb
         uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: ${{ env.SCARB_VERSION }}
+          tool-versions: cairo-libs/.tool-versions
+          scarb-lock: cairo-libs/Scarb.lock
 
       - name: Install Universal Sierra Compiler
         uses: software-mansion/setup-universal-sierra-compiler@v1
-
-      - name: Extract foundry version
-        working-directory: ./cairo-contracts
-        run: |
-          FOUNDRY_VERSION=$(grep 'snforge_std' Scarb.toml | sed 's/.*= "\(.*\)"/\1/')
-          echo "FOUNDRY_VERSION=$FOUNDRY_VERSION" >> "$GITHUB_ENV"
+        with:
+          tool-versions: cairo-libs/.tool-versions
 
       - name: Install Starknet Foundry
         uses: foundry-rs/setup-snfoundry@v3
         with:
-          starknet-foundry-version: ${{ env.FOUNDRY_VERSION }}
+          tool-versions: cairo-libs/.tool-versions
+
+      - name: Build and Test Cairo libraries
+        working-directory: ./cairo-libs
+        run: |
+          scarb build -w
+          scarb test -w
+
+  test-cairo-contracts:
+    needs: test-cairo-libs
+    name: Test Cairo contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust nightly toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+
+      - name: Install Scarb
+        uses: software-mansion/setup-scarb@v1
+        with:
+          tool-versions: cairo-contracts/.tool-versions
+          scarb-lock: cairo-contracts/Scarb.lock
+
+      - name: Install Universal Sierra Compiler
+        uses: software-mansion/setup-universal-sierra-compiler@v1
+        with:
+          tool-versions: cairo-contracts/.tool-versions
+
+      - name: Install Starknet Foundry
+        uses: foundry-rs/setup-snfoundry@v3
+        with:
+          tool-versions: cairo-contracts/.tool-versions
 
       - name: Build and Test Cairo contracts
         working-directory: ./cairo-contracts
         run: |
           scarb build
           scarb build -p starknet_ibc_contracts
-          scarb test -w
-
-      - name: Build and Test Cairo libraries
-        working-directory: ./cairo-libs
-        run: |
-          scarb build -w
           scarb test -w

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -40,7 +40,6 @@ jobs:
         run: |
           nix build \
             .#starknet-devnet \
-            .#cairo \
             .#scarb \
             .#universal-sierra-compiler \
             .#rust \

--- a/cairo-contracts/.tool-versions
+++ b/cairo-contracts/.tool-versions
@@ -1,3 +1,3 @@
 scarb 2.9.2
-starknet-foundry 0.31.0
+starknet-foundry 0.37.0
 universal-sierra-compiler 2.3.0

--- a/cairo-contracts/.tool-versions
+++ b/cairo-contracts/.tool-versions
@@ -1,3 +1,3 @@
-scarb 2.8.4
+scarb 2.9.2
 starknet-foundry 0.31.0
 universal-sierra-compiler 2.3.0

--- a/cairo-contracts/.tool-versions
+++ b/cairo-contracts/.tool-versions
@@ -1,3 +1,3 @@
 scarb 2.9.2
-starknet-foundry 0.37.0
+starknet-foundry 0.34.0
 universal-sierra-compiler 2.3.0

--- a/cairo-contracts/README.md
+++ b/cairo-contracts/README.md
@@ -31,7 +31,7 @@ directory that includes:
 
 ## How to build
 
-Install `scarb v2.8.4` with the instruction provided in the [Scarb
+Install `scarb v2.9.2` with the instruction provided in the [Scarb
 Documentation](https://docs.swmansion.com/scarb/download.html). Then, to build
 the contracts, you simply need to run the following command:
 

--- a/cairo-contracts/Scarb.lock
+++ b/cairo-contracts/Scarb.lock
@@ -4,7 +4,7 @@ version = 1
 [[package]]
 name = "alexandria_bytes"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=162bed1#162bed1c636d31ccaaa90ed3eb32c9eb1d5e3bd3"
 dependencies = [
  "alexandria_data_structures",
  "alexandria_math",
@@ -13,7 +13,7 @@ dependencies = [
 [[package]]
 name = "alexandria_data_structures"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=162bed1#162bed1c636d31ccaaa90ed3eb32c9eb1d5e3bd3"
 dependencies = [
  "alexandria_encoding",
 ]
@@ -21,9 +21,10 @@ dependencies = [
 [[package]]
 name = "alexandria_encoding"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=162bed1#162bed1c636d31ccaaa90ed3eb32c9eb1d5e3bd3"
 dependencies = [
  "alexandria_bytes",
+ "alexandria_data_structures",
  "alexandria_math",
  "alexandria_numeric",
 ]
@@ -31,12 +32,12 @@ dependencies = [
 [[package]]
 name = "alexandria_math"
 version = "0.2.1"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=162bed1#162bed1c636d31ccaaa90ed3eb32c9eb1d5e3bd3"
 
 [[package]]
 name = "alexandria_numeric"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=162bed1#162bed1c636d31ccaaa90ed3eb32c9eb1d5e3bd3"
 dependencies = [
  "alexandria_math",
  "alexandria_searching",
@@ -45,7 +46,7 @@ dependencies = [
 [[package]]
 name = "alexandria_searching"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=162bed1#162bed1c636d31ccaaa90ed3eb32c9eb1d5e3bd3"
 dependencies = [
  "alexandria_data_structures",
 ]
@@ -53,7 +54,7 @@ dependencies = [
 [[package]]
 name = "alexandria_sorting"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=95d98a5#95d98a5182001d07673b856a356eff0e6bd05354"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=162bed1#162bed1c636d31ccaaa90ed3eb32c9eb1d5e3bd3"
 dependencies = [
  "alexandria_data_structures",
 ]

--- a/cairo-contracts/Scarb.lock
+++ b/cairo-contracts/Scarb.lock
@@ -116,13 +116,13 @@ version = "0.1.0"
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.31.0"
+version = "0.37.0"
 source = "registry+https://scarbs.xyz/"
 checksum = "sha256:1fce075fcbf7fce1b0935f6f9a034549704837fb221da212d3b6e9134cebfdaa"
 
 [[package]]
 name = "snforge_std"
-version = "0.31.0"
+version = "0.37.0"
 source = "registry+https://scarbs.xyz/"
 checksum = "sha256:60ac980b297281f9a59a5f1668cb56bdea1b28fd2f8008008270f9a3c91ad3ba"
 dependencies = [

--- a/cairo-contracts/Scarb.lock
+++ b/cairo-contracts/Scarb.lock
@@ -146,9 +146,11 @@ name = "starknet_ibc_apps"
 version = "0.1.0"
 dependencies = [
  "openzeppelin_access",
+ "openzeppelin_testing",
  "openzeppelin_token",
  "openzeppelin_utils",
  "serde_json",
+ "snforge_std",
  "starknet_ibc_contracts",
  "starknet_ibc_core",
  "starknet_ibc_testkit",
@@ -159,9 +161,13 @@ dependencies = [
 name = "starknet_ibc_clients"
 version = "0.1.0"
 dependencies = [
+ "alexandria_data_structures",
  "alexandria_sorting",
+ "openzeppelin_access",
+ "snforge_std",
  "starknet_ibc_core",
  "starknet_ibc_testkit",
+ "starknet_ibc_utils",
 ]
 
 [[package]]
@@ -183,6 +189,7 @@ dependencies = [
 name = "starknet_ibc_core"
 version = "0.1.0"
 dependencies = [
+ "alexandria_data_structures",
  "alexandria_numeric",
  "openzeppelin_testing",
  "serde_json",
@@ -197,7 +204,9 @@ version = "0.1.0"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_testing",
+ "openzeppelin_token",
  "openzeppelin_utils",
+ "serde_json",
  "snforge_std",
  "starknet_ibc_apps",
  "starknet_ibc_clients",

--- a/cairo-contracts/Scarb.lock
+++ b/cairo-contracts/Scarb.lock
@@ -60,19 +60,18 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_access"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:424314072ae27d5b6f4264472a5c403711448ea62763a661b89e6ff5f23297fd"
+checksum = "sha256:7734901a0ca7a7065e69416fea615dd1dc586c8dc9e76c032f25ee62e8b2a06c"
 dependencies = [
  "openzeppelin_introspection",
- "openzeppelin_utils",
 ]
 
 [[package]]
 name = "openzeppelin_account"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:83e6571cac4c67049c8d0ab4e3c7ad146d582d7605e7354248835833e1d26c4a"
+checksum = "sha256:1aa3a71e2f40f66f98d96aa9bf9f361f53db0fd20fa83ef7df04426a3c3a926a"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -80,25 +79,26 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_introspection"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:46c4cc6c95c9baa4c7d5cc0ed2bdaf334f46c25a8c92b3012829fff936e3042b"
+checksum = "sha256:13e04a2190684e6804229a77a6c56de7d033db8b9ef519e5e8dee400a70d8a3d"
 
 [[package]]
 name = "openzeppelin_testing"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:87a8f984f68870e0039fa678112a22ec67db263e53b5faa23775f495b14455d1"
+checksum = "sha256:2fa9aaadacffd6a95754781ed18f6ee660f52a30d27b024efcde2b4b5648e0b3"
 dependencies = [
  "snforge_std",
 ]
 
 [[package]]
 name = "openzeppelin_token"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:eafbe13f6a0487ce212459e25a81ae07f340ba76208ad4616626eb2d25a9625e"
+checksum = "sha256:4452f449dc6c1ea97cf69d1d9182749abd40e85bd826cd79652c06a627eafd91"
 dependencies = [
+ "openzeppelin_access",
  "openzeppelin_account",
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_utils"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:725b212839f3eddc32791408609099c5e808c167ca0cf331d8c1d778b07a4e21"
+checksum = "sha256:44f32d242af1e43982decc49c563e613a9b67ade552f5c3d5cde504e92f74607"
 
 [[package]]
 name = "serde_json"
@@ -116,15 +116,15 @@ version = "0.1.0"
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.37.0"
+version = "0.34.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:1fce075fcbf7fce1b0935f6f9a034549704837fb221da212d3b6e9134cebfdaa"
+checksum = "sha256:56f2b06ff2f0d8bbdfb7fb6c211fba7e4da6e5334ea70ba849af329a739faf11"
 
 [[package]]
 name = "snforge_std"
-version = "0.37.0"
+version = "0.34.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:60ac980b297281f9a59a5f1668cb56bdea1b28fd2f8008008270f9a3c91ad3ba"
+checksum = "sha256:bd20964bde07e6fd0f7adb50d41216f05d66abd422ed82241030369333385876"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/cairo-contracts/Scarb.toml
+++ b/cairo-contracts/Scarb.toml
@@ -25,8 +25,8 @@ test = "snforge test"
 
 [workspace.dependencies]
 # external dependencies
-alexandria_numeric   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
-alexandria_sorting   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
+alexandria_numeric   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "162bed1" }
+alexandria_sorting   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "162bed1" }
 assert_macros        = "2.9.2"
 starknet             = "2.9.2"
 openzeppelin_access  = "0.20.0"

--- a/cairo-contracts/Scarb.toml
+++ b/cairo-contracts/Scarb.toml
@@ -11,8 +11,8 @@ members = [
 [workspace.package]
 version       = "0.1.0"
 edition       = "2024_07"
-cairo-version = "2.8.4"
-scarb-version = "2.8.4"
+cairo-version = "2.9.2"
+scarb-version = "2.9.2"
 license       = "Apache-2.0"
 authors       = [ "Informal Systems <hello@informal.systems>" ]
 repository    = "https://github.com/informalsystems/ibc-starknet"
@@ -27,8 +27,8 @@ test = "snforge test"
 # external dependencies
 alexandria_numeric   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
 alexandria_sorting   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
-assert_macros        = "2.8.4"
-starknet             = "2.8.4"
+assert_macros        = "2.9.2"
+starknet             = "2.9.2"
 openzeppelin_access  = "0.18.0"
 openzeppelin_token   = "0.18.0"
 openzeppelin_testing = "0.18.0"

--- a/cairo-contracts/Scarb.toml
+++ b/cairo-contracts/Scarb.toml
@@ -25,15 +25,16 @@ test = "snforge test"
 
 [workspace.dependencies]
 # external dependencies
-alexandria_numeric   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "162bed1" }
-alexandria_sorting   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "162bed1" }
-assert_macros        = "2.9.2"
-starknet             = "2.9.2"
-openzeppelin_access  = "0.20.0"
-openzeppelin_token   = "0.20.0"
-openzeppelin_testing = "0.20.0"
-openzeppelin_utils   = "0.20.0"
-snforge_std          = "0.34.0"
+alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "162bed1" }
+alexandria_numeric         = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "162bed1" }
+alexandria_sorting         = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "162bed1" }
+assert_macros              = "2.9.2"
+starknet                   = "2.9.2"
+openzeppelin_access        = "0.20.0"
+openzeppelin_token         = "0.20.0"
+openzeppelin_testing       = "0.20.0"
+openzeppelin_utils         = "0.20.0"
+snforge_std                = "0.34.0"
 
 # internal dependencies
 serde_json = { path = "../cairo-libs/packages/serde_json" }

--- a/cairo-contracts/Scarb.toml
+++ b/cairo-contracts/Scarb.toml
@@ -33,7 +33,7 @@ openzeppelin_access  = "0.18.0"
 openzeppelin_token   = "0.18.0"
 openzeppelin_testing = "0.18.0"
 openzeppelin_utils   = "0.18.0"
-snforge_std          = "0.31.0"
+snforge_std          = "0.37.0"
 
 # internal dependencies
 serde_json = { path = "../cairo-libs/packages/serde_json" }

--- a/cairo-contracts/Scarb.toml
+++ b/cairo-contracts/Scarb.toml
@@ -33,7 +33,7 @@ openzeppelin_access  = "0.20.0"
 openzeppelin_token   = "0.20.0"
 openzeppelin_testing = "0.20.0"
 openzeppelin_utils   = "0.20.0"
-snforge_std          = "0.37.0"
+snforge_std          = "0.34.0"
 
 # internal dependencies
 serde_json = { path = "../cairo-libs/packages/serde_json" }

--- a/cairo-contracts/Scarb.toml
+++ b/cairo-contracts/Scarb.toml
@@ -29,10 +29,10 @@ alexandria_numeric   = { git = "https://github.com/keep-starknet-strange/alexand
 alexandria_sorting   = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "95d98a5" }
 assert_macros        = "2.9.2"
 starknet             = "2.9.2"
-openzeppelin_access  = "0.18.0"
-openzeppelin_token   = "0.18.0"
-openzeppelin_testing = "0.18.0"
-openzeppelin_utils   = "0.18.0"
+openzeppelin_access  = "0.20.0"
+openzeppelin_token   = "0.20.0"
+openzeppelin_testing = "0.20.0"
+openzeppelin_utils   = "0.20.0"
 snforge_std          = "0.37.0"
 
 # internal dependencies

--- a/cairo-contracts/packages/apps/Scarb.toml
+++ b/cairo-contracts/packages/apps/Scarb.toml
@@ -24,10 +24,12 @@ fmt = { workspace = true }
 
 [dependencies]
 # external dependencies
-openzeppelin_access = { workspace = true }
-openzeppelin_token  = { workspace = true }
-openzeppelin_utils  = { workspace = true }
-starknet            = { workspace = true }
+openzeppelin_access  = { workspace = true }
+openzeppelin_token   = { workspace = true }
+openzeppelin_utils   = { workspace = true }
+openzeppelin_testing = { workspace = true }
+starknet             = { workspace = true }
+snforge_std          = { workspace = true }
 
 # internal dependencies
 serde_json = { workspace = true }

--- a/cairo-contracts/packages/clients/Scarb.toml
+++ b/cairo-contracts/packages/clients/Scarb.toml
@@ -23,13 +23,17 @@ test = { workspace = true }
 fmt = { workspace = true }
 
 [dependencies]
-alexandria_sorting = { workspace = true }
+alexandria_data_structures = { workspace = true }
+alexandria_sorting         = { workspace = true }
+openzeppelin_access        = { workspace = true }
+snforge_std                = { workspace = true }
 
 # external dependencies
 starknet = { workspace = true }
 
 # ibc dependencies
-starknet_ibc_core = { workspace = true }
+starknet_ibc_core  = { workspace = true }
+starknet_ibc_utils = { workspace = true }
 
 [dev-dependencies]
 starknet_ibc_testkit = { workspace = true }

--- a/cairo-contracts/packages/core/Scarb.toml
+++ b/cairo-contracts/packages/core/Scarb.toml
@@ -24,8 +24,9 @@ fmt = { workspace = true }
 
 [dependencies]
 # external dependencies
-alexandria_numeric = { workspace = true }
-starknet           = { workspace = true }
+alexandria_data_structures = { workspace = true }
+alexandria_numeric         = { workspace = true }
+starknet                   = { workspace = true }
 
 # ibc dependencies
 starknet_ibc_utils = { workspace = true }

--- a/cairo-contracts/packages/testkit/Scarb.toml
+++ b/cairo-contracts/packages/testkit/Scarb.toml
@@ -27,6 +27,7 @@ fmt = { workspace = true }
 openzeppelin_access  = { workspace = true }
 openzeppelin_testing = { workspace = true }
 openzeppelin_utils   = { workspace = true }
+openzeppelin_token   = { workspace = true }
 snforge_std          = { workspace = true }
 starknet             = { workspace = true }
 
@@ -34,6 +35,8 @@ starknet             = { workspace = true }
 starknet_ibc_core    = { workspace = true }
 starknet_ibc_clients = { workspace = true }
 starknet_ibc_apps    = { workspace = true }
+
+serde_json = { workspace = true }
 
 [[target.starknet-contract]]
 allowed-libfuncs-list.name = "experimental"

--- a/cairo-libs/.tool-versions
+++ b/cairo-libs/.tool-versions
@@ -1,3 +1,3 @@
 scarb 2.9.2
-starknet-foundry 0.31.0
+starknet-foundry 0.37.0
 universal-sierra-compiler 2.3.0

--- a/cairo-libs/.tool-versions
+++ b/cairo-libs/.tool-versions
@@ -1,3 +1,3 @@
-scarb 2.8.4
+scarb 2.9.2
 starknet-foundry 0.31.0
 universal-sierra-compiler 2.3.0

--- a/cairo-libs/.tool-versions
+++ b/cairo-libs/.tool-versions
@@ -1,3 +1,3 @@
 scarb 2.9.2
-starknet-foundry 0.37.0
+starknet-foundry 0.34.0
 universal-sierra-compiler 2.3.0

--- a/cairo-libs/Scarb.lock
+++ b/cairo-libs/Scarb.lock
@@ -25,13 +25,13 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.31.0"
+version = "0.37.0"
 source = "registry+https://scarbs.xyz/"
 checksum = "sha256:1fce075fcbf7fce1b0935f6f9a034549704837fb221da212d3b6e9134cebfdaa"
 
 [[package]]
 name = "snforge_std"
-version = "0.31.0"
+version = "0.37.0"
 source = "registry+https://scarbs.xyz/"
 checksum = "sha256:60ac980b297281f9a59a5f1668cb56bdea1b28fd2f8008008270f9a3c91ad3ba"
 dependencies = [

--- a/cairo-libs/Scarb.lock
+++ b/cairo-libs/Scarb.lock
@@ -25,15 +25,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.37.0"
+version = "0.34.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:1fce075fcbf7fce1b0935f6f9a034549704837fb221da212d3b6e9134cebfdaa"
+checksum = "sha256:56f2b06ff2f0d8bbdfb7fb6c211fba7e4da6e5334ea70ba849af329a739faf11"
 
 [[package]]
 name = "snforge_std"
-version = "0.37.0"
+version = "0.34.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:60ac980b297281f9a59a5f1668cb56bdea1b28fd2f8008008270f9a3c91ad3ba"
+checksum = "sha256:bd20964bde07e6fd0f7adb50d41216f05d66abd422ed82241030369333385876"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/cairo-libs/Scarb.toml
+++ b/cairo-libs/Scarb.toml
@@ -25,7 +25,7 @@ test = "snforge test"
 assert_macros = "2.9.2"
 cairo_test    = "2.9.2"
 starknet      = "2.9.2"
-snforge_std   = "0.37.0"
+snforge_std   = "0.34.0"
 
 [workspace.tool.fmt]
 sort-module-level-items = true

--- a/cairo-libs/Scarb.toml
+++ b/cairo-libs/Scarb.toml
@@ -25,7 +25,7 @@ test = "snforge test"
 assert_macros = "2.9.2"
 cairo_test    = "2.9.2"
 starknet      = "2.9.2"
-snforge_std   = "0.31.0"
+snforge_std   = "0.37.0"
 
 [workspace.tool.fmt]
 sort-module-level-items = true

--- a/cairo-libs/Scarb.toml
+++ b/cairo-libs/Scarb.toml
@@ -23,7 +23,6 @@ test = "snforge test"
 [workspace.dependencies]
 # external dependencies
 assert_macros = "2.9.2"
-cairo_test    = "2.9.2"
 starknet      = "2.9.2"
 snforge_std   = "0.34.0"
 

--- a/cairo-libs/Scarb.toml
+++ b/cairo-libs/Scarb.toml
@@ -8,8 +8,8 @@ members = [
 [workspace.package]
 version       = "0.1.0"
 edition       = "2024_07"
-cairo-version = "2.8.4"
-scarb-version = "2.8.4"
+cairo-version = "2.9.2"
+scarb-version = "2.9.2"
 license       = "Apache-2.0"
 authors       = [ "Informal Systems <hello@informal.systems>" ]
 repository    = "https://github.com/informalsystems/ibc-starknet"
@@ -22,9 +22,9 @@ test = "snforge test"
 
 [workspace.dependencies]
 # external dependencies
-assert_macros = "2.8.4"
-cairo_test    = "2.8.4"
-starknet      = "2.8.4"
+assert_macros = "2.9.2"
+cairo_test    = "2.9.2"
+starknet      = "2.9.2"
 snforge_std   = "0.31.0"
 
 [workspace.tool.fmt]

--- a/cairo-libs/packages/cometbft/Scarb.toml
+++ b/cairo-libs/packages/cometbft/Scarb.toml
@@ -3,9 +3,13 @@ name    = "cometbft"
 version = "0.1.0"
 edition = { workspace = true }
 
+[lib]
+
+[scripts]
+test = { workspace = true }
+
 [dependencies]
 protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
-cairo_test  = { workspace = true }
 snforge_std = { workspace = true }

--- a/cairo-libs/packages/cometbft/Scarb.toml
+++ b/cairo-libs/packages/cometbft/Scarb.toml
@@ -12,4 +12,5 @@ test = { workspace = true }
 protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
-snforge_std = { workspace = true }
+assert_macros = { workspace = true }
+snforge_std   = { workspace = true }

--- a/cairo-libs/packages/protobuf/Scarb.toml
+++ b/cairo-libs/packages/protobuf/Scarb.toml
@@ -11,4 +11,5 @@ test = { workspace = true }
 [dependencies]
 
 [dev-dependencies]
-snforge_std = { workspace = true }
+assert_macros = { workspace = true }
+snforge_std   = { workspace = true }

--- a/cairo-libs/packages/protobuf/Scarb.toml
+++ b/cairo-libs/packages/protobuf/Scarb.toml
@@ -3,8 +3,12 @@ name    = "protobuf"
 version = "0.1.0"
 edition = { workspace = true }
 
+[lib]
+
+[scripts]
+test = { workspace = true }
+
 [dependencies]
 
 [dev-dependencies]
-cairo_test  = { workspace = true }
 snforge_std = { workspace = true }

--- a/flake.lock
+++ b/flake.lock
@@ -1708,6 +1708,7 @@
         "rust-overlay": "rust-overlay_2",
         "scarb-src": "scarb-src",
         "starknet-devnet-src": "starknet-devnet-src",
+        "starknet-foundry-src": "starknet-foundry-src",
         "universal-sierra-compiler-src": "universal-sierra-compiler-src"
       }
     },
@@ -1875,6 +1876,23 @@
       "original": {
         "owner": "0xSpaceShard",
         "repo": "starknet-devnet-rs",
+        "type": "github"
+      }
+    },
+    "starknet-foundry-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1738659589,
+        "narHash": "sha256-ZUMGuQNbRl+1ZiH0m10cfIJwk7ZymrHx2+2NdMTuA7U=",
+        "owner": "foundry-rs",
+        "repo": "starknet-foundry",
+        "rev": "05c840d1b4367088296225284e2d722256778f58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "foundry-rs",
+        "ref": "v0.37.0",
+        "repo": "starknet-foundry",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -87,16 +87,16 @@
     "cairo-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1728298007,
-        "narHash": "sha256-xHvBbm1ewNu96TyK//l2emiq+jaPhSWvvbVK9Q/O5lo=",
+        "lastModified": 1733902425,
+        "narHash": "sha256-zjgCOrTlIPN4aU0+FCohJmISPiwpppj3zO/7unVi/iU=",
         "owner": "starkware-libs",
         "repo": "cairo",
-        "rev": "f67829f80d0b13bd4da466f07006b64fe421c42d",
+        "rev": "35b299291fd7819f75409fb303ece7d30e4adb19",
         "type": "github"
       },
       "original": {
         "owner": "starkware-libs",
-        "ref": "v2.8.4",
+        "ref": "v2.9.2",
         "repo": "cairo",
         "type": "github"
       }
@@ -1769,16 +1769,16 @@
     "scarb-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1728308720,
-        "narHash": "sha256-mUY7EjuqKh6YeI/BqS+f9lEWf+QhACBSl5cHKEcsOPk=",
+        "lastModified": 1733946942,
+        "narHash": "sha256-GJKcXQrORjVNihTxC57HCXjIAgB9Ym3Tn7SMJ/bjuz8=",
         "owner": "software-mansion",
         "repo": "scarb",
-        "rev": "2aa4e193ec930417a8789ceafcfb9dc29963f8e7",
+        "rev": "5070ff3749497c596dafd6263869a9cef49dbe91",
         "type": "github"
       },
       "original": {
         "owner": "software-mansion",
-        "ref": "v2.8.4",
+        "ref": "v2.9.2",
         "repo": "scarb",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1882,16 +1882,16 @@
     "starknet-foundry-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1738659589,
-        "narHash": "sha256-ZUMGuQNbRl+1ZiH0m10cfIJwk7ZymrHx2+2NdMTuA7U=",
+        "lastModified": 1732634552,
+        "narHash": "sha256-+QnHejOGH/8rGVULFr49BN2gRAY7iuXZGvJr5ple6YY=",
         "owner": "foundry-rs",
         "repo": "starknet-foundry",
-        "rev": "05c840d1b4367088296225284e2d722256778f58",
+        "rev": "d6976d4635cbe69bd199fd502788c469d408ed2d",
         "type": "github"
       },
       "original": {
         "owner": "foundry-rs",
-        "ref": "v0.37.0",
+        "ref": "v0.34.0",
         "repo": "starknet-foundry",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,11 @@
       url = "github:software-mansion/universal-sierra-compiler/v2.3.0";
       flake = false;
     };
+
+    starknet-foundry-src = {
+      url = "github:foundry-rs/starknet-foundry/v0.37.0";
+      flake = false;
+    };
   };
 
   outputs =
@@ -87,6 +92,11 @@
             rust = rust-1_79;
           };
 
+          starknet-foundry = import ./nix/starknet-foundry.nix {
+            inherit nixpkgs;
+            inherit (inputs) starknet-foundry-src;
+          };
+
           ibc-starknet-cw = import ./nix/ibc-starknet-cw.nix {
             inherit nixpkgs;
 
@@ -99,6 +109,7 @@
               cairo
               scarb
               universal-sierra-compiler
+              starknet-foundry
               wasm-simapp
               osmosis
               ;

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     };
 
     starknet-foundry-src = {
-      url = "github:foundry-rs/starknet-foundry/v0.37.0";
+      url = "github:foundry-rs/starknet-foundry/v0.34.0";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -14,12 +14,12 @@
     };
 
     cairo-src = {
-      url = "github:starkware-libs/cairo/v2.8.4";
+      url = "github:starkware-libs/cairo/v2.9.2";
       flake = false;
     };
 
     scarb-src = {
-      url = "github:software-mansion/scarb/v2.8.4";
+      url = "github:software-mansion/scarb/v2.9.2";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -109,7 +109,7 @@
               cairo
               scarb
               universal-sierra-compiler
-              starknet-foundry
+              # starknet-foundry
               wasm-simapp
               osmosis
               ;

--- a/nix/cairo.nix
+++ b/nix/cairo.nix
@@ -2,13 +2,13 @@
 let
   cairo = nixpkgs.rustPlatform.buildRustPackage {
     name = "cairo";
-    version = "2.8.4";
+    version = "2.9.2";
 
     doCheck = false;
 
     src = cairo-src;
 
-    cargoHash = "sha256-P694ATBnAA9O4aoMDG/3bmcJXOLK0qXQGy0nE9uFMMM=";
+    cargoHash = "sha256-1SGbhusL5Ig+/8oVRxicVkdLfuLwK1Z0Bq4oR7Tei3A=";
 
     OPENSSL_NO_VENDOR = 1;
     PKG_CONFIG_PATH = "${nixpkgs.openssl.dev}/lib/pkgconfig";

--- a/nix/scarb.nix
+++ b/nix/scarb.nix
@@ -6,13 +6,13 @@
 let
   cairo = nixpkgs.rustPlatform.buildRustPackage {
     name = "scarb";
-    version = "2.8.4";
+    version = "2.9.2";
 
     doCheck = false;
 
     src = scarb-src;
 
-    cargoHash = "sha256-CGMPFE31s1mwkrGCotqSHx8j5hD3J6twGvvG1Rmc63Q=";
+    cargoHash = "sha256-kk7s2GEZKsG98ej1OWymhwP/NK2k7BJPBxIBM2vIuRE=";
 
     SCARB_CORELIB_LOCAL_PATH = cairo-src + "/corelib";
 

--- a/nix/starknet-foundry.nix
+++ b/nix/starknet-foundry.nix
@@ -2,7 +2,7 @@
 let
   starknet-foundry = nixpkgs.rustPlatform.buildRustPackage {
     pname = "starknet-foundry";
-    version = "0.37.0";
+    version = "0.34.0";
 
     src = starknet-foundry-src;
 

--- a/nix/starknet-foundry.nix
+++ b/nix/starknet-foundry.nix
@@ -1,16 +1,15 @@
-{ nixpkgs, snforge-src }:
+{ nixpkgs, starknet-foundry-src }:
 let
-  snforge = nixpkgs.rustPlatform.buildRustPackage {
-    pname = "forge";
-    version = "0.31.0";
+  starknet-foundry = nixpkgs.rustPlatform.buildRustPackage {
+    pname = "starknet-foundry";
+    version = "0.37.0";
 
-    src = snforge-src;
+    src = starknet-foundry-src;
 
     cargoLock = {
-      lockFile = snforge-src + "/Cargo.lock";
+      lockFile = starknet-foundry-src + "/Cargo.lock";
       outputHashes = {
         "starknet-0.11.0" = "sha256-Dgx5Czrzj2JKwmSJ5EvqpikRFwpWwEydkhZl0pnjfWE=";
-        "trace-data-0.4.0" = "sha256-C5rgp+wthWkjNBkY1PlHfLkGexrmjOQpUgbPKPrKf7g=";
       };
     };
 
@@ -26,4 +25,4 @@ let
     ];
   };
 in
-snforge
+starknet-foundry

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -43,7 +43,7 @@ sha2                        = { version = "0.10.8" }
 tonic                       = { version = "0.12" }
 prost                       = { version = "0.13.1" }
 prost-types                 = { version = "0.13.1" }
-cairo-lang-starknet-classes = { version = "2.8.4" }
+cairo-lang-starknet-classes = { version = "2.9.2" }
 clap                        = { version = "4.5.20" }
 toml                        = { version = "0.8.15" }
 oneline-eyre                = { version = "0.1.0" }


### PR DESCRIPTION
required for #177. we need [`LowerHex`](https://github.com/starkware-libs/cairo/blob/3c5a2f414204388da4db6f9530cd22e6d1ba5184/corelib/src/fmt.cairo#L336) which is introduced in cairo 2.9.0.

- updated:
  - scarb 2.9.2
  - cairo 2.9.2
  - starknet 2.9.2
  - openzeppelin 0.20.0
  - snforge 0.34.0
  - alexandria rev-162bed1
- faster cairo CI jobs.