### PR TITLE
Apply `#[cgp_provider]` to all provider implementations

### DIFF
--- a/light-client/Cargo.lock
+++ b/light-client/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cgp"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async",
  "cgp-core",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "cgp-async"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async-macro",
  "cgp-sync",
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "cgp-async-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -332,12 +332,12 @@ dependencies = [
 [[package]]
 name = "cgp-component"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 
 [[package]]
 name = "cgp-component-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-component-macro-lib",
  "syn 2.0.96",
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 name = "cgp-component-macro-lib"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "itertools 0.14.0",
  "prettyplease",
@@ -358,7 +358,7 @@ dependencies = [
 [[package]]
 name = "cgp-core"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -372,7 +372,7 @@ dependencies = [
 [[package]]
 name = "cgp-error"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "cgp-error-extra"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-core",
 ]
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "cgp-extra"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-error-extra",
  "cgp-inner",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "cgp-field"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-field-macro-lib",
  "proc-macro2",
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro-lib"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -432,7 +432,7 @@ dependencies = [
 [[package]]
 name = "cgp-inner"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "cgp-run"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "cgp-runtime"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-core",
 ]
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "cgp-sync"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async-macro",
 ]
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "cgp-type"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -1045,7 +1045,7 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 [[package]]
 name = "hermes-cosmos-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "hermes-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
 ]
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "hermes-protobuf-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-encoding-components",

--- a/light-client/ibc-client-starknet-types/Cargo.toml
+++ b/light-client/ibc-client-starknet-types/Cargo.toml
@@ -21,7 +21,7 @@ tendermint                          = { workspace = true }
 derive_more                         = { workspace = true }
 prost                               = { workspace = true }
 serde                               = { workspace = true, optional = true }
-cgp                                 = { workspace = true }
+cgp                                 = { workspace = true, features = ["provider-supertrait"] }
 hermes-encoding-components          = { workspace = true }
 hermes-protobuf-encoding-components = { workspace = true }
 hermes-cosmos-encoding-components   = { workspace = true }

--- a/light-client/ibc-client-starknet-types/Cargo.toml
+++ b/light-client/ibc-client-starknet-types/Cargo.toml
@@ -21,7 +21,7 @@ tendermint                          = { workspace = true }
 derive_more                         = { workspace = true }
 prost                               = { workspace = true }
 serde                               = { workspace = true, optional = true }
-cgp                                 = { workspace = true, features = ["provider-supertrait"] }
+cgp                                 = { workspace = true, features = [ "provider-supertrait" ] }
 hermes-encoding-components          = { workspace = true }
 hermes-protobuf-encoding-components = { workspace = true }
 hermes-cosmos-encoding-components   = { workspace = true }

--- a/light-client/ibc-client-starknet-types/src/encoding/components.rs
+++ b/light-client/ibc-client-starknet-types/src/encoding/components.rs
@@ -1,151 +1,158 @@
-use cgp::core::component::{UseContext, UseDelegate};
-use cgp::prelude::*;
-pub use hermes_cosmos_encoding_components::components::{
-    CosmosEncodingComponents, DecoderComponent, EncodedLengthGetterComponent, EncoderComponent,
-    MutDecoderComponent, MutEncoderComponent,
-};
-pub use hermes_encoding_components::traits::convert::ConverterComponent;
-pub use hermes_encoding_components::traits::schema::SchemaGetterComponent;
-pub use hermes_protobuf_encoding_components::components::{
-    DecodeBufferTypeComponent, EncodeBufferTypeComponent, EncodedTypeComponent, SchemaTypeComponent,
-};
-use hermes_protobuf_encoding_components::impl_type_url;
-use hermes_protobuf_encoding_components::impls::any::{DecodeAsAnyProtobuf, EncodeAsAnyProtobuf};
-use hermes_protobuf_encoding_components::impls::encode::buffer::EncodeProtoWithMutBuffer;
-use hermes_protobuf_encoding_components::impls::via_any::EncodeViaAny;
-use hermes_protobuf_encoding_components::types::any::Any;
-use hermes_protobuf_encoding_components::types::strategy::{ViaAny, ViaProtobuf};
-use ibc_core::client::types::Height;
-use ibc_core::commitment_types::commitment::CommitmentRoot;
-use ibc_core::primitives::Timestamp;
+#[cgp::re_export_imports]
+mod preset {
+    use cgp::core::component::{UseContext, UseDelegate};
+    use cgp::prelude::*;
+    use hermes_cosmos_encoding_components::components::{
+        CosmosEncodingComponents, DecoderComponent, EncodedLengthGetterComponent, EncoderComponent,
+        MutDecoderComponent, MutEncoderComponent,
+    };
+    use hermes_encoding_components::traits::convert::ConverterComponent;
+    use hermes_encoding_components::traits::schema::SchemaGetterComponent;
+    use hermes_protobuf_encoding_components::components::{
+        DecodeBufferTypeComponent, EncodeBufferTypeComponent, EncodedTypeComponent,
+        SchemaTypeComponent,
+    };
+    use hermes_protobuf_encoding_components::impl_type_url;
+    use hermes_protobuf_encoding_components::impls::any::{
+        DecodeAsAnyProtobuf, EncodeAsAnyProtobuf,
+    };
+    use hermes_protobuf_encoding_components::impls::encode::buffer::EncodeProtoWithMutBuffer;
+    use hermes_protobuf_encoding_components::impls::via_any::EncodeViaAny;
+    use hermes_protobuf_encoding_components::types::any::Any;
+    use hermes_protobuf_encoding_components::types::strategy::{ViaAny, ViaProtobuf};
+    use ibc_core::client::types::Height;
+    use ibc_core::commitment_types::commitment::CommitmentRoot;
+    use ibc_core::primitives::Timestamp;
 
-use crate::encoding::impls::client_state::EncodeStarknetClientState;
-use crate::encoding::impls::consensus_state::EncodeStarknetConsensusState;
-use crate::encoding::impls::header::{EncodeSignedStarknetHeader, EncodeStarknetHeader};
-use crate::header::{
-    SignedStarknetHeader, StarknetHeader, SIGNED_STARKNET_HEADER_TYPE_URL, STARKNET_HEADER_TYPE_URL,
-};
-use crate::{
-    StarknetClientState, StarknetConsensusState, STARKNET_CLIENT_STATE_TYPE_URL,
-    STARKNET_CONSENSUS_STATE_TYPE_URL,
-};
+    use crate::encoding::impls::client_state::EncodeStarknetClientState;
+    use crate::encoding::impls::consensus_state::EncodeStarknetConsensusState;
+    use crate::encoding::impls::header::{EncodeSignedStarknetHeader, EncodeStarknetHeader};
+    use crate::header::{
+        SignedStarknetHeader, StarknetHeader, SIGNED_STARKNET_HEADER_TYPE_URL,
+        STARKNET_HEADER_TYPE_URL,
+    };
+    use crate::{
+        StarknetClientState, StarknetConsensusState, STARKNET_CLIENT_STATE_TYPE_URL,
+        STARKNET_CONSENSUS_STATE_TYPE_URL,
+    };
 
-cgp_preset! {
-    StarknetLightClientEncodingComponents {
-        [
-            EncodedTypeComponent,
-            EncodeBufferTypeComponent,
-            DecodeBufferTypeComponent,
-            SchemaTypeComponent,
-        ]:
-            CosmosEncodingComponents,
-        [
-            EncoderComponent,
-            DecoderComponent,
-        ]:
-            UseDelegate<StarknetLightClientEncoderComponents>,
-        [
-            MutEncoderComponent,
-            MutDecoderComponent,
-            EncodedLengthGetterComponent,
-        ]:
-            UseDelegate<StarknetLightClientEncodeMutComponents>,
-        SchemaGetterComponent:
-            StarknetLightClientTypeUrlSchemas,
-        ConverterComponent:
-            UseDelegate<StarknetLightClientConverterComponents>,
+    cgp_preset! {
+        StarknetLightClientEncodingComponents {
+            [
+                EncodedTypeComponent,
+                EncodeBufferTypeComponent,
+                DecodeBufferTypeComponent,
+                SchemaTypeComponent,
+            ]:
+                CosmosEncodingComponents,
+            [
+                EncoderComponent,
+                DecoderComponent,
+            ]:
+                UseDelegate<StarknetLightClientEncoderComponents>,
+            [
+                MutEncoderComponent,
+                MutDecoderComponent,
+                EncodedLengthGetterComponent,
+            ]:
+                UseDelegate<StarknetLightClientEncodeMutComponents>,
+            SchemaGetterComponent:
+                StarknetLightClientTypeUrlSchemas,
+            ConverterComponent:
+                UseDelegate<StarknetLightClientConverterComponents>,
+        }
     }
-}
 
-pub struct StarknetLightClientEncoderComponents;
+    pub struct StarknetLightClientEncoderComponents;
 
-pub struct StarknetLightClientEncodeMutComponents;
+    pub struct StarknetLightClientEncodeMutComponents;
 
-pub struct StarknetLightClientTypeUrlSchemas;
+    pub struct StarknetLightClientTypeUrlSchemas;
 
-pub struct StarknetLightClientConverterComponents;
+    pub struct StarknetLightClientConverterComponents;
 
-delegate_components! {
-    StarknetLightClientEncoderComponents {
-        [
-            (ViaProtobuf, Any),
-            (ViaProtobuf, Height),
-            (ViaProtobuf, StarknetClientState),
-            (ViaProtobuf, StarknetConsensusState),
-            (ViaProtobuf, StarknetHeader),
-            (ViaProtobuf, SignedStarknetHeader),
-        ]: EncodeProtoWithMutBuffer,
+    delegate_components! {
+        StarknetLightClientEncoderComponents {
+            [
+                (ViaProtobuf, Any),
+                (ViaProtobuf, Height),
+                (ViaProtobuf, StarknetClientState),
+                (ViaProtobuf, StarknetConsensusState),
+                (ViaProtobuf, StarknetHeader),
+                (ViaProtobuf, SignedStarknetHeader),
+            ]: EncodeProtoWithMutBuffer,
 
-        [
-            (ViaAny, StarknetClientState),
-            (ViaAny, StarknetConsensusState),
-            (ViaAny, StarknetHeader),
-            (ViaAny, SignedStarknetHeader),
-        ]: EncodeViaAny<ViaProtobuf>,
+            [
+                (ViaAny, StarknetClientState),
+                (ViaAny, StarknetConsensusState),
+                (ViaAny, StarknetHeader),
+                (ViaAny, SignedStarknetHeader),
+            ]: EncodeViaAny<ViaProtobuf>,
+        }
     }
-}
 
-delegate_components! {
-    StarknetLightClientEncodeMutComponents {
-        [
-            (ViaProtobuf, Height),
-            (ViaProtobuf, Any),
-            (ViaProtobuf, CommitmentRoot),
-            (ViaProtobuf, Timestamp),
-        ]: CosmosEncodingComponents,
+    delegate_components! {
+        StarknetLightClientEncodeMutComponents {
+            [
+                (ViaProtobuf, Height),
+                (ViaProtobuf, Any),
+                (ViaProtobuf, CommitmentRoot),
+                (ViaProtobuf, Timestamp),
+            ]: CosmosEncodingComponents,
 
-        (ViaProtobuf, StarknetClientState):
-            EncodeStarknetClientState,
+            (ViaProtobuf, StarknetClientState):
+                EncodeStarknetClientState,
 
-        (ViaProtobuf, StarknetConsensusState):
-            EncodeStarknetConsensusState,
+            (ViaProtobuf, StarknetConsensusState):
+                EncodeStarknetConsensusState,
 
-        (ViaProtobuf, StarknetHeader):
-            EncodeStarknetHeader,
+            (ViaProtobuf, StarknetHeader):
+                EncodeStarknetHeader,
 
-        (ViaProtobuf, SignedStarknetHeader):
-            EncodeSignedStarknetHeader,
+            (ViaProtobuf, SignedStarknetHeader):
+                EncodeSignedStarknetHeader,
+        }
     }
-}
 
-delegate_components! {
-    StarknetLightClientConverterComponents {
-        [
-            (StarknetClientState, Any),
-            (StarknetConsensusState, Any),
-            (StarknetHeader, Any),
-            (SignedStarknetHeader, Any),
-        ]: EncodeAsAnyProtobuf<ViaProtobuf, UseContext>,
+    delegate_components! {
+        StarknetLightClientConverterComponents {
+            [
+                (StarknetClientState, Any),
+                (StarknetConsensusState, Any),
+                (StarknetHeader, Any),
+                (SignedStarknetHeader, Any),
+            ]: EncodeAsAnyProtobuf<ViaProtobuf, UseContext>,
 
-        [
-            (Any, StarknetClientState),
-            (Any, StarknetConsensusState),
-            (Any, StarknetHeader),
-            (Any, SignedStarknetHeader),
-        ]: DecodeAsAnyProtobuf<ViaProtobuf, UseContext>,
+            [
+                (Any, StarknetClientState),
+                (Any, StarknetConsensusState),
+                (Any, StarknetHeader),
+                (Any, SignedStarknetHeader),
+            ]: DecodeAsAnyProtobuf<ViaProtobuf, UseContext>,
+        }
     }
+
+    impl_type_url!(
+        StarknetLightClientTypeUrlSchemas,
+        StarknetClientState,
+        STARKNET_CLIENT_STATE_TYPE_URL,
+    );
+
+    impl_type_url!(
+        StarknetLightClientTypeUrlSchemas,
+        StarknetConsensusState,
+        STARKNET_CONSENSUS_STATE_TYPE_URL,
+    );
+
+    impl_type_url!(
+        StarknetLightClientTypeUrlSchemas,
+        StarknetHeader,
+        STARKNET_HEADER_TYPE_URL,
+    );
+
+    impl_type_url!(
+        StarknetLightClientTypeUrlSchemas,
+        SignedStarknetHeader,
+        SIGNED_STARKNET_HEADER_TYPE_URL,
+    );
 }
-
-impl_type_url!(
-    StarknetLightClientTypeUrlSchemas,
-    StarknetClientState,
-    STARKNET_CLIENT_STATE_TYPE_URL,
-);
-
-impl_type_url!(
-    StarknetLightClientTypeUrlSchemas,
-    StarknetConsensusState,
-    STARKNET_CONSENSUS_STATE_TYPE_URL,
-);
-
-impl_type_url!(
-    StarknetLightClientTypeUrlSchemas,
-    StarknetHeader,
-    STARKNET_HEADER_TYPE_URL,
-);
-
-impl_type_url!(
-    StarknetLightClientTypeUrlSchemas,
-    SignedStarknetHeader,
-    SIGNED_STARKNET_HEADER_TYPE_URL,
-);

--- a/light-client/ibc-client-starknet/src/encoding/context.rs
+++ b/light-client/ibc-client-starknet/src/encoding/context.rs
@@ -3,7 +3,9 @@ use core::convert::Infallible;
 use core::num::{ParseIntError, TryFromIntError};
 use core::str::Utf8Error;
 
-use cgp::core::error::{ErrorRaiser, ErrorRaiserComponent, ErrorTypeProvider, ErrorTypeProviderComponent};
+use cgp::core::error::{
+    ErrorRaiser, ErrorRaiserComponent, ErrorTypeProvider, ErrorTypeProviderComponent,
+};
 use cgp::prelude::*;
 use hermes_encoding_components::traits::convert::{CanConvert, CanConvertBothWays};
 use hermes_encoding_components::traits::encode_and_decode::CanEncodeAndDecode;

--- a/light-client/ibc-client-starknet/src/encoding/context.rs
+++ b/light-client/ibc-client-starknet/src/encoding/context.rs
@@ -3,7 +3,7 @@ use core::convert::Infallible;
 use core::num::{ParseIntError, TryFromIntError};
 use core::str::Utf8Error;
 
-use cgp::core::error::{ErrorRaiser, ErrorTypeProvider};
+use cgp::core::error::{ErrorRaiser, ErrorRaiserComponent, ErrorTypeProvider, ErrorTypeProviderComponent};
 use cgp::prelude::*;
 use hermes_encoding_components::traits::convert::{CanConvert, CanConvertBothWays};
 use hermes_encoding_components::traits::encode_and_decode::CanEncodeAndDecode;
@@ -28,12 +28,14 @@ use prost::DecodeError;
 #[cgp_context(StarknetLightClientEncodingContextComponents: StarknetLightClientEncodingComponents)]
 pub struct StarknetLightClientEncoding;
 
+#[cgp_provider(ErrorTypeProviderComponent)]
 impl ErrorTypeProvider<StarknetLightClientEncoding>
     for StarknetLightClientEncodingContextComponents
 {
     type Error = ClientError;
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, ClientError>
     for StarknetLightClientEncodingContextComponents
 {
@@ -42,6 +44,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, ClientError>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, Infallible>
     for StarknetLightClientEncodingContextComponents
 {
@@ -50,6 +53,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, Infallible>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, DecodeError>
     for StarknetLightClientEncodingContextComponents
 {
@@ -60,6 +64,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, DecodeError>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, Utf8Error>
     for StarknetLightClientEncodingContextComponents
 {
@@ -70,6 +75,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, Utf8Error>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, ParseIntError>
     for StarknetLightClientEncodingContextComponents
 {
@@ -80,6 +86,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, ParseIntError>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, TryFromIntError>
     for StarknetLightClientEncodingContextComponents
 {
@@ -90,6 +97,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, TryFromIntError>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, TryFromSliceError>
     for StarknetLightClientEncodingContextComponents
 {
@@ -100,6 +108,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, TryFromSliceError>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, TimestampError>
     for StarknetLightClientEncodingContextComponents
 {
@@ -110,6 +119,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, TimestampError>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, DecodingError>
     for StarknetLightClientEncodingContextComponents
 {
@@ -120,6 +130,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, DecodingError>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, UnsupportedWireType>
     for StarknetLightClientEncodingContextComponents
 {
@@ -130,6 +141,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, UnsupportedWireType>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, InvalidWireType>
     for StarknetLightClientEncodingContextComponents
 {
@@ -140,6 +152,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, InvalidWireType>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, RequiredFieldTagNotFound>
     for StarknetLightClientEncodingContextComponents
 {
@@ -150,6 +163,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, RequiredFieldTagNotFound>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, TypeUrlMismatchError>
     for StarknetLightClientEncodingContextComponents
 {
@@ -160,6 +174,7 @@ impl ErrorRaiser<StarknetLightClientEncoding, TypeUrlMismatchError>
     }
 }
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl ErrorRaiser<StarknetLightClientEncoding, IdentifierError>
     for StarknetLightClientEncodingContextComponents
 {

--- a/nix/ibc-starknet-cw.nix
+++ b/nix/ibc-starknet-cw.nix
@@ -10,8 +10,8 @@ let
     cargoLock = {
       lockFile = ./../light-client/Cargo.lock;
       outputHashes = {
-        "hermes-cosmos-encoding-components-0.1.0" = "sha256-/zEFPrqCbcw/yThX9DVXUSPvsWwqoKuoeN5xhQbg9tY=";
-        "cgp-0.3.1" = "sha256-C5lW8/7DIHEH9Mg9UEKG7nKnLbg3jROv3IEz8w/bV/U=";
+        "hermes-cosmos-encoding-components-0.1.0" = "sha256-ns9KGPwPQHBXHL0UUukzf7NMhLpAGucHx9YKnY9Zbx8=";
+        "cgp-0.3.1" = "sha256-sADWXKY/M73QqJasVicJWRTuuIMb0ZGIu1b8S8F/JG8=";
         "ibc-client-cw-0.56.0" = "sha256-DA3AB8ejUrx4ksBtN/vaOznjpKE0+0F6vGA7JmWyHWA=";
         "ibc-0.56.0" = "sha256-7DPIqu/zs0szjmtJTfXI2eQ0HEkRyvGjArcMZsFWMT4=";
       };

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -682,7 +682,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cgp"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async",
  "cgp-core",
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "cgp-async"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async-macro",
  "cgp-sync",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "cgp-async-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -711,12 +711,12 @@ dependencies = [
 [[package]]
 name = "cgp-component"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 
 [[package]]
 name = "cgp-component-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-component-macro-lib",
  "syn 2.0.96",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "cgp-component-macro-lib"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "itertools 0.14.0",
  "prettyplease",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "cgp-core"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -751,7 +751,7 @@ dependencies = [
 [[package]]
 name = "cgp-error"
 version = "0.3.1"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "cgp-error-extra"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-core",
 ]
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "cgp-error-eyre"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-core",
  "eyre",
@@ -779,7 +779,7 @@ dependencies = [
 [[package]]
 name = "cgp-extra"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-error-extra",
  "cgp-inner",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "cgp-field"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-field-macro-lib",
  "proc-macro2",
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "cgp-field-macro-lib"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "cgp-inner"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "cgp-run"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async",
  "cgp-component",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "cgp-runtime"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-core",
 ]
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "cgp-sync"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-async-macro",
 ]
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "cgp-type"
 version = "0.3.0"
-source = "git+https://github.com/contextgeneric/cgp.git#6dd33da8574520c409bda44c6e078e49b9c8c002"
+source = "git+https://github.com/contextgeneric/cgp.git#6c4a36be8b5230aa0e83742e46e69b4e46bd663b"
 dependencies = [
  "cgp-component",
  "cgp-component-macro",
@@ -1825,7 +1825,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hermes-any-counterparty"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-cosmos-chain-components",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "hermes-async-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "async-trait",
  "cgp",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-type-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
 ]
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "clap",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "clap",
@@ -1943,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli-framework"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "clap",
@@ -1962,7 +1962,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -1971,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-context"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "eyre",
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-integration-tests"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "eyre",
@@ -2087,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "dirs-next",
@@ -2136,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hdpath",
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-wasm-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "eyre",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "hermes-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
 ]
@@ -2220,7 +2220,7 @@ dependencies = [
 [[package]]
 name = "hermes-error"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "eyre",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "hermes-ibc-test-suite"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "hermes-logger"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "hermes-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
 ]
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "hermes-protobuf-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-chain-components",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components-extra"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-async-runtime-components",
@@ -2309,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
 ]
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "hermes-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2545,7 +2545,7 @@ dependencies = [
 [[package]]
 name = "hermes-tokio-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "futures",
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "hermes-tracing-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2571,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-cosmos-chain-components",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-cosmos-encoding-components",
@@ -2604,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#8d87ae8098c0a9301047f75f190c0ee55d098a81"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#75207c3f46f96e473ae22b67ecaa104561f53706"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -4446,7 +4446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",

--- a/relayer/crates/cairo-encoding-components/src/components/encode_mut.rs
+++ b/relayer/crates/cairo-encoding-components/src/components/encode_mut.rs
@@ -1,37 +1,40 @@
-use cgp::prelude::*;
-pub use starknet::core::types::{Felt, U256};
+#[cgp::re_export_imports]
+mod preset {
+    use cgp::prelude::*;
+    use starknet::core::types::{Felt, U256};
 
-use crate::impls::encode_mut::array::EncodeArray;
-use crate::impls::encode_mut::bool::EncodeBool;
-use crate::impls::encode_mut::byte_array::EncodeByteArray;
-use crate::impls::encode_mut::felt::EncodeFelt;
-use crate::impls::encode_mut::from_u128::EncodeFromU128;
-use crate::impls::encode_mut::string::EncodeUtf8String;
-use crate::impls::encode_mut::u128::EncodeU128;
-use crate::impls::encode_mut::u256::EncodeU256;
-use crate::impls::encode_mut::unit::EncodeNothing;
-use crate::impls::encode_mut::vec::EncodeList;
-use crate::strategy::ViaCairo;
+    use crate::impls::encode_mut::array::EncodeArray;
+    use crate::impls::encode_mut::bool::EncodeBool;
+    use crate::impls::encode_mut::byte_array::EncodeByteArray;
+    use crate::impls::encode_mut::felt::EncodeFelt;
+    use crate::impls::encode_mut::from_u128::EncodeFromU128;
+    use crate::impls::encode_mut::string::EncodeUtf8String;
+    use crate::impls::encode_mut::u128::EncodeU128;
+    use crate::impls::encode_mut::u256::EncodeU256;
+    use crate::impls::encode_mut::unit::EncodeNothing;
+    use crate::impls::encode_mut::vec::EncodeList;
+    use crate::strategy::ViaCairo;
 
-cgp_preset! {
-    CairoEncodeMutComponents {
-        (ViaCairo, Felt): EncodeFelt,
-        (ViaCairo, u128): EncodeU128,
-        (ViaCairo, U256): EncodeU256,
-        // TODO(rano): ByteArray and Array<u8> are different types in Cairo
-        // for now, we CANNOT use Vec<u8> to deserialize to Array<u8>
-        (ViaCairo, Vec<u8>): EncodeByteArray,
-        (ViaCairo, Vec<Felt>): EncodeList,
-        (ViaCairo, bool): EncodeBool,
-        (ViaCairo, u64): EncodeFromU128,
-        (ViaCairo, u32): EncodeFromU128,
-        (ViaCairo, usize): EncodeFromU128,
-        (ViaCairo, String): EncodeUtf8String,
-        (ViaCairo, ()): EncodeNothing,
-        (ViaCairo, Nil): EncodeNothing,
-        (ViaCairo, Vec<String>): EncodeList,
-        // TODO(rano): use <const N: usize>
-        (ViaCairo, [String; 2]): EncodeArray,
-        (ViaCairo, [u32; 8]): EncodeArray,
+    cgp_preset! {
+        CairoEncodeMutComponents {
+            (ViaCairo, Felt): EncodeFelt,
+            (ViaCairo, u128): EncodeU128,
+            (ViaCairo, U256): EncodeU256,
+            // TODO(rano): ByteArray and Array<u8> are different types in Cairo
+            // for now, we CANNOT use Vec<u8> to deserialize to Array<u8>
+            (ViaCairo, Vec<u8>): EncodeByteArray,
+            (ViaCairo, Vec<Felt>): EncodeList,
+            (ViaCairo, bool): EncodeBool,
+            (ViaCairo, u64): EncodeFromU128,
+            (ViaCairo, u32): EncodeFromU128,
+            (ViaCairo, usize): EncodeFromU128,
+            (ViaCairo, String): EncodeUtf8String,
+            (ViaCairo, ()): EncodeNothing,
+            (ViaCairo, Nil): EncodeNothing,
+            (ViaCairo, Vec<String>): EncodeList,
+            // TODO(rano): use <const N: usize>
+            (ViaCairo, [String; 2]): EncodeArray,
+            (ViaCairo, [u32; 8]): EncodeArray,
+        }
     }
 }

--- a/relayer/crates/cairo-encoding-components/src/components/encoding.rs
+++ b/relayer/crates/cairo-encoding-components/src/components/encoding.rs
@@ -1,39 +1,42 @@
-use cgp::prelude::*;
-pub use hermes_encoding_components::traits::decode::DecoderComponent;
-pub use hermes_encoding_components::traits::decode_mut::DecodeBufferPeekerComponent;
-pub use hermes_encoding_components::traits::encode::EncoderComponent;
-pub use hermes_encoding_components::traits::types::decode_buffer::{
-    DecodeBufferBuilderComponent, DecodeBufferTypeComponent,
-};
-pub use hermes_encoding_components::traits::types::encode_buffer::{
-    EncodeBufferFinalizerComponent, EncodeBufferTypeComponent,
-};
-pub use hermes_encoding_components::traits::types::encoded::EncodedTypeComponent;
+#[cgp::re_export_imports]
+mod preset {
+    use cgp::prelude::*;
+    use hermes_encoding_components::traits::decode::DecoderComponent;
+    use hermes_encoding_components::traits::decode_mut::DecodeBufferPeekerComponent;
+    use hermes_encoding_components::traits::encode::EncoderComponent;
+    use hermes_encoding_components::traits::types::decode_buffer::{
+        DecodeBufferBuilderComponent, DecodeBufferTypeComponent,
+    };
+    use hermes_encoding_components::traits::types::encode_buffer::{
+        EncodeBufferFinalizerComponent, EncodeBufferTypeComponent,
+    };
+    use hermes_encoding_components::traits::types::encoded::EncodedTypeComponent;
 
-use crate::impls::encode::buffer::EncodeWithMutBuffer;
-use crate::impls::types::decode_buffer::ProvideVecIterDecodeBuffer;
-use crate::impls::types::encode_buffer::ProvideVecEncodeBuffer;
-use crate::impls::types::encoded::ProvideVecFeltEncodedType;
+    use crate::impls::encode::buffer::EncodeWithMutBuffer;
+    use crate::impls::types::decode_buffer::ProvideVecIterDecodeBuffer;
+    use crate::impls::types::encode_buffer::ProvideVecEncodeBuffer;
+    use crate::impls::types::encoded::ProvideVecFeltEncodedType;
 
-cgp_preset! {
-    CairoEncodingComponents {
-        EncodedTypeComponent:
-            ProvideVecFeltEncodedType,
-        [
-            EncodeBufferTypeComponent,
-            EncodeBufferFinalizerComponent,
-        ]:
-            ProvideVecEncodeBuffer,
-        [
-            DecodeBufferTypeComponent,
-            DecodeBufferBuilderComponent,
-            DecodeBufferPeekerComponent,
-        ]:
-            ProvideVecIterDecodeBuffer,
-        [
-            EncoderComponent,
-            DecoderComponent,
-        ]:
-            EncodeWithMutBuffer,
+    cgp_preset! {
+        CairoEncodingComponents {
+            EncodedTypeComponent:
+                ProvideVecFeltEncodedType,
+            [
+                EncodeBufferTypeComponent,
+                EncodeBufferFinalizerComponent,
+            ]:
+                ProvideVecEncodeBuffer,
+            [
+                DecodeBufferTypeComponent,
+                DecodeBufferBuilderComponent,
+                DecodeBufferPeekerComponent,
+            ]:
+                ProvideVecIterDecodeBuffer,
+            [
+                EncoderComponent,
+                DecoderComponent,
+            ]:
+                EncodeWithMutBuffer,
+        }
     }
 }

--- a/relayer/crates/cairo-encoding-components/src/impls/encode/buffer.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode/buffer.rs
@@ -1,6 +1,7 @@
-use hermes_encoding_components::traits::decode::Decoder;
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode::{Decoder, DecoderComponent};
 use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
-use hermes_encoding_components::traits::encode::Encoder;
+use hermes_encoding_components::traits::encode::{Encoder, EncoderComponent};
 use hermes_encoding_components::traits::encode_mut::CanEncodeMut;
 use hermes_encoding_components::traits::types::decode_buffer::CanBuildDecodeBuffer;
 use hermes_encoding_components::traits::types::encode_buffer::CanFinalizedEncodeBuffer;
@@ -9,6 +10,7 @@ use crate::impls::encode_mut::end::DecodeEnd;
 
 pub struct EncodeWithMutBuffer;
 
+#[cgp_provider(EncoderComponent)]
 impl<Encoding, Strategy, Value> Encoder<Encoding, Strategy, Value> for EncodeWithMutBuffer
 where
     Encoding: CanEncodeMut<Strategy, Value> + CanFinalizedEncodeBuffer,
@@ -22,6 +24,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<Encoding, Strategy, Value> Decoder<Encoding, Strategy, Value> for EncodeWithMutBuffer
 where
     Encoding: CanDecodeMut<Strategy, Value> + CanBuildDecodeBuffer,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/array.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/array.rs
@@ -1,10 +1,16 @@
 use core::fmt::Debug;
 
-use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
-use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{
+    CanDecodeMut, MutDecoder, MutDecoderComponent,
+};
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 
 pub struct EncodeArray;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy, Value, const SIZE: usize> MutEncoder<Encoding, Strategy, [Value; SIZE]>
     for EncodeArray
 where
@@ -23,6 +29,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy, Value, const SIZE: usize> MutDecoder<Encoding, Strategy, [Value; SIZE]>
     for EncodeArray
 where

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/bool.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/bool.rs
@@ -1,8 +1,12 @@
 use core::fmt::Debug;
 
-use cgp::core::error::CanRaiseAsyncError;
-use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
-use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{
+    CanDecodeMut, MutDecoder, MutDecoderComponent,
+};
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 use starknet::core::types::Felt;
 
 pub struct EncodeBool;
@@ -11,6 +15,7 @@ pub struct DecodeBoolError {
     pub felt: Felt,
 }
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, bool> for EncodeBool
 where
     Encoding: CanEncodeMut<Strategy, Felt>,
@@ -27,6 +32,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, bool> for EncodeBool
 where
     Encoding: CanDecodeMut<Strategy, Felt> + CanRaiseAsyncError<DecodeBoolError>,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/byte_array.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/byte_array.rs
@@ -1,9 +1,15 @@
-use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
-use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{
+    CanDecodeMut, MutDecoder, MutDecoderComponent,
+};
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 use starknet::core::types::Felt;
 
 pub struct EncodeByteArray;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy, Value> MutEncoder<Encoding, Strategy, Value> for EncodeByteArray
 where
     Encoding: CanEncodeMut<Strategy, Felt> + CanEncodeMut<Strategy, usize>,
@@ -37,6 +43,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, Vec<u8>> for EncodeByteArray
 where
     Encoding: CanDecodeMut<Strategy, Felt> + CanDecodeMut<Strategy, usize>,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/cons.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/cons.rs
@@ -1,14 +1,15 @@
 use core::marker::PhantomData;
 
 use cgp::core::error::HasAsyncErrorType;
-use cgp::prelude::Cons;
-use hermes_encoding_components::traits::decode_mut::MutDecoder;
-use hermes_encoding_components::traits::encode_mut::MutEncoder;
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{MutDecoder, MutDecoderComponent};
+use hermes_encoding_components::traits::encode_mut::{MutEncoder, MutEncoderComponent};
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;
 use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
 
 pub struct EncoderCons<EncoderA, EncoderB>(pub PhantomData<(EncoderA, EncoderB)>);
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy, EncoderA, EncoderB, ValueA, ValueB>
     MutEncoder<Encoding, Strategy, Cons<ValueA, ValueB>> for EncoderCons<EncoderA, EncoderB>
 where
@@ -28,6 +29,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy, EncoderA, EncoderB, ValueA, ValueB>
     MutDecoder<Encoding, Strategy, Cons<ValueA, ValueB>> for EncoderCons<EncoderA, EncoderB>
 where

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/end.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/end.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
-use cgp::core::error::CanRaiseAsyncError;
-use hermes_encoding_components::traits::decode_mut::MutDecoder;
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{MutDecoder, MutDecoderComponent};
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;
 
 pub struct DecodeEnd;
@@ -10,6 +10,7 @@ pub struct DecodeEnd;
 pub struct NonEmptyBuffer;
 
 #[allow(unused_mut)]
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ()> for DecodeEnd
 where
     Encoding: HasDecodeBufferType + CanRaiseAsyncError<NonEmptyBuffer>,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/felt.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/felt.rs
@@ -1,8 +1,8 @@
 use core::iter;
 
-use cgp::core::error::{CanRaiseAsyncError, HasAsyncErrorType};
-use hermes_encoding_components::traits::decode_mut::MutDecoder;
-use hermes_encoding_components::traits::encode_mut::MutEncoder;
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{MutDecoder, MutDecoderComponent};
+use hermes_encoding_components::traits::encode_mut::{MutEncoder, MutEncoderComponent};
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;
 use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
 use starknet::core::types::Felt;
@@ -12,6 +12,7 @@ pub struct EncodeFelt;
 #[derive(Debug, Copy, Clone)]
 pub struct UnexpectedEndOfBuffer;
 
+#[cgp_provider(MutEncoderComponent)]
 #[allow(unused_mut)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, Felt> for EncodeFelt
 where
@@ -29,6 +30,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 #[allow(unused_mut)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, Felt> for EncodeFelt
 where

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/from_felt.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/from_felt.rs
@@ -1,8 +1,12 @@
-use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 use starknet::core::types::Felt;
 
 pub struct EncodeFromFelt;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Strategy, Encoding, Value> MutEncoder<Encoding, Strategy, Value> for EncodeFromFelt
 where
     Encoding: CanEncodeMut<Strategy, Felt>,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/from_u128.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/from_u128.rs
@@ -1,9 +1,14 @@
-use cgp::core::error::CanRaiseAsyncError;
-use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
-use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{
+    CanDecodeMut, MutDecoder, MutDecoderComponent,
+};
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 
 pub struct EncodeFromU128;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Strategy, Encoding, Value, Error> MutEncoder<Encoding, Strategy, Value> for EncodeFromU128
 where
     Encoding: CanEncodeMut<Strategy, u128> + CanRaiseAsyncError<Error>,
@@ -19,6 +24,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Strategy, Encoding, Value, Error> MutDecoder<Encoding, Strategy, Value> for EncodeFromU128
 where
     Encoding: CanDecodeMut<Strategy, u128> + CanRaiseAsyncError<Error>,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/iter.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/iter.rs
@@ -1,7 +1,11 @@
-use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 
 pub struct EncodeArray;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy, Value> MutEncoder<Encoding, Strategy, Value> for EncodeArray
 where
     Encoding: for<'a> CanEncodeMut<Strategy, <&'a Value as IntoIterator>::Item>,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/pair.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/pair.rs
@@ -1,13 +1,14 @@
 use core::marker::PhantomData;
 
-use cgp::core::error::HasAsyncErrorType;
-use hermes_encoding_components::traits::decode_mut::MutDecoder;
-use hermes_encoding_components::traits::encode_mut::MutEncoder;
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{MutDecoder, MutDecoderComponent};
+use hermes_encoding_components::traits::encode_mut::{MutEncoder, MutEncoderComponent};
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;
 use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
 
 pub struct EncoderPair<EncoderA, EncoderB>(pub PhantomData<(EncoderA, EncoderB)>);
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy, EncoderA, EncoderB, ValueA, ValueB>
     MutEncoder<Encoding, Strategy, (ValueA, ValueB)> for EncoderPair<EncoderA, EncoderB>
 where
@@ -27,6 +28,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy, EncoderA, EncoderB, ValueA, ValueB>
     MutDecoder<Encoding, Strategy, (ValueA, ValueB)> for EncoderPair<EncoderA, EncoderB>
 where

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/reference.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/reference.rs
@@ -1,9 +1,13 @@
 use core::ops::Deref;
 
-use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 
 pub struct EncodeDeref;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy, Value> MutEncoder<Encoding, Strategy, Value> for EncodeDeref
 where
     Encoding: CanEncodeMut<Strategy, Value::Target>,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/string.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/string.rs
@@ -10,8 +10,10 @@ use crate::impls::encode_mut::byte_array::EncodeByteArray;
 
 pub struct EncodeUtf8String;
 
-impl DelegateComponent<MutEncoderComponent> for EncodeUtf8String {
-    type Delegate = EncodeByteArray;
+delegate_components! {
+    EncodeUtf8String {
+        MutEncoderComponent: EncodeByteArray,
+    }
 }
 
 #[cgp_provider(MutDecoderComponent)]

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/string.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/string.rs
@@ -1,8 +1,9 @@
 use std::string::FromUtf8Error;
 
-use cgp::core::error::CanRaiseAsyncError;
-use cgp::prelude::DelegateComponent;
-use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{
+    CanDecodeMut, MutDecoder, MutDecoderComponent,
+};
 use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
 
 use crate::impls::encode_mut::byte_array::EncodeByteArray;
@@ -13,6 +14,7 @@ impl DelegateComponent<MutEncoderComponent> for EncodeUtf8String {
     type Delegate = EncodeByteArray;
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, String> for EncodeUtf8String
 where
     Encoding: CanDecodeMut<Strategy, Vec<u8>> + CanRaiseAsyncError<FromUtf8Error>,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/u128.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/u128.rs
@@ -1,5 +1,7 @@
-use cgp::prelude::DelegateComponent;
-use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{
+    CanDecodeMut, MutDecoder, MutDecoderComponent,
+};
 use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
 use starknet::core::types::Felt;
 
@@ -7,6 +9,7 @@ use crate::impls::encode_mut::from_felt::EncodeFromFelt;
 
 pub struct EncodeU128;
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, u128> for EncodeU128
 where
     Encoding: CanDecodeMut<Strategy, Felt>,
@@ -22,8 +25,10 @@ where
     }
 }
 
-impl DelegateComponent<MutEncoderComponent> for EncodeU128 {
-    type Delegate = EncodeFromFelt;
+delegate_components! {
+    EncodeU128 {
+        MutEncoderComponent: EncodeFromFelt,
+    }
 }
 
 pub fn felt_to_u128(felt: Felt) -> u128 {

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/u256.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/u256.rs
@@ -1,9 +1,15 @@
-use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
-use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{
+    CanDecodeMut, MutDecoder, MutDecoderComponent,
+};
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 use starknet::core::types::U256;
 
 pub struct EncodeU256;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, U256> for EncodeU256
 where
     Encoding: CanEncodeMut<Strategy, u128>,
@@ -20,6 +26,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, U256> for EncodeU256
 where
     Encoding: CanDecodeMut<Strategy, u128>,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/unit.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/unit.rs
@@ -1,12 +1,12 @@
-use cgp::core::error::HasAsyncErrorType;
-use cgp::prelude::Nil;
-use hermes_encoding_components::traits::decode_mut::MutDecoder;
-use hermes_encoding_components::traits::encode_mut::MutEncoder;
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{MutDecoder, MutDecoderComponent};
+use hermes_encoding_components::traits::encode_mut::{MutEncoder, MutEncoderComponent};
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;
 use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
 
 pub struct EncodeNothing;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ()> for EncodeNothing
 where
     Encoding: HasEncodeBufferType + HasAsyncErrorType,
@@ -20,6 +20,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ()> for EncodeNothing
 where
     Encoding: HasDecodeBufferType + HasAsyncErrorType,
@@ -32,6 +33,7 @@ where
     }
 }
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, Nil> for EncodeNothing
 where
     Encoding: HasEncodeBufferType + HasAsyncErrorType,
@@ -45,6 +47,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, Nil> for EncodeNothing
 where
     Encoding: HasDecodeBufferType + HasAsyncErrorType,

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/variant.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/variant.rs
@@ -1,11 +1,12 @@
 use core::marker::PhantomData;
 
-use cgp::core::error::CanRaiseAsyncError;
 use cgp::prelude::*;
 use hermes_encoding_components::traits::decode_mut::{
-    CanDecodeMut, CanPeekDecodeBuffer, MutDecoder,
+    CanDecodeMut, CanPeekDecodeBuffer, MutDecoder, MutDecoderComponent,
 };
-use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
 use starknet::core::types::Felt;
 
@@ -22,6 +23,7 @@ pub struct VariantIndexOutOfBound {
 
 pub struct SumEncoders<Index, Remain>(pub PhantomData<(Index, Remain)>);
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy, ValueA, ValueB, I, N>
     MutEncoder<Encoding, Strategy, Either<ValueA, ValueB>> for SumEncoders<I, S<N>>
 where
@@ -45,6 +47,7 @@ where
     }
 }
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy, Value, I> MutEncoder<Encoding, Strategy, Either<Value, Void>>
     for SumEncoders<I, Z>
 where
@@ -66,6 +69,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy, ValueA, ValueB, I, N>
     MutDecoder<Encoding, Strategy, Either<ValueA, ValueB>> for SumEncoders<I, S<N>>
 where
@@ -96,6 +100,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy, Value, I> MutDecoder<Encoding, Strategy, Either<Value, Void>>
     for SumEncoders<I, Z>
 where

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/variant_from.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/variant_from.rs
@@ -1,8 +1,8 @@
 use core::marker::PhantomData;
 
-use cgp::core::error::HasAsyncErrorType;
-use hermes_encoding_components::traits::decode_mut::MutDecoder;
-use hermes_encoding_components::traits::encode_mut::MutEncoder;
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{MutDecoder, MutDecoderComponent};
+use hermes_encoding_components::traits::encode_mut::{MutEncoder, MutEncoderComponent};
 use hermes_encoding_components::traits::transform::{Transformer, TransformerRef};
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;
 use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
@@ -13,6 +13,7 @@ use crate::types::nat::{S, Z};
 
 pub struct EncodeVariantFrom<Transform>(pub PhantomData<Transform>);
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy, N, Transform> MutEncoder<Encoding, Strategy, Transform::From>
     for EncodeVariantFrom<Transform>
 where
@@ -31,6 +32,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy, N, Transform, Source, Target> MutDecoder<Encoding, Strategy, Target>
     for EncodeVariantFrom<Transform>
 where

--- a/relayer/crates/cairo-encoding-components/src/impls/encode_mut/vec.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/encode_mut/vec.rs
@@ -1,8 +1,14 @@
-use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
-use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{
+    CanDecodeMut, MutDecoder, MutDecoderComponent,
+};
+use hermes_encoding_components::traits::encode_mut::{
+    CanEncodeMut, MutEncoder, MutEncoderComponent,
+};
 
 pub struct EncodeList;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy, Value> MutEncoder<Encoding, Strategy, Vec<Value>> for EncodeList
 where
     Encoding: CanEncodeMut<Strategy, Value> + CanEncodeMut<Strategy, usize>,
@@ -22,6 +28,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy, Value> MutDecoder<Encoding, Strategy, Vec<Value>> for EncodeList
 where
     Encoding: CanDecodeMut<Strategy, Value> + CanDecodeMut<Strategy, usize>,

--- a/relayer/crates/cairo-encoding-components/src/impls/types/decode_buffer.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/types/decode_buffer.rs
@@ -2,19 +2,25 @@ use core::iter::Peekable;
 use core::ops::Deref;
 use core::slice::Iter;
 
-use hermes_encoding_components::traits::decode_mut::DecodeBufferPeeker;
+use cgp::prelude::*;
+use hermes_encoding_components::traits::decode_mut::{
+    DecodeBufferPeeker, DecodeBufferPeekerComponent,
+};
 use hermes_encoding_components::traits::types::decode_buffer::{
-    DecodeBufferBuilder, HasDecodeBufferType, ProvideDecodeBufferType,
+    DecodeBufferBuilder, DecodeBufferBuilderComponent, DecodeBufferTypeComponent,
+    HasDecodeBufferType, ProvideDecodeBufferType,
 };
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
 use starknet::core::types::Felt;
 
 pub struct ProvideVecIterDecodeBuffer;
 
+#[cgp_provider(DecodeBufferTypeComponent)]
 impl<Encoding> ProvideDecodeBufferType<Encoding> for ProvideVecIterDecodeBuffer {
     type DecodeBuffer<'a> = Peekable<Iter<'a, Felt>>;
 }
 
+#[cgp_provider(DecodeBufferBuilderComponent)]
 impl<Encoding> DecodeBufferBuilder<Encoding> for ProvideVecIterDecodeBuffer
 where
     Encoding: HasEncodedType<Encoded = Vec<Felt>>
@@ -25,6 +31,7 @@ where
     }
 }
 
+#[cgp_provider(DecodeBufferPeekerComponent)]
 impl<Encoding> DecodeBufferPeeker<Encoding, Felt> for ProvideVecIterDecodeBuffer
 where
     Encoding: for<'a> HasDecodeBufferType<DecodeBuffer<'a> = Peekable<Iter<'a, Felt>>>,

--- a/relayer/crates/cairo-encoding-components/src/impls/types/encode_buffer.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/types/encode_buffer.rs
@@ -1,15 +1,19 @@
+use cgp::prelude::*;
 use hermes_encoding_components::traits::types::encode_buffer::{
-    EncodeBufferFinalizer, HasEncodeBufferType, ProvideEncodeBufferType,
+    EncodeBufferFinalizer, EncodeBufferFinalizerComponent, EncodeBufferTypeComponent,
+    HasEncodeBufferType, ProvideEncodeBufferType,
 };
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
 use starknet::core::types::Felt;
 
 pub struct ProvideVecEncodeBuffer;
 
+#[cgp_provider(EncodeBufferTypeComponent)]
 impl<Encoding> ProvideEncodeBufferType<Encoding> for ProvideVecEncodeBuffer {
     type EncodeBuffer = Vec<Felt>;
 }
 
+#[cgp_provider(EncodeBufferFinalizerComponent)]
 impl<Encoding> EncodeBufferFinalizer<Encoding> for ProvideVecEncodeBuffer
 where
     Encoding: HasEncodedType<Encoded = Vec<Felt>> + HasEncodeBufferType<EncodeBuffer = Vec<Felt>>,

--- a/relayer/crates/cairo-encoding-components/src/impls/types/encoded.rs
+++ b/relayer/crates/cairo-encoding-components/src/impls/types/encoded.rs
@@ -1,9 +1,12 @@
-use cgp::core::Async;
-use hermes_encoding_components::traits::types::encoded::ProvideEncodedType;
+use cgp::prelude::*;
+use hermes_encoding_components::traits::types::encoded::{
+    EncodedTypeComponent, ProvideEncodedType,
+};
 use starknet::core::types::Felt;
 
 pub struct ProvideVecFeltEncodedType;
 
+#[cgp_provider(EncodedTypeComponent)]
 impl<Encoding: Async> ProvideEncodedType<Encoding> for ProvideVecFeltEncodedType {
     type Encoded = Vec<Felt>;
 }

--- a/relayer/crates/starknet-chain-components/src/components/chain.rs
+++ b/relayer/crates/starknet-chain-components/src/components/chain.rs
@@ -1,13 +1,4 @@
-use cgp::core::component::WithProvider;
 use cgp::core::types::UseDelegatedType;
-use cgp::prelude::*;
-use hermes_chain_components::impls::payload_builders::channel::BuildChannelHandshakePayload;
-use hermes_chain_components::impls::payload_builders::connection::BuildConnectionHandshakePayload;
-use hermes_chain_components::impls::payload_builders::packet::BuildPacketPayloads;
-use hermes_chain_components::impls::queries::block_events::{
-    RetryQueryBlockEvents, WaitBlockHeightAndQueryEvents,
-};
-use hermes_chain_components::impls::queries::consensus_state_height::QueryConsensusStateHeightsAndFindHeightBefore;
 use hermes_chain_components::impls::queries::consensus_state_heights::QueryLatestConsensusStateHeightAsHeights;
 use hermes_chain_components::impls::types::ack::ProvideBytesAcknowlegement;
 use hermes_chain_components::impls::types::commitment::ProvideBytesPacketCommitment;
@@ -19,10 +10,7 @@ use hermes_chain_components::impls::types::receipt::ProvideBytesPacketReceipt;
 use hermes_chain_components::traits::commitment_prefix::IbcCommitmentPrefixGetterComponent;
 pub use hermes_chain_components::traits::packet::from_send_packet::PacketFromSendPacketEventBuilderComponent;
 pub use hermes_cosmos_chain_components::components::client::*;
-use hermes_cosmos_chain_components::impls::channel::init_channel_options::ProvideCosmosInitChannelOptionsType;
-use hermes_cosmos_chain_components::impls::connection::init_connection_options::ProvideCosmosInitConnectionOptionsType;
 use hermes_cosmos_chain_components::impls::packet::packet_fields::CosmosPacketFieldReader;
-use hermes_cosmos_chain_components::impls::types::chain::ProvideCosmosChainTypes;
 use hermes_cosmos_chain_components::impls::types::create_client_options::ProvideNoCreateClientMessageOptionsType;
 pub use hermes_relayer_components::chain::traits::queries::chain_status::ChainStatusQuerierComponent;
 pub use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;

--- a/relayer/crates/starknet-chain-components/src/components/chain.rs
+++ b/relayer/crates/starknet-chain-components/src/components/chain.rs
@@ -1,404 +1,408 @@
-use cgp::core::types::UseDelegatedType;
-use hermes_chain_components::impls::queries::consensus_state_heights::QueryLatestConsensusStateHeightAsHeights;
-use hermes_chain_components::impls::types::ack::ProvideBytesAcknowlegement;
-use hermes_chain_components::impls::types::commitment::ProvideBytesPacketCommitment;
-use hermes_chain_components::impls::types::commitment_prefix::ProvideCommitmentPrefixBytes;
-use hermes_chain_components::impls::types::payloads::channel::ProvideChannelPayloadTypes;
-use hermes_chain_components::impls::types::payloads::connection::ProvideConnectionPayloadTypes;
-use hermes_chain_components::impls::types::payloads::packet::ProvidePacketPayloadTypes;
-use hermes_chain_components::impls::types::receipt::ProvideBytesPacketReceipt;
-use hermes_chain_components::traits::commitment_prefix::IbcCommitmentPrefixGetterComponent;
-pub use hermes_chain_components::traits::packet::from_send_packet::PacketFromSendPacketEventBuilderComponent;
-pub use hermes_cosmos_chain_components::components::client::*;
-use hermes_cosmos_chain_components::impls::packet::packet_fields::CosmosPacketFieldReader;
-use hermes_cosmos_chain_components::impls::types::create_client_options::ProvideNoCreateClientMessageOptionsType;
-pub use hermes_relayer_components::chain::traits::queries::chain_status::ChainStatusQuerierComponent;
-pub use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;
-pub use hermes_relayer_components::chain::traits::types::chain_id::ChainIdTypeComponent;
-pub use hermes_relayer_components::chain::traits::types::client_state::ClientStateTypeComponent;
-pub use hermes_relayer_components::chain::traits::types::consensus_state::ConsensusStateTypeComponent;
-pub use hermes_relayer_components::chain::traits::types::event::EventTypeComponent;
-pub use hermes_relayer_components::chain::traits::types::height::{
-    HeightFieldComponent, HeightTypeComponent,
-};
-pub use hermes_relayer_components::chain::traits::types::message::MessageTypeComponent;
-pub use hermes_relayer_components::chain::traits::types::status::ChainStatusTypeComponent;
-use hermes_relayer_components::error::impls::retry::ReturnRetryable;
-pub use hermes_relayer_components::error::traits::retry::RetryableErrorComponent;
-pub use hermes_relayer_components::transaction::impls::poll_tx_response::PollTimeoutGetterComponent;
-use hermes_relayer_components::transaction::impls::poll_tx_response::PollTxResponse;
-pub use hermes_relayer_components::transaction::traits::poll_tx_response::TxResponsePollerComponent;
-pub use hermes_relayer_components::transaction::traits::query_tx_response::TxResponseQuerierComponent;
-pub use hermes_relayer_components::transaction::traits::submit_tx::TxSubmitterComponent;
-pub use hermes_relayer_components::transaction::traits::types::transaction::TransactionTypeComponent;
-pub use hermes_relayer_components::transaction::traits::types::tx_hash::TransactionHashTypeComponent;
-pub use hermes_relayer_components::transaction::traits::types::tx_response::TxResponseTypeComponent;
-use hermes_test_components::chain::impls::assert::default_assert_duration::ProvideDefaultPollAssertDuration;
-use hermes_test_components::chain::impls::assert::poll_assert_eventual_amount::PollAssertEventualAmount;
-use hermes_test_components::chain::impls::ibc_transfer::SendIbcTransferMessage;
-pub use hermes_test_components::chain::traits::assert::eventual_amount::EventualAmountAsserterComponent;
-pub use hermes_test_components::chain::traits::assert::poll_assert::PollAssertDurationGetterComponent;
-use hermes_test_components::chain::traits::messages::ibc_transfer::IbcTokenTransferMessageBuilderComponent;
-use hermes_test_components::chain::traits::queries::balance::BalanceQuerierComponent;
-use hermes_test_components::chain::traits::transfer::ibc_transfer::TokenIbcTransferrerComponent;
-use hermes_test_components::chain::traits::transfer::string_memo::ProvideStringMemoType;
-pub use hermes_test_components::chain::traits::types::address::AddressTypeComponent;
-pub use hermes_test_components::chain::traits::types::amount::AmountTypeComponent;
-pub use hermes_test_components::chain::traits::types::denom::DenomTypeComponent;
-use hermes_test_components::chain::traits::types::memo::MemoTypeComponent;
+#[cgp::re_export_imports]
+mod preset {
+    use cgp::core::types::UseDelegatedType;
+    use hermes_chain_components::impls::queries::consensus_state_heights::QueryLatestConsensusStateHeightAsHeights;
+    use hermes_chain_components::impls::types::ack::ProvideBytesAcknowlegement;
+    use hermes_chain_components::impls::types::commitment::ProvideBytesPacketCommitment;
+    use hermes_chain_components::impls::types::commitment_prefix::ProvideCommitmentPrefixBytes;
+    use hermes_chain_components::impls::types::payloads::channel::ProvideChannelPayloadTypes;
+    use hermes_chain_components::impls::types::payloads::connection::ProvideConnectionPayloadTypes;
+    use hermes_chain_components::impls::types::payloads::packet::ProvidePacketPayloadTypes;
+    use hermes_chain_components::impls::types::receipt::ProvideBytesPacketReceipt;
+    use hermes_chain_components::traits::commitment_prefix::IbcCommitmentPrefixGetterComponent;
+    use hermes_chain_components::traits::packet::from_send_packet::PacketFromSendPacketEventBuilderComponent;
+    use hermes_cosmos_chain_components::components::client::*;
+    use hermes_cosmos_chain_components::impls::packet::packet_fields::CosmosPacketFieldReader;
+    use hermes_cosmos_chain_components::impls::types::create_client_options::ProvideNoCreateClientMessageOptionsType;
+    use hermes_relayer_components::chain::traits::queries::chain_status::ChainStatusQuerierComponent;
+    use hermes_relayer_components::chain::traits::send_message::MessageSenderComponent;
+    use hermes_relayer_components::chain::traits::types::chain_id::ChainIdTypeComponent;
+    use hermes_relayer_components::chain::traits::types::client_state::ClientStateTypeComponent;
+    use hermes_relayer_components::chain::traits::types::consensus_state::ConsensusStateTypeComponent;
+    use hermes_relayer_components::chain::traits::types::event::EventTypeComponent;
+    use hermes_relayer_components::chain::traits::types::height::{
+        HeightFieldComponent, HeightTypeComponent,
+    };
+    use hermes_relayer_components::chain::traits::types::message::MessageTypeComponent;
+    use hermes_relayer_components::chain::traits::types::status::ChainStatusTypeComponent;
+    use hermes_relayer_components::error::impls::retry::ReturnRetryable;
+    use hermes_relayer_components::error::traits::retry::RetryableErrorComponent;
+    use hermes_relayer_components::transaction::impls::poll_tx_response::{
+        PollTimeoutGetterComponent, PollTxResponse,
+    };
+    use hermes_relayer_components::transaction::traits::poll_tx_response::TxResponsePollerComponent;
+    use hermes_relayer_components::transaction::traits::query_tx_response::TxResponseQuerierComponent;
+    use hermes_relayer_components::transaction::traits::submit_tx::TxSubmitterComponent;
+    use hermes_relayer_components::transaction::traits::types::transaction::TransactionTypeComponent;
+    use hermes_relayer_components::transaction::traits::types::tx_hash::TransactionHashTypeComponent;
+    use hermes_relayer_components::transaction::traits::types::tx_response::TxResponseTypeComponent;
+    use hermes_test_components::chain::impls::assert::default_assert_duration::ProvideDefaultPollAssertDuration;
+    use hermes_test_components::chain::impls::assert::poll_assert_eventual_amount::PollAssertEventualAmount;
+    use hermes_test_components::chain::impls::ibc_transfer::SendIbcTransferMessage;
+    use hermes_test_components::chain::traits::assert::eventual_amount::EventualAmountAsserterComponent;
+    use hermes_test_components::chain::traits::assert::poll_assert::PollAssertDurationGetterComponent;
+    use hermes_test_components::chain::traits::messages::ibc_transfer::IbcTokenTransferMessageBuilderComponent;
+    use hermes_test_components::chain::traits::queries::balance::BalanceQuerierComponent;
+    use hermes_test_components::chain::traits::transfer::ibc_transfer::TokenIbcTransferrerComponent;
+    use hermes_test_components::chain::traits::transfer::string_memo::ProvideStringMemoType;
+    use hermes_test_components::chain::traits::types::address::AddressTypeComponent;
+    use hermes_test_components::chain::traits::types::amount::AmountTypeComponent;
+    use hermes_test_components::chain::traits::types::denom::DenomTypeComponent;
+    use hermes_test_components::chain::traits::types::memo::MemoTypeComponent;
 
-use crate::components::types::StarknetChainTypes;
-use crate::impls::commitment_prefix::GetStarknetCommitmentPrefix;
-use crate::impls::contract::call::CallStarknetContract;
-use crate::impls::contract::declare::DeclareSierraContract;
-use crate::impls::contract::deploy::DeployStarknetContract;
-use crate::impls::contract::invoke::InvokeStarknetContract;
-use crate::impls::contract::message::BuildInvokeContractCall;
-use crate::impls::counterparty_message_height::GetCounterpartyCosmosHeightFromStarknetMessage;
-use crate::impls::events::UseStarknetEvents;
-use crate::impls::messages::channel::BuildStarknetChannelHandshakeMessages;
-use crate::impls::messages::connection::BuildStarknetConnectionHandshakeMessages;
-use crate::impls::messages::create_client::BuildCreateCometClientMessage;
-use crate::impls::messages::ibc_transfer::BuildStarknetIbcTransferMessage;
-use crate::impls::messages::packet::BuildStarknetPacketMessages;
-use crate::impls::messages::update_client::BuildUpdateCometClientMessage;
-use crate::impls::packet_fields::ReadPacketSrcStarknetFields;
-use crate::impls::packet_filter::FilterStarknetPackets;
-use crate::impls::payload_builders::create_client::BuildStarknetCreateClientPayload;
-use crate::impls::payload_builders::update_client::BuildStarknetUpdateClientPayload;
-use crate::impls::queries::ack_commitment::QueryStarknetAckCommitment;
-use crate::impls::queries::balance::QueryStarknetWalletBalance;
-use crate::impls::queries::block_events::GetStarknetBlockEvents;
-use crate::impls::queries::channel_end::QueryChannelEndFromStarknet;
-use crate::impls::queries::client_state::QueryCometClientState;
-use crate::impls::queries::connection_end::QueryConnectionEndFromStarknet;
-use crate::impls::queries::consensus_state::QueryCometConsensusState;
-use crate::impls::queries::contract_address::GetContractAddressFromField;
-use crate::impls::queries::counterparty_chain_id::QueryCosmosChainIdFromStarknetChannelId;
-use crate::impls::queries::packet_commitment::QueryStarknetPacketCommitment;
-use crate::impls::queries::packet_is_cleared::QueryStarknetPacketIsCleared;
-use crate::impls::queries::packet_receipt::QueryStarknetPacketReceipt;
-use crate::impls::queries::packet_received::QueryPacketIsReceivedOnStarknet;
-use crate::impls::queries::status::QueryStarknetChainStatus;
-use crate::impls::queries::token_balance::QueryErc20TokenBalance;
-use crate::impls::send_message::SendCallMessages;
-use crate::impls::submit_tx::SubmitCallTransaction;
-use crate::impls::transfer::TransferErc20Token;
-use crate::impls::tx_response::{DefaultPollTimeout, QueryTransactionReceipt};
-use crate::impls::types::address::ProvideFeltAddressType;
-use crate::impls::types::amount::ProvideU256Amount;
-use crate::impls::types::blob::ProvideFeltBlobType;
-use crate::impls::types::chain_id::ProvideFeltChainId;
-use crate::impls::types::client::ProvideStarknetIbcClientTypes;
-use crate::impls::types::commitment_proof::UseStarknetCommitmentProof;
-use crate::impls::types::contract::ProvideStarknetContractTypes;
-use crate::impls::types::denom::ProvideTokenAddressDenom;
-use crate::impls::types::event::ProvideStarknetEvent;
-use crate::impls::types::height::ProvideStarknetHeight;
-use crate::impls::types::message::ProvideCallMessage;
-use crate::impls::types::method::ProvideFeltSelector;
-use crate::impls::types::payloads::ProvideStarknetPayloadTypes;
-use crate::impls::types::status::ProvideStarknetChainStatusType;
-use crate::impls::types::transaction::ProvideCallTransaction;
-use crate::impls::types::tx_hash::ProvideFeltTxHash;
-use crate::impls::types::tx_response::ProvideStarknetTxResponse;
-pub use crate::traits::contract::call::ContractCallerComponent;
-pub use crate::traits::contract::declare::ContractDeclarerComponent;
-pub use crate::traits::contract::deploy::ContractDeployerComponent;
-pub use crate::traits::contract::invoke::ContractInvokerComponent;
-pub use crate::traits::contract::message::InvokeContractMessageBuilderComponent;
-pub use crate::traits::messages::transfer::TransferTokenMessageBuilderComponent;
-pub use crate::traits::queries::address::ContractAddressQuerierComponent;
-pub use crate::traits::queries::token_balance::TokenBalanceQuerierComponent;
-pub use crate::traits::transfer::TokenTransferComponent;
-pub use crate::traits::types::blob::BlobTypeComponent;
-pub use crate::traits::types::contract_class::{
-    ContractClassHashTypeComponent, ContractClassTypeComponent,
-};
-pub use crate::traits::types::method::SelectorTypeComponent;
-use crate::types::message_response::UseStarknetMessageResponse;
-use crate::types::messages::erc20::transfer::BuildTransferErc20TokenMessage;
+    use crate::components::types::StarknetChainTypes;
+    use crate::impls::commitment_prefix::GetStarknetCommitmentPrefix;
+    use crate::impls::contract::call::CallStarknetContract;
+    use crate::impls::contract::declare::DeclareSierraContract;
+    use crate::impls::contract::deploy::DeployStarknetContract;
+    use crate::impls::contract::invoke::InvokeStarknetContract;
+    use crate::impls::contract::message::BuildInvokeContractCall;
+    use crate::impls::counterparty_message_height::GetCounterpartyCosmosHeightFromStarknetMessage;
+    use crate::impls::events::UseStarknetEvents;
+    use crate::impls::messages::channel::BuildStarknetChannelHandshakeMessages;
+    use crate::impls::messages::connection::BuildStarknetConnectionHandshakeMessages;
+    use crate::impls::messages::create_client::BuildCreateCometClientMessage;
+    use crate::impls::messages::ibc_transfer::BuildStarknetIbcTransferMessage;
+    use crate::impls::messages::packet::BuildStarknetPacketMessages;
+    use crate::impls::messages::update_client::BuildUpdateCometClientMessage;
+    use crate::impls::packet_fields::ReadPacketSrcStarknetFields;
+    use crate::impls::packet_filter::FilterStarknetPackets;
+    use crate::impls::payload_builders::create_client::BuildStarknetCreateClientPayload;
+    use crate::impls::payload_builders::update_client::BuildStarknetUpdateClientPayload;
+    use crate::impls::queries::ack_commitment::QueryStarknetAckCommitment;
+    use crate::impls::queries::balance::QueryStarknetWalletBalance;
+    use crate::impls::queries::block_events::GetStarknetBlockEvents;
+    use crate::impls::queries::channel_end::QueryChannelEndFromStarknet;
+    use crate::impls::queries::client_state::QueryCometClientState;
+    use crate::impls::queries::connection_end::QueryConnectionEndFromStarknet;
+    use crate::impls::queries::consensus_state::QueryCometConsensusState;
+    use crate::impls::queries::contract_address::GetContractAddressFromField;
+    use crate::impls::queries::counterparty_chain_id::QueryCosmosChainIdFromStarknetChannelId;
+    use crate::impls::queries::packet_commitment::QueryStarknetPacketCommitment;
+    use crate::impls::queries::packet_is_cleared::QueryStarknetPacketIsCleared;
+    use crate::impls::queries::packet_receipt::QueryStarknetPacketReceipt;
+    use crate::impls::queries::packet_received::QueryPacketIsReceivedOnStarknet;
+    use crate::impls::queries::status::QueryStarknetChainStatus;
+    use crate::impls::queries::token_balance::QueryErc20TokenBalance;
+    use crate::impls::send_message::SendCallMessages;
+    use crate::impls::submit_tx::SubmitCallTransaction;
+    use crate::impls::transfer::TransferErc20Token;
+    use crate::impls::tx_response::{DefaultPollTimeout, QueryTransactionReceipt};
+    use crate::impls::types::address::ProvideFeltAddressType;
+    use crate::impls::types::amount::ProvideU256Amount;
+    use crate::impls::types::blob::ProvideFeltBlobType;
+    use crate::impls::types::chain_id::ProvideFeltChainId;
+    use crate::impls::types::client::ProvideStarknetIbcClientTypes;
+    use crate::impls::types::commitment_proof::UseStarknetCommitmentProof;
+    use crate::impls::types::contract::ProvideStarknetContractTypes;
+    use crate::impls::types::denom::ProvideTokenAddressDenom;
+    use crate::impls::types::event::ProvideStarknetEvent;
+    use crate::impls::types::height::ProvideStarknetHeight;
+    use crate::impls::types::message::ProvideCallMessage;
+    use crate::impls::types::method::ProvideFeltSelector;
+    use crate::impls::types::payloads::ProvideStarknetPayloadTypes;
+    use crate::impls::types::status::ProvideStarknetChainStatusType;
+    use crate::impls::types::transaction::ProvideCallTransaction;
+    use crate::impls::types::tx_hash::ProvideFeltTxHash;
+    use crate::impls::types::tx_response::ProvideStarknetTxResponse;
+    use crate::traits::contract::call::ContractCallerComponent;
+    use crate::traits::contract::declare::ContractDeclarerComponent;
+    use crate::traits::contract::deploy::ContractDeployerComponent;
+    use crate::traits::contract::invoke::ContractInvokerComponent;
+    use crate::traits::contract::message::InvokeContractMessageBuilderComponent;
+    use crate::traits::messages::transfer::TransferTokenMessageBuilderComponent;
+    use crate::traits::queries::address::ContractAddressQuerierComponent;
+    use crate::traits::queries::token_balance::TokenBalanceQuerierComponent;
+    use crate::traits::transfer::TokenTransferComponent;
+    use crate::traits::types::blob::BlobTypeComponent;
+    use crate::traits::types::contract_class::{
+        ContractClassHashTypeComponent, ContractClassTypeComponent,
+    };
+    use crate::traits::types::method::SelectorTypeComponent;
+    use crate::types::message_response::UseStarknetMessageResponse;
+    use crate::types::messages::erc20::transfer::BuildTransferErc20TokenMessage;
 
-cgp_preset! {
-    StarknetChainComponents {
-        ChainIdTypeComponent:
-            ProvideFeltChainId,
-        [
-            HeightTypeComponent,
-            HeightFieldComponent,
-            HeightIncrementerComponent,
-        ]:
-            ProvideStarknetHeight,
-        ChainStatusTypeComponent:
-            ProvideStarknetChainStatusType,
-        AddressTypeComponent:
-            ProvideFeltAddressType,
-        BlobTypeComponent:
-            ProvideFeltBlobType,
-        MessageTypeComponent:
-            ProvideCallMessage,
-        EventTypeComponent:
-            ProvideStarknetEvent,
-        [
-            MessageResponseTypeComponent,
-            MessageResponseEventsGetterComponent,
-        ]:
-            UseStarknetMessageResponse,
-        AmountTypeComponent:
-            ProvideU256Amount,
-        DenomTypeComponent:
-            ProvideTokenAddressDenom,
-        MemoTypeComponent:
-            ProvideStringMemoType,
-        TokenIbcTransferrerComponent:
-            SendIbcTransferMessage,
-        TransactionTypeComponent:
-            ProvideCallTransaction,
-        TransactionHashTypeComponent:
-            ProvideFeltTxHash,
-        TxResponseTypeComponent:
-            ProvideStarknetTxResponse,
-        SelectorTypeComponent:
-            ProvideFeltSelector,
-        [
-            ContractClassTypeComponent,
-            ContractClassHashTypeComponent,
-        ]:
-            ProvideStarknetContractTypes,
-        // FIXME: we may have to define our own chain types,
-        // or implement Cairo encoding for the Cosmos types
-        [
-            PortIdTypeComponent,
-            SequenceTypeComponent,
-            OutgoingPacketTypeComponent,
-            TimeTypeComponent,
-            TimeoutTypeComponent,
-        ]:
-            ProvideCosmosChainTypes,
-        [
-            ClientIdTypeComponent,
-            ConnectionIdTypeComponent,
-            ChannelIdTypeComponent,
-            ConnectionEndTypeComponent,
-            ChannelEndTypeComponent,
-        ]:
-            WithProvider<UseDelegatedType<StarknetChainTypes>>,
-        [
-            ClientStateTypeComponent,
-            ConsensusStateTypeComponent,
-            ClientStateFieldsComponent,
-        ]:
-            ProvideStarknetIbcClientTypes,
-        [
-            CreateClientPayloadTypeComponent,
-            CreateClientPayloadOptionsTypeComponent,
-            UpdateClientPayloadTypeComponent,
-        ]:
-            ProvideStarknetPayloadTypes,
-        // FIXME: define our own Starknet init channel options type
-        InitChannelOptionsTypeComponent:
-            ProvideCosmosInitChannelOptionsType,
-        [
-            CommitmentProofTypeComponent,
-            CommitmentProofHeightGetterComponent,
-            CommitmentProofBytesGetterComponent,
-        ]:
-            UseStarknetCommitmentProof,
-        CommitmentPrefixTypeComponent:
-            ProvideCommitmentPrefixBytes,
-        PacketCommitmentTypeComponent:
-            ProvideBytesPacketCommitment,
-        AcknowledgementTypeComponent:
-            ProvideBytesAcknowlegement,
-        PacketReceiptTypeComponent:
-            ProvideBytesPacketReceipt,
-        [
-            PacketSrcPortIdGetterComponent,
-            PacketDstChannelIdGetterComponent,
-            PacketDstPortIdGetterComponent,
-            PacketSequenceGetterComponent,
-            PacketTimeoutHeightGetterComponent,
-            PacketTimeoutTimestampGetterComponent,
-        ]:
-            CosmosPacketFieldReader,
-        [
-            PacketSrcChannelIdGetterComponent,
-        ]:
-            ReadPacketSrcStarknetFields,
-        ChainStatusQuerierComponent:
-            QueryStarknetChainStatus,
-        BlockEventsQuerierComponent:
-            RetryQueryBlockEvents<
-                5,
-                WaitBlockHeightAndQueryEvents<
-                    GetStarknetBlockEvents
-                >>,
-        MessageSenderComponent:
-            SendCallMessages,
-        TxSubmitterComponent:
-            SubmitCallTransaction,
-        TxResponseQuerierComponent:
-            QueryTransactionReceipt,
-        TxResponsePollerComponent:
-            PollTxResponse,
-        PollTimeoutGetterComponent:
-            DefaultPollTimeout,
-        ContractCallerComponent:
-            CallStarknetContract,
-        ContractInvokerComponent:
-            InvokeStarknetContract,
-        ContractDeclarerComponent:
-            DeclareSierraContract,
-        ContractDeployerComponent:
-            DeployStarknetContract,
-        InvokeContractMessageBuilderComponent:
-            BuildInvokeContractCall,
-        IbcCommitmentPrefixGetterComponent:
-            GetStarknetCommitmentPrefix,
-        RetryableErrorComponent:
-            ReturnRetryable<false>,
-        TransferTokenMessageBuilderComponent:
-            BuildTransferErc20TokenMessage,
-        TokenTransferComponent:
-            TransferErc20Token,
-        TokenBalanceQuerierComponent:
-            QueryErc20TokenBalance,
-        BalanceQuerierComponent:
-            QueryStarknetWalletBalance,
-        [
-            CreateClientEventComponent,
-            ConnectionOpenInitEventComponent,
-            ConnectionOpenTryEventComponent,
-            ChannelOpenInitEventComponent,
-            ChannelOpenTryEventComponent,
-            SendPacketEventComponent,
-            WriteAckEventComponent,
-            EventExtractorComponent,
-            MessageResponseExtractorComponent,
-            PacketFromWriteAckEventBuilderComponent,
-            PacketFromSendPacketEventBuilderComponent,
-        ]:
-            UseStarknetEvents,
-        CreateClientMessageOptionsTypeComponent:
-            ProvideNoCreateClientMessageOptionsType,
-        CreateClientPayloadBuilderComponent:
-            BuildStarknetCreateClientPayload,
-        UpdateClientMessageBuilderComponent:
-            BuildUpdateCometClientMessage,
-        CreateClientMessageBuilderComponent:
-            BuildCreateCometClientMessage,
-        UpdateClientPayloadBuilderComponent:
-            BuildStarknetUpdateClientPayload,
-        [
-            ClientStateQuerierComponent,
-            ClientStateWithProofsQuerierComponent,
-        ]:
-            QueryCometClientState,
-        [
-            ConsensusStateQuerierComponent,
-            ConsensusStateWithProofsQuerierComponent,
-        ]:
-            QueryCometConsensusState,
-        ConsensusStateHeightQuerierComponent:
-            QueryConsensusStateHeightsAndFindHeightBefore,
-        ConsensusStateHeightsQuerierComponent:
-            QueryLatestConsensusStateHeightAsHeights,
-        ContractAddressQuerierComponent:
-            GetContractAddressFromField,
-        CounterpartyMessageHeightGetterComponent:
-            GetCounterpartyCosmosHeightFromStarknetMessage,
-        InitConnectionOptionsTypeComponent:
-            ProvideCosmosInitConnectionOptionsType,
-        [
-            ConnectionOpenInitPayloadTypeComponent,
-            ConnectionOpenTryPayloadTypeComponent,
-            ConnectionOpenAckPayloadTypeComponent,
-            ConnectionOpenConfirmPayloadTypeComponent,
-        ]:
-            ProvideConnectionPayloadTypes,
-        [
-            ChannelOpenTryPayloadTypeComponent,
-            ChannelOpenAckPayloadTypeComponent,
-            ChannelOpenConfirmPayloadTypeComponent,
-        ]:
-            ProvideChannelPayloadTypes,
-        [
-            ReceivePacketPayloadTypeComponent,
-            AckPacketPayloadTypeComponent,
-            TimeoutUnorderedPacketPayloadTypeComponent,
-        ]:
-            ProvidePacketPayloadTypes,
-        [
-            ConnectionOpenInitPayloadBuilderComponent,
-            ConnectionOpenTryPayloadBuilderComponent,
-            ConnectionOpenAckPayloadBuilderComponent,
-            ConnectionOpenConfirmPayloadBuilderComponent,
-        ]:
-            BuildConnectionHandshakePayload,
-        [
-            ChannelOpenTryPayloadBuilderComponent,
-            ChannelOpenAckPayloadBuilderComponent,
-            ChannelOpenConfirmPayloadBuilderComponent,
-        ]:
-            BuildChannelHandshakePayload,
-        [
-            ConnectionOpenInitMessageBuilderComponent,
-            ConnectionOpenTryMessageBuilderComponent,
-            ConnectionOpenAckMessageBuilderComponent,
-            ConnectionOpenConfirmMessageBuilderComponent,
-        ]:
-            BuildStarknetConnectionHandshakeMessages,
-        [
-            ChannelOpenInitMessageBuilderComponent,
-            ChannelOpenTryMessageBuilderComponent,
-            ChannelOpenAckMessageBuilderComponent,
-            ChannelOpenConfirmMessageBuilderComponent,
-        ]:
-            BuildStarknetChannelHandshakeMessages,
-        [
-            ReceivePacketMessageBuilderComponent,
-            AckPacketMessageBuilderComponent,
-            TimeoutUnorderedPacketMessageBuilderComponent,
-        ]:
-            BuildStarknetPacketMessages,
-        [
-            ReceivePacketPayloadBuilderComponent,
-            AckPacketPayloadBuilderComponent,
-            TimeoutUnorderedPacketPayloadBuilderComponent,
-        ]:
-            BuildPacketPayloads,
-        [
-            ConnectionEndQuerierComponent,
-            ConnectionEndWithProofsQuerierComponent,
-        ]:
-            QueryConnectionEndFromStarknet,
-        [
-            ChannelEndQuerierComponent,
-            ChannelEndWithProofsQuerierComponent,
-        ]:
-            QueryChannelEndFromStarknet,
-        PacketCommitmentQuerierComponent:
-            QueryStarknetPacketCommitment,
-        PacketAcknowledgementQuerierComponent:
-            QueryStarknetAckCommitment,
-        PacketReceiptQuerierComponent:
-            QueryStarknetPacketReceipt,
-        [
-            OutgoingPacketFilterComponent,
-            IncomingPacketFilterComponent,
-        ]:
-            FilterStarknetPackets,
-        CounterpartyChainIdQuerierComponent:
-            QueryCosmosChainIdFromStarknetChannelId,
-        EventualAmountAsserterComponent:
-            PollAssertEventualAmount,
-        PollAssertDurationGetterComponent:
-            ProvideDefaultPollAssertDuration,
-        IbcTokenTransferMessageBuilderComponent:
-            BuildStarknetIbcTransferMessage,
-        PacketIsReceivedQuerierComponent:
-            QueryPacketIsReceivedOnStarknet,
-        PacketIsClearedQuerierComponent:
-            QueryStarknetPacketIsCleared,
+    cgp_preset! {
+        StarknetChainComponents {
+            ChainIdTypeComponent:
+                ProvideFeltChainId,
+            [
+                HeightTypeComponent,
+                HeightFieldComponent,
+                HeightIncrementerComponent,
+            ]:
+                ProvideStarknetHeight,
+            ChainStatusTypeComponent:
+                ProvideStarknetChainStatusType,
+            AddressTypeComponent:
+                ProvideFeltAddressType,
+            BlobTypeComponent:
+                ProvideFeltBlobType,
+            MessageTypeComponent:
+                ProvideCallMessage,
+            EventTypeComponent:
+                ProvideStarknetEvent,
+            [
+                MessageResponseTypeComponent,
+                MessageResponseEventsGetterComponent,
+            ]:
+                UseStarknetMessageResponse,
+            AmountTypeComponent:
+                ProvideU256Amount,
+            DenomTypeComponent:
+                ProvideTokenAddressDenom,
+            MemoTypeComponent:
+                ProvideStringMemoType,
+            TokenIbcTransferrerComponent:
+                SendIbcTransferMessage,
+            TransactionTypeComponent:
+                ProvideCallTransaction,
+            TransactionHashTypeComponent:
+                ProvideFeltTxHash,
+            TxResponseTypeComponent:
+                ProvideStarknetTxResponse,
+            SelectorTypeComponent:
+                ProvideFeltSelector,
+            [
+                ContractClassTypeComponent,
+                ContractClassHashTypeComponent,
+            ]:
+                ProvideStarknetContractTypes,
+            // FIXME: we may have to define our own chain types,
+            // or implement Cairo encoding for the Cosmos types
+            [
+                PortIdTypeComponent,
+                SequenceTypeComponent,
+                OutgoingPacketTypeComponent,
+                TimeTypeComponent,
+                TimeoutTypeComponent,
+            ]:
+                ProvideCosmosChainTypes,
+            [
+                ClientIdTypeComponent,
+                ConnectionIdTypeComponent,
+                ChannelIdTypeComponent,
+                ConnectionEndTypeComponent,
+                ChannelEndTypeComponent,
+            ]:
+                WithProvider<UseDelegatedType<StarknetChainTypes>>,
+            [
+                ClientStateTypeComponent,
+                ConsensusStateTypeComponent,
+                ClientStateFieldsComponent,
+            ]:
+                ProvideStarknetIbcClientTypes,
+            [
+                CreateClientPayloadTypeComponent,
+                CreateClientPayloadOptionsTypeComponent,
+                UpdateClientPayloadTypeComponent,
+            ]:
+                ProvideStarknetPayloadTypes,
+            // FIXME: define our own Starknet init channel options type
+            InitChannelOptionsTypeComponent:
+                ProvideCosmosInitChannelOptionsType,
+            [
+                CommitmentProofTypeComponent,
+                CommitmentProofHeightGetterComponent,
+                CommitmentProofBytesGetterComponent,
+            ]:
+                UseStarknetCommitmentProof,
+            CommitmentPrefixTypeComponent:
+                ProvideCommitmentPrefixBytes,
+            PacketCommitmentTypeComponent:
+                ProvideBytesPacketCommitment,
+            AcknowledgementTypeComponent:
+                ProvideBytesAcknowlegement,
+            PacketReceiptTypeComponent:
+                ProvideBytesPacketReceipt,
+            [
+                PacketSrcPortIdGetterComponent,
+                PacketDstChannelIdGetterComponent,
+                PacketDstPortIdGetterComponent,
+                PacketSequenceGetterComponent,
+                PacketTimeoutHeightGetterComponent,
+                PacketTimeoutTimestampGetterComponent,
+            ]:
+                CosmosPacketFieldReader,
+            [
+                PacketSrcChannelIdGetterComponent,
+            ]:
+                ReadPacketSrcStarknetFields,
+            ChainStatusQuerierComponent:
+                QueryStarknetChainStatus,
+            BlockEventsQuerierComponent:
+                RetryQueryBlockEvents<
+                    5,
+                    WaitBlockHeightAndQueryEvents<
+                        GetStarknetBlockEvents
+                    >>,
+            MessageSenderComponent:
+                SendCallMessages,
+            TxSubmitterComponent:
+                SubmitCallTransaction,
+            TxResponseQuerierComponent:
+                QueryTransactionReceipt,
+            TxResponsePollerComponent:
+                PollTxResponse,
+            PollTimeoutGetterComponent:
+                DefaultPollTimeout,
+            ContractCallerComponent:
+                CallStarknetContract,
+            ContractInvokerComponent:
+                InvokeStarknetContract,
+            ContractDeclarerComponent:
+                DeclareSierraContract,
+            ContractDeployerComponent:
+                DeployStarknetContract,
+            InvokeContractMessageBuilderComponent:
+                BuildInvokeContractCall,
+            IbcCommitmentPrefixGetterComponent:
+                GetStarknetCommitmentPrefix,
+            RetryableErrorComponent:
+                ReturnRetryable<false>,
+            TransferTokenMessageBuilderComponent:
+                BuildTransferErc20TokenMessage,
+            TokenTransferComponent:
+                TransferErc20Token,
+            TokenBalanceQuerierComponent:
+                QueryErc20TokenBalance,
+            BalanceQuerierComponent:
+                QueryStarknetWalletBalance,
+            [
+                CreateClientEventComponent,
+                ConnectionOpenInitEventComponent,
+                ConnectionOpenTryEventComponent,
+                ChannelOpenInitEventComponent,
+                ChannelOpenTryEventComponent,
+                SendPacketEventComponent,
+                WriteAckEventComponent,
+                EventExtractorComponent,
+                MessageResponseExtractorComponent,
+                PacketFromWriteAckEventBuilderComponent,
+                PacketFromSendPacketEventBuilderComponent,
+            ]:
+                UseStarknetEvents,
+            CreateClientMessageOptionsTypeComponent:
+                ProvideNoCreateClientMessageOptionsType,
+            CreateClientPayloadBuilderComponent:
+                BuildStarknetCreateClientPayload,
+            UpdateClientMessageBuilderComponent:
+                BuildUpdateCometClientMessage,
+            CreateClientMessageBuilderComponent:
+                BuildCreateCometClientMessage,
+            UpdateClientPayloadBuilderComponent:
+                BuildStarknetUpdateClientPayload,
+            [
+                ClientStateQuerierComponent,
+                ClientStateWithProofsQuerierComponent,
+            ]:
+                QueryCometClientState,
+            [
+                ConsensusStateQuerierComponent,
+                ConsensusStateWithProofsQuerierComponent,
+            ]:
+                QueryCometConsensusState,
+            ConsensusStateHeightQuerierComponent:
+                QueryConsensusStateHeightsAndFindHeightBefore,
+            ConsensusStateHeightsQuerierComponent:
+                QueryLatestConsensusStateHeightAsHeights,
+            ContractAddressQuerierComponent:
+                GetContractAddressFromField,
+            CounterpartyMessageHeightGetterComponent:
+                GetCounterpartyCosmosHeightFromStarknetMessage,
+            InitConnectionOptionsTypeComponent:
+                ProvideCosmosInitConnectionOptionsType,
+            [
+                ConnectionOpenInitPayloadTypeComponent,
+                ConnectionOpenTryPayloadTypeComponent,
+                ConnectionOpenAckPayloadTypeComponent,
+                ConnectionOpenConfirmPayloadTypeComponent,
+            ]:
+                ProvideConnectionPayloadTypes,
+            [
+                ChannelOpenTryPayloadTypeComponent,
+                ChannelOpenAckPayloadTypeComponent,
+                ChannelOpenConfirmPayloadTypeComponent,
+            ]:
+                ProvideChannelPayloadTypes,
+            [
+                ReceivePacketPayloadTypeComponent,
+                AckPacketPayloadTypeComponent,
+                TimeoutUnorderedPacketPayloadTypeComponent,
+            ]:
+                ProvidePacketPayloadTypes,
+            [
+                ConnectionOpenInitPayloadBuilderComponent,
+                ConnectionOpenTryPayloadBuilderComponent,
+                ConnectionOpenAckPayloadBuilderComponent,
+                ConnectionOpenConfirmPayloadBuilderComponent,
+            ]:
+                BuildConnectionHandshakePayload,
+            [
+                ChannelOpenTryPayloadBuilderComponent,
+                ChannelOpenAckPayloadBuilderComponent,
+                ChannelOpenConfirmPayloadBuilderComponent,
+            ]:
+                BuildChannelHandshakePayload,
+            [
+                ConnectionOpenInitMessageBuilderComponent,
+                ConnectionOpenTryMessageBuilderComponent,
+                ConnectionOpenAckMessageBuilderComponent,
+                ConnectionOpenConfirmMessageBuilderComponent,
+            ]:
+                BuildStarknetConnectionHandshakeMessages,
+            [
+                ChannelOpenInitMessageBuilderComponent,
+                ChannelOpenTryMessageBuilderComponent,
+                ChannelOpenAckMessageBuilderComponent,
+                ChannelOpenConfirmMessageBuilderComponent,
+            ]:
+                BuildStarknetChannelHandshakeMessages,
+            [
+                ReceivePacketMessageBuilderComponent,
+                AckPacketMessageBuilderComponent,
+                TimeoutUnorderedPacketMessageBuilderComponent,
+            ]:
+                BuildStarknetPacketMessages,
+            [
+                ReceivePacketPayloadBuilderComponent,
+                AckPacketPayloadBuilderComponent,
+                TimeoutUnorderedPacketPayloadBuilderComponent,
+            ]:
+                BuildPacketPayloads,
+            [
+                ConnectionEndQuerierComponent,
+                ConnectionEndWithProofsQuerierComponent,
+            ]:
+                QueryConnectionEndFromStarknet,
+            [
+                ChannelEndQuerierComponent,
+                ChannelEndWithProofsQuerierComponent,
+            ]:
+                QueryChannelEndFromStarknet,
+            PacketCommitmentQuerierComponent:
+                QueryStarknetPacketCommitment,
+            PacketAcknowledgementQuerierComponent:
+                QueryStarknetAckCommitment,
+            PacketReceiptQuerierComponent:
+                QueryStarknetPacketReceipt,
+            [
+                OutgoingPacketFilterComponent,
+                IncomingPacketFilterComponent,
+            ]:
+                FilterStarknetPackets,
+            CounterpartyChainIdQuerierComponent:
+                QueryCosmosChainIdFromStarknetChannelId,
+            EventualAmountAsserterComponent:
+                PollAssertEventualAmount,
+            PollAssertDurationGetterComponent:
+                ProvideDefaultPollAssertDuration,
+            IbcTokenTransferMessageBuilderComponent:
+                BuildStarknetIbcTransferMessage,
+            PacketIsReceivedQuerierComponent:
+                QueryPacketIsReceivedOnStarknet,
+            PacketIsClearedQuerierComponent:
+                QueryStarknetPacketIsCleared,
+        }
     }
 }

--- a/relayer/crates/starknet-chain-components/src/components/encoding/cairo.rs
+++ b/relayer/crates/starknet-chain-components/src/components/encoding/cairo.rs
@@ -1,162 +1,166 @@
-use core::time::Duration;
+#[cgp::re_export_imports]
+mod preset {
+    use core::time::Duration;
 
-use cgp::core::component::{UseContext, UseDelegate};
-use cgp::prelude::*;
-use hermes_cairo_encoding_components::components::encode_mut::*;
-pub use hermes_cairo_encoding_components::components::encoding::*;
-use hermes_cairo_encoding_components::impls::encode_mut::cons::EncoderCons;
-use hermes_cairo_encoding_components::impls::encode_mut::option::EncodeOption;
-use hermes_cairo_encoding_components::impls::encode_mut::pair::EncoderPair;
-use hermes_cairo_encoding_components::impls::encode_mut::reference::EncodeDeref;
-use hermes_cairo_encoding_components::impls::encode_mut::vec::EncodeList;
-use hermes_cairo_encoding_components::strategy::ViaCairo;
-pub use hermes_encoding_components::traits::decode_mut::MutDecoderComponent;
-pub use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
-use ibc::core::host::types::identifiers::ChainId;
-use starknet::core::types::U256;
+    use cgp::core::component::{UseContext, UseDelegate};
+    use cgp::prelude::*;
+    use hermes_cairo_encoding_components::components::encode_mut::*;
+    use hermes_cairo_encoding_components::components::encoding::*;
+    use hermes_cairo_encoding_components::impls::encode_mut::cons::EncoderCons;
+    use hermes_cairo_encoding_components::impls::encode_mut::option::EncodeOption;
+    use hermes_cairo_encoding_components::impls::encode_mut::pair::EncoderPair;
+    use hermes_cairo_encoding_components::impls::encode_mut::reference::EncodeDeref;
+    use hermes_cairo_encoding_components::impls::encode_mut::vec::EncodeList;
+    use hermes_cairo_encoding_components::strategy::ViaCairo;
+    use hermes_encoding_components::traits::decode_mut::MutDecoderComponent;
+    use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
+    use ibc::core::host::types::identifiers::ChainId;
+    use starknet::core::types::U256;
 
-use crate::impls::types::address::{EncodeStarknetAddress, StarknetAddress};
-use crate::types::channel_id::{
-    ChannelCounterparty, ChannelEnd, ChannelId, ChannelState, EncodeChannelCounterparty,
-    EncodeChannelEnd, EncodeChannelId, EncodeChannelState,
-};
-use crate::types::client_id::{ClientId, EncodeClientId};
-use crate::types::connection_id::{
-    ConnectionCounterparty, ConnectionEnd, ConnectionId, ConnectionState,
-    EncodeConnectionCounterparty, EncodeConnectionEnd, EncodeConnectionId, EncodeConnectionState,
-    EncodeDuration,
-};
-use crate::types::cosmos::client_state::{
-    ClientStatus, CometClientState, EncodeChainId, EncodeClientStatus, EncodeCometClientState,
-};
-use crate::types::cosmos::consensus_state::{CometConsensusState, EncodeCometConsensusState};
-use crate::types::cosmos::height::{EncodeHeight, Height};
-use crate::types::cosmos::timestamp::{EncodeTimestamp, Timestamp};
-use crate::types::cosmos::update::{CometUpdateHeader, EncodeCometUpdateHeader};
-use crate::types::message_responses::create_client::{
-    CreateClientResponse, DecodeCreateClientResponse,
-};
-use crate::types::messages::erc20::deploy::{
-    DeployErc20TokenMessage, EncodeDeployErc20TokenMessage,
-};
-use crate::types::messages::erc20::transfer::{
-    EncodeTransferErc20TokenMessage, TransferErc20TokenMessage,
-};
-use crate::types::messages::ibc::channel::{
-    AppVersion, ChannelOrdering, EncodeAppVersion, EncodeChannelOrdering, EncodeMsgChanOpenAck,
-    EncodeMsgChanOpenConfirm, EncodeMsgChanOpenInit, EncodeMsgChanOpenTry, EncodePortId,
-    MsgChanOpenAck, MsgChanOpenConfirm, MsgChanOpenInit, MsgChanOpenTry, PortId,
-};
-use crate::types::messages::ibc::connection::{
-    BasePrefix, ConnectionVersion, EncodeBasePrefix, EncodeConnectionVersion, EncodeMsgConnOpenAck,
-    EncodeMsgConnOpenConfirm, EncodeMsgConnOpenInit, EncodeMsgConnOpenTry, MsgConnOpenAck,
-    MsgConnOpenConfirm, MsgConnOpenInit, MsgConnOpenTry,
-};
-use crate::types::messages::ibc::denom::{
-    Denom, EncodeDenom, EncodePrefixedDenom, EncodeTracePrefix, PrefixedDenom, TracePrefix,
-};
-use crate::types::messages::ibc::ibc_transfer::{
-    EncodeMsgTransfer, EncodeParticipant, EncodeTransferPacketData, MsgTransfer, Participant,
-    TransferPacketData,
-};
-use crate::types::messages::ibc::packet::{
-    AckStatus, Acknowledgement, EncodeAckStatus, EncodeAcknowledgement, EncodeMsgAckPacket,
-    EncodeMsgRecvPacket, EncodeMsgTimeoutPacket, EncodePacket, EncodeSequence, EncodeStateProof,
-    MsgAckPacket, MsgRecvPacket, MsgTimeoutPacket, Packet, Sequence, StateProof,
-};
-use crate::types::register::{
-    EncodeRegisterApp, EncodeRegisterClient, MsgRegisterApp, MsgRegisterClient,
-};
+    use crate::impls::types::address::{EncodeStarknetAddress, StarknetAddress};
+    use crate::types::channel_id::{
+        ChannelCounterparty, ChannelEnd, ChannelId, ChannelState, EncodeChannelCounterparty,
+        EncodeChannelEnd, EncodeChannelId, EncodeChannelState,
+    };
+    use crate::types::client_id::{ClientId, EncodeClientId};
+    use crate::types::connection_id::{
+        ConnectionCounterparty, ConnectionEnd, ConnectionId, ConnectionState,
+        EncodeConnectionCounterparty, EncodeConnectionEnd, EncodeConnectionId,
+        EncodeConnectionState, EncodeDuration,
+    };
+    use crate::types::cosmos::client_state::{
+        ClientStatus, CometClientState, EncodeChainId, EncodeClientStatus, EncodeCometClientState,
+    };
+    use crate::types::cosmos::consensus_state::{CometConsensusState, EncodeCometConsensusState};
+    use crate::types::cosmos::height::{EncodeHeight, Height};
+    use crate::types::cosmos::timestamp::{EncodeTimestamp, Timestamp};
+    use crate::types::cosmos::update::{CometUpdateHeader, EncodeCometUpdateHeader};
+    use crate::types::message_responses::create_client::{
+        CreateClientResponse, DecodeCreateClientResponse,
+    };
+    use crate::types::messages::erc20::deploy::{
+        DeployErc20TokenMessage, EncodeDeployErc20TokenMessage,
+    };
+    use crate::types::messages::erc20::transfer::{
+        EncodeTransferErc20TokenMessage, TransferErc20TokenMessage,
+    };
+    use crate::types::messages::ibc::channel::{
+        AppVersion, ChannelOrdering, EncodeAppVersion, EncodeChannelOrdering, EncodeMsgChanOpenAck,
+        EncodeMsgChanOpenConfirm, EncodeMsgChanOpenInit, EncodeMsgChanOpenTry, EncodePortId,
+        MsgChanOpenAck, MsgChanOpenConfirm, MsgChanOpenInit, MsgChanOpenTry, PortId,
+    };
+    use crate::types::messages::ibc::connection::{
+        BasePrefix, ConnectionVersion, EncodeBasePrefix, EncodeConnectionVersion,
+        EncodeMsgConnOpenAck, EncodeMsgConnOpenConfirm, EncodeMsgConnOpenInit,
+        EncodeMsgConnOpenTry, MsgConnOpenAck, MsgConnOpenConfirm, MsgConnOpenInit, MsgConnOpenTry,
+    };
+    use crate::types::messages::ibc::denom::{
+        Denom, EncodeDenom, EncodePrefixedDenom, EncodeTracePrefix, PrefixedDenom, TracePrefix,
+    };
+    use crate::types::messages::ibc::ibc_transfer::{
+        EncodeMsgTransfer, EncodeParticipant, EncodeTransferPacketData, MsgTransfer, Participant,
+        TransferPacketData,
+    };
+    use crate::types::messages::ibc::packet::{
+        AckStatus, Acknowledgement, EncodeAckStatus, EncodeAcknowledgement, EncodeMsgAckPacket,
+        EncodeMsgRecvPacket, EncodeMsgTimeoutPacket, EncodePacket, EncodeSequence,
+        EncodeStateProof, MsgAckPacket, MsgRecvPacket, MsgTimeoutPacket, Packet, Sequence,
+        StateProof,
+    };
+    use crate::types::register::{
+        EncodeRegisterApp, EncodeRegisterClient, MsgRegisterApp, MsgRegisterClient,
+    };
 
-cgp_preset! {
-    StarknetCairoEncodingComponents {
-        [
-            EncodedTypeComponent,
-            EncodeBufferTypeComponent,
-            EncodeBufferFinalizerComponent,
-            DecodeBufferTypeComponent,
-            DecodeBufferBuilderComponent,
-            DecodeBufferPeekerComponent,
-            EncoderComponent,
-            DecoderComponent,
-        ]: CairoEncodingComponents,
-        [
-            MutEncoderComponent,
-            MutDecoderComponent,
-        ]:
-            UseDelegate<StarknetEncodeMutComponents>
+    cgp_preset! {
+        StarknetCairoEncodingComponents {
+            [
+                EncodedTypeComponent,
+                EncodeBufferTypeComponent,
+                EncodeBufferFinalizerComponent,
+                DecodeBufferTypeComponent,
+                DecodeBufferBuilderComponent,
+                DecodeBufferPeekerComponent,
+                EncoderComponent,
+                DecoderComponent,
+            ]: CairoEncodingComponents,
+            [
+                MutEncoderComponent,
+                MutDecoderComponent,
+            ]:
+                UseDelegate<StarknetEncodeMutComponents>
+        }
     }
-}
 
-pub struct StarknetEncodeMutComponents;
+    pub struct StarknetEncodeMutComponents;
 
-with_cairo_encode_mut_components! {
-    | Components | {
-        delegate_components! {
-            StarknetEncodeMutComponents {
-                Components: UseDelegate<CairoEncodeMutComponents>,
+    with_cairo_encode_mut_components! {
+        | Components | {
+            delegate_components! {
+                StarknetEncodeMutComponents {
+                    Components: UseDelegate<CairoEncodeMutComponents>,
+                }
             }
         }
     }
-}
 
-delegate_components! {
-    StarknetEncodeMutComponents {
-        <'a, V> (ViaCairo, &'a V): EncodeDeref,
-        <V> (ViaCairo, Option<V>): EncodeOption<V>,
-        <A, B> (ViaCairo, (A, B)): EncoderPair<UseContext, UseContext>,
-        <A, B> (ViaCairo, Cons<A, B>): EncoderCons<UseContext, UseContext>,
-        (ViaCairo, TransferErc20TokenMessage): EncodeTransferErc20TokenMessage,
-        (ViaCairo, DeployErc20TokenMessage): EncodeDeployErc20TokenMessage,
-        (ViaCairo, Denom): EncodeDenom,
-        (ViaCairo, TracePrefix): EncodeTracePrefix,
-        (ViaCairo, Vec<TracePrefix>): EncodeList,
-        (ViaCairo, PrefixedDenom): EncodePrefixedDenom,
-        (ViaCairo, Participant): EncodeParticipant,
-        (ViaCairo, TransferPacketData): EncodeTransferPacketData,
-        (ViaCairo, MsgTransfer): EncodeMsgTransfer,
-        (ViaCairo, Height): EncodeHeight,
-        (ViaCairo, Timestamp): EncodeTimestamp,
-        (ViaCairo, StarknetAddress): EncodeStarknetAddress,
-        (ViaCairo, Packet): EncodePacket,
-        (ViaCairo, StateProof): EncodeStateProof,
-        (ViaCairo, MsgRecvPacket): EncodeMsgRecvPacket,
-        (ViaCairo, Acknowledgement): EncodeAcknowledgement,
-        (ViaCairo, MsgAckPacket): EncodeMsgAckPacket,
-        (ViaCairo, AckStatus): EncodeAckStatus,
-        (ViaCairo, Sequence): EncodeSequence,
-        (ViaCairo, Vec<Sequence>): EncodeList,
-        (ViaCairo, MsgTimeoutPacket): EncodeMsgTimeoutPacket,
-        (ViaCairo, ClientStatus): EncodeClientStatus,
-        (ViaCairo, CometClientState): EncodeCometClientState,
-        (ViaCairo, CometConsensusState): EncodeCometConsensusState,
-        (ViaCairo, ClientId): EncodeClientId,
-        (ViaCairo, ChainId): EncodeChainId,
-        (ViaCairo, ConnectionId): EncodeConnectionId,
-        (ViaCairo, Duration): EncodeDuration,
-        (ViaCairo, ConnectionCounterparty): EncodeConnectionCounterparty,
-        (ViaCairo, ConnectionState): EncodeConnectionState,
-        (ViaCairo, ConnectionEnd): EncodeConnectionEnd,
-        (ViaCairo, ChannelId): EncodeChannelId,
-        (ViaCairo, ChannelState): EncodeChannelState,
-        (ViaCairo, ChannelCounterparty): EncodeChannelCounterparty,
-        (ViaCairo, ChannelEnd): EncodeChannelEnd,
-        (ViaCairo, CometUpdateHeader): EncodeCometUpdateHeader,
-        (ViaCairo, CreateClientResponse): DecodeCreateClientResponse,
-        (ViaCairo, MsgRegisterClient): EncodeRegisterClient,
-        (ViaCairo, MsgRegisterApp): EncodeRegisterApp,
-        (ViaCairo, BasePrefix): EncodeBasePrefix,
-        (ViaCairo, ConnectionVersion): EncodeConnectionVersion,
-        (ViaCairo, MsgConnOpenInit): EncodeMsgConnOpenInit,
-        (ViaCairo, MsgConnOpenTry): EncodeMsgConnOpenTry,
-        (ViaCairo, MsgConnOpenAck): EncodeMsgConnOpenAck,
-        (ViaCairo, MsgConnOpenConfirm): EncodeMsgConnOpenConfirm,
-        (ViaCairo, PortId): EncodePortId,
-        (ViaCairo, AppVersion): EncodeAppVersion,
-        (ViaCairo, ChannelOrdering): EncodeChannelOrdering,
-        (ViaCairo, MsgChanOpenInit): EncodeMsgChanOpenInit,
-        (ViaCairo, MsgChanOpenTry): EncodeMsgChanOpenTry,
-        (ViaCairo, MsgChanOpenAck): EncodeMsgChanOpenAck,
-        (ViaCairo, MsgChanOpenConfirm): EncodeMsgChanOpenConfirm,
+    delegate_components! {
+        StarknetEncodeMutComponents {
+            <'a, V> (ViaCairo, &'a V): EncodeDeref,
+            <V> (ViaCairo, Option<V>): EncodeOption<V>,
+            <A, B> (ViaCairo, (A, B)): EncoderPair<UseContext, UseContext>,
+            <A, B> (ViaCairo, Cons<A, B>): EncoderCons<UseContext, UseContext>,
+            (ViaCairo, TransferErc20TokenMessage): EncodeTransferErc20TokenMessage,
+            (ViaCairo, DeployErc20TokenMessage): EncodeDeployErc20TokenMessage,
+            (ViaCairo, Denom): EncodeDenom,
+            (ViaCairo, TracePrefix): EncodeTracePrefix,
+            (ViaCairo, Vec<TracePrefix>): EncodeList,
+            (ViaCairo, PrefixedDenom): EncodePrefixedDenom,
+            (ViaCairo, Participant): EncodeParticipant,
+            (ViaCairo, TransferPacketData): EncodeTransferPacketData,
+            (ViaCairo, MsgTransfer): EncodeMsgTransfer,
+            (ViaCairo, Height): EncodeHeight,
+            (ViaCairo, Timestamp): EncodeTimestamp,
+            (ViaCairo, StarknetAddress): EncodeStarknetAddress,
+            (ViaCairo, Packet): EncodePacket,
+            (ViaCairo, StateProof): EncodeStateProof,
+            (ViaCairo, MsgRecvPacket): EncodeMsgRecvPacket,
+            (ViaCairo, Acknowledgement): EncodeAcknowledgement,
+            (ViaCairo, MsgAckPacket): EncodeMsgAckPacket,
+            (ViaCairo, AckStatus): EncodeAckStatus,
+            (ViaCairo, Sequence): EncodeSequence,
+            (ViaCairo, Vec<Sequence>): EncodeList,
+            (ViaCairo, MsgTimeoutPacket): EncodeMsgTimeoutPacket,
+            (ViaCairo, ClientStatus): EncodeClientStatus,
+            (ViaCairo, CometClientState): EncodeCometClientState,
+            (ViaCairo, CometConsensusState): EncodeCometConsensusState,
+            (ViaCairo, ClientId): EncodeClientId,
+            (ViaCairo, ChainId): EncodeChainId,
+            (ViaCairo, ConnectionId): EncodeConnectionId,
+            (ViaCairo, Duration): EncodeDuration,
+            (ViaCairo, ConnectionCounterparty): EncodeConnectionCounterparty,
+            (ViaCairo, ConnectionState): EncodeConnectionState,
+            (ViaCairo, ConnectionEnd): EncodeConnectionEnd,
+            (ViaCairo, ChannelId): EncodeChannelId,
+            (ViaCairo, ChannelState): EncodeChannelState,
+            (ViaCairo, ChannelCounterparty): EncodeChannelCounterparty,
+            (ViaCairo, ChannelEnd): EncodeChannelEnd,
+            (ViaCairo, CometUpdateHeader): EncodeCometUpdateHeader,
+            (ViaCairo, CreateClientResponse): DecodeCreateClientResponse,
+            (ViaCairo, MsgRegisterClient): EncodeRegisterClient,
+            (ViaCairo, MsgRegisterApp): EncodeRegisterApp,
+            (ViaCairo, BasePrefix): EncodeBasePrefix,
+            (ViaCairo, ConnectionVersion): EncodeConnectionVersion,
+            (ViaCairo, MsgConnOpenInit): EncodeMsgConnOpenInit,
+            (ViaCairo, MsgConnOpenTry): EncodeMsgConnOpenTry,
+            (ViaCairo, MsgConnOpenAck): EncodeMsgConnOpenAck,
+            (ViaCairo, MsgConnOpenConfirm): EncodeMsgConnOpenConfirm,
+            (ViaCairo, PortId): EncodePortId,
+            (ViaCairo, AppVersion): EncodeAppVersion,
+            (ViaCairo, ChannelOrdering): EncodeChannelOrdering,
+            (ViaCairo, MsgChanOpenInit): EncodeMsgChanOpenInit,
+            (ViaCairo, MsgChanOpenTry): EncodeMsgChanOpenTry,
+            (ViaCairo, MsgChanOpenAck): EncodeMsgChanOpenAck,
+            (ViaCairo, MsgChanOpenConfirm): EncodeMsgChanOpenConfirm,
+        }
     }
 }

--- a/relayer/crates/starknet-chain-components/src/components/encoding/event.rs
+++ b/relayer/crates/starknet-chain-components/src/components/encoding/event.rs
@@ -35,6 +35,7 @@ cgp_preset! {
 
 pub struct ProvideEncodedStarknetEventType;
 
+#[cgp_provider(EncodedTypeComponent)]
 impl<Encoding: Async> ProvideEncodedType<Encoding> for ProvideEncodedStarknetEventType {
     type Encoded = StarknetEvent;
 }

--- a/relayer/crates/starknet-chain-components/src/components/encoding/protobuf.rs
+++ b/relayer/crates/starknet-chain-components/src/components/encoding/protobuf.rs
@@ -1,203 +1,208 @@
-use cgp::core::component::{UseContext, UseDelegate};
-use cgp::prelude::*;
-pub use hermes_cosmos_chain_components::encoding::components::{
-    DecodeBufferTypeComponent, EncodeBufferTypeComponent,
-};
-use hermes_encoding_components::impls::types::encoded::ProvideEncodedBytes;
-use hermes_encoding_components::impls::types::schema::ProvideStringSchema;
-pub use hermes_encoding_components::traits::convert::ConverterComponent;
-pub use hermes_encoding_components::traits::decode::DecoderComponent;
-pub use hermes_encoding_components::traits::decode_mut::MutDecoderComponent;
-pub use hermes_encoding_components::traits::encode::EncoderComponent;
-pub use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
-pub use hermes_encoding_components::traits::schema::SchemaGetterComponent;
-pub use hermes_encoding_components::traits::types::encoded::EncodedTypeComponent;
-pub use hermes_encoding_components::traits::types::schema::SchemaTypeComponent;
-use hermes_protobuf_encoding_components::impl_type_url;
-use hermes_protobuf_encoding_components::impls::any::{DecodeAsAnyProtobuf, EncodeAsAnyProtobuf};
-use hermes_protobuf_encoding_components::impls::types::decode_buffer::ProvideProtoChunksDecodeBuffer;
-use hermes_protobuf_encoding_components::impls::types::encode_buffer::ProvideBytesEncodeBuffer;
-pub use hermes_protobuf_encoding_components::traits::length::EncodedLengthGetterComponent;
-use hermes_protobuf_encoding_components::types::strategy::{ViaAny, ViaProtobuf};
-use hermes_wasm_encoding_components::components::WasmEncodingComponents;
-use hermes_wasm_encoding_components::impls::convert::client_message::{
-    DecodeViaClientMessage, EncodeViaClientMessage,
-};
-use hermes_wasm_encoding_components::types::client_message::WasmClientMessage;
-use hermes_wasm_encoding_components::types::client_state::WasmClientState;
-use hermes_wasm_encoding_components::types::consensus_state::WasmConsensusState;
-use ibc::clients::wasm_types::client_message::ClientMessage;
-use ibc::core::client::types::Height;
-use ibc::core::commitment_types::commitment::CommitmentRoot;
-use ibc::primitives::Timestamp;
-use ibc_client_starknet_types::encoding::components::StarknetLightClientEncodingComponents;
-use ibc_client_starknet_types::header::{SignedStarknetHeader, StarknetHeader};
-use prost_types::Any;
+#[cgp::re_export_imports]
+mod preset {
+    use cgp::core::component::{UseContext, UseDelegate};
+    use cgp::prelude::*;
+    use hermes_cosmos_chain_components::encoding::components::{
+        DecodeBufferTypeComponent, EncodeBufferTypeComponent,
+    };
+    use hermes_encoding_components::impls::types::encoded::ProvideEncodedBytes;
+    use hermes_encoding_components::impls::types::schema::ProvideStringSchema;
+    use hermes_encoding_components::traits::convert::ConverterComponent;
+    use hermes_encoding_components::traits::decode::DecoderComponent;
+    use hermes_encoding_components::traits::decode_mut::MutDecoderComponent;
+    use hermes_encoding_components::traits::encode::EncoderComponent;
+    use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
+    use hermes_encoding_components::traits::schema::SchemaGetterComponent;
+    use hermes_encoding_components::traits::types::encoded::EncodedTypeComponent;
+    use hermes_encoding_components::traits::types::schema::SchemaTypeComponent;
+    use hermes_protobuf_encoding_components::impl_type_url;
+    use hermes_protobuf_encoding_components::impls::any::{
+        DecodeAsAnyProtobuf, EncodeAsAnyProtobuf,
+    };
+    use hermes_protobuf_encoding_components::impls::types::decode_buffer::ProvideProtoChunksDecodeBuffer;
+    use hermes_protobuf_encoding_components::impls::types::encode_buffer::ProvideBytesEncodeBuffer;
+    use hermes_protobuf_encoding_components::traits::length::EncodedLengthGetterComponent;
+    use hermes_protobuf_encoding_components::types::strategy::{ViaAny, ViaProtobuf};
+    use hermes_wasm_encoding_components::components::WasmEncodingComponents;
+    use hermes_wasm_encoding_components::impls::convert::client_message::{
+        DecodeViaClientMessage, EncodeViaClientMessage,
+    };
+    use hermes_wasm_encoding_components::types::client_message::WasmClientMessage;
+    use hermes_wasm_encoding_components::types::client_state::WasmClientState;
+    use hermes_wasm_encoding_components::types::consensus_state::WasmConsensusState;
+    use ibc::clients::wasm_types::client_message::ClientMessage;
+    use ibc::core::client::types::Height;
+    use ibc::core::commitment_types::commitment::CommitmentRoot;
+    use ibc::primitives::Timestamp;
+    use ibc_client_starknet_types::encoding::components::StarknetLightClientEncodingComponents;
+    use ibc_client_starknet_types::header::{SignedStarknetHeader, StarknetHeader};
+    use prost_types::Any;
 
-use crate::types::client_state::{
-    ConvertWasmStarknetClientState, StarknetClientState, WasmStarknetClientState,
-};
-use crate::types::consensus_state::{
-    ConvertWasmStarknetConsensusState, StarknetConsensusState, WasmStarknetConsensusState,
-};
+    use crate::types::client_state::{
+        ConvertWasmStarknetClientState, StarknetClientState, WasmStarknetClientState,
+    };
+    use crate::types::consensus_state::{
+        ConvertWasmStarknetConsensusState, StarknetConsensusState, WasmStarknetConsensusState,
+    };
 
-cgp_preset! {
-    StarknetProtobufEncodingComponents {
-        EncodedTypeComponent:
-            ProvideEncodedBytes,
-        SchemaTypeComponent:
-            ProvideStringSchema,
-        EncodeBufferTypeComponent:
-            ProvideBytesEncodeBuffer,
-        DecodeBufferTypeComponent:
-            ProvideProtoChunksDecodeBuffer,
-        ConverterComponent:
-            UseDelegate<StarknetConverterComponents>,
-        [
-            EncoderComponent,
-            DecoderComponent,
-        ]:
-            UseDelegate<StarknetEncoderComponents>,
-        [
-            MutEncoderComponent,
-            MutDecoderComponent,
-            EncodedLengthGetterComponent,
-        ]:
-            UseDelegate<StarknetMutEncoderComponents>,
-        SchemaGetterComponent:
-            UseDelegate<StarknetTypeUrlSchemas>,
+    cgp_preset! {
+        StarknetProtobufEncodingComponents {
+            EncodedTypeComponent:
+                ProvideEncodedBytes,
+            SchemaTypeComponent:
+                ProvideStringSchema,
+            EncodeBufferTypeComponent:
+                ProvideBytesEncodeBuffer,
+            DecodeBufferTypeComponent:
+                ProvideProtoChunksDecodeBuffer,
+            ConverterComponent:
+                UseDelegate<StarknetConverterComponents>,
+            [
+                EncoderComponent,
+                DecoderComponent,
+            ]:
+                UseDelegate<StarknetEncoderComponents>,
+            [
+                MutEncoderComponent,
+                MutDecoderComponent,
+                EncodedLengthGetterComponent,
+            ]:
+                UseDelegate<StarknetMutEncoderComponents>,
+            SchemaGetterComponent:
+                UseDelegate<StarknetTypeUrlSchemas>,
+        }
     }
-}
 
-pub struct StarknetEncoderComponents;
+    pub struct StarknetEncoderComponents;
 
-pub struct StarknetMutEncoderComponents;
+    pub struct StarknetMutEncoderComponents;
 
-pub struct StarknetConverterComponents;
+    pub struct StarknetConverterComponents;
 
-pub struct StarknetTypeUrlSchemas;
+    pub struct StarknetTypeUrlSchemas;
 
-delegate_components! {
-    StarknetEncoderComponents {
-        [
-            (ViaProtobuf, StarknetClientState),
-            (ViaProtobuf, StarknetConsensusState),
-            (ViaProtobuf, StarknetHeader),
-            (ViaProtobuf, SignedStarknetHeader),
+    delegate_components! {
+        StarknetEncoderComponents {
+            [
+                (ViaProtobuf, StarknetClientState),
+                (ViaProtobuf, StarknetConsensusState),
+                (ViaProtobuf, StarknetHeader),
+                (ViaProtobuf, SignedStarknetHeader),
 
-            (ViaAny, StarknetClientState),
-            (ViaAny, StarknetConsensusState),
-            (ViaAny, StarknetHeader),
-            (ViaAny, SignedStarknetHeader),
-        ]:
-            StarknetLightClientEncodingComponents,
+                (ViaAny, StarknetClientState),
+                (ViaAny, StarknetConsensusState),
+                (ViaAny, StarknetHeader),
+                (ViaAny, SignedStarknetHeader),
+            ]:
+                StarknetLightClientEncodingComponents,
 
-        [
-            (ViaProtobuf, Any),
+            [
+                (ViaProtobuf, Any),
 
-            (ViaAny, WasmClientState),
-            (ViaProtobuf, WasmClientState),
+                (ViaAny, WasmClientState),
+                (ViaProtobuf, WasmClientState),
 
-            (ViaAny, WasmConsensusState),
-            (ViaProtobuf, WasmConsensusState),
+                (ViaAny, WasmConsensusState),
+                (ViaProtobuf, WasmConsensusState),
 
-            (ViaAny, WasmClientMessage),
-            (ViaProtobuf, WasmClientMessage),
-        ]:
-            WasmEncodingComponents,
+                (ViaAny, WasmClientMessage),
+                (ViaProtobuf, WasmClientMessage),
+            ]:
+                WasmEncodingComponents,
+        }
     }
-}
 
-delegate_components! {
-    StarknetMutEncoderComponents {
-        [
-            (ViaProtobuf, Height),
-            (ViaProtobuf, WasmClientState),
-            (ViaProtobuf, WasmConsensusState),
-            (ViaProtobuf, WasmClientMessage),
-        ]: WasmEncodingComponents,
+    delegate_components! {
+        StarknetMutEncoderComponents {
+            [
+                (ViaProtobuf, Height),
+                (ViaProtobuf, WasmClientState),
+                (ViaProtobuf, WasmConsensusState),
+                (ViaProtobuf, WasmClientMessage),
+            ]: WasmEncodingComponents,
 
-        [
-            (ViaProtobuf, StarknetClientState),
-            (ViaProtobuf, StarknetConsensusState),
-            (ViaProtobuf, StarknetHeader),
-            (ViaProtobuf, SignedStarknetHeader),
-            (ViaProtobuf, CommitmentRoot),
-            (ViaProtobuf, Timestamp),
-        ]:
-            StarknetLightClientEncodingComponents,
+            [
+                (ViaProtobuf, StarknetClientState),
+                (ViaProtobuf, StarknetConsensusState),
+                (ViaProtobuf, StarknetHeader),
+                (ViaProtobuf, SignedStarknetHeader),
+                (ViaProtobuf, CommitmentRoot),
+                (ViaProtobuf, Timestamp),
+            ]:
+                StarknetLightClientEncodingComponents,
+        }
     }
-}
 
-delegate_components! {
-    StarknetConverterComponents {
-        (ClientMessage, Any): EncodeAsAnyProtobuf<ViaProtobuf, UseContext>,
-        (Any, ClientMessage): DecodeAsAnyProtobuf<ViaProtobuf, UseContext>,
+    delegate_components! {
+        StarknetConverterComponents {
+            (ClientMessage, Any): EncodeAsAnyProtobuf<ViaProtobuf, UseContext>,
+            (Any, ClientMessage): DecodeAsAnyProtobuf<ViaProtobuf, UseContext>,
 
-        (StarknetHeader, Any):
-            EncodeViaClientMessage,
+            (StarknetHeader, Any):
+                EncodeViaClientMessage,
 
-        (Any, StarknetHeader):
-            DecodeViaClientMessage,
+            (Any, StarknetHeader):
+                DecodeViaClientMessage,
 
-        (SignedStarknetHeader, Any):
-            EncodeViaClientMessage,
+            (SignedStarknetHeader, Any):
+                EncodeViaClientMessage,
 
-        (Any, SignedStarknetHeader):
-            DecodeViaClientMessage,
+            (Any, SignedStarknetHeader):
+                DecodeViaClientMessage,
 
-        [
-            (StarknetClientState, Any),
-            (Any, StarknetClientState),
-            (StarknetConsensusState, Any),
-            (Any, StarknetConsensusState),
-        ]:
-            StarknetLightClientEncodingComponents,
+            [
+                (StarknetClientState, Any),
+                (Any, StarknetClientState),
+                (StarknetConsensusState, Any),
+                (Any, StarknetConsensusState),
+            ]:
+                StarknetLightClientEncodingComponents,
 
-        [
-            (WasmClientState, Any),
-            (Any, WasmClientState),
-            (WasmConsensusState, Any),
-            (Any, WasmConsensusState),
-        ]:
-            WasmEncodingComponents,
+            [
+                (WasmClientState, Any),
+                (Any, WasmClientState),
+                (WasmConsensusState, Any),
+                (Any, WasmConsensusState),
+            ]:
+                WasmEncodingComponents,
 
-        [
-            (Any, WasmStarknetClientState),
-            (WasmStarknetClientState, Any),
-        ]:
-            ConvertWasmStarknetClientState,
+            [
+                (Any, WasmStarknetClientState),
+                (WasmStarknetClientState, Any),
+            ]:
+                ConvertWasmStarknetClientState,
 
-        [
-            (Any, WasmStarknetConsensusState),
-            (WasmStarknetConsensusState, Any),
-        ]:
-            ConvertWasmStarknetConsensusState,
+            [
+                (Any, WasmStarknetConsensusState),
+                (WasmStarknetConsensusState, Any),
+            ]:
+                ConvertWasmStarknetConsensusState,
+        }
     }
-}
 
-delegate_components! {
-    StarknetTypeUrlSchemas {
-        ClientMessage: Self,
+    delegate_components! {
+        StarknetTypeUrlSchemas {
+            ClientMessage: Self,
 
-        [
-            StarknetClientState,
-            StarknetConsensusState,
-            StarknetHeader,
-            SignedStarknetHeader,
-        ]:
-            StarknetLightClientEncodingComponents,
+            [
+                StarknetClientState,
+                StarknetConsensusState,
+                StarknetHeader,
+                SignedStarknetHeader,
+            ]:
+                StarknetLightClientEncodingComponents,
 
-        [
-            WasmClientState,
-            WasmConsensusState,
-        ]:
-            WasmEncodingComponents,
+            [
+                WasmClientState,
+                WasmConsensusState,
+            ]:
+                WasmEncodingComponents,
+        }
     }
-}
 
-impl_type_url!(
-    StarknetTypeUrlSchemas,
-    ClientMessage,
-    "/ibc.lightclients.wasm.v1.ClientMessage",
-);
+    impl_type_url!(
+        StarknetTypeUrlSchemas,
+        ClientMessage,
+        "/ibc.lightclients.wasm.v1.ClientMessage",
+    );
+}

--- a/relayer/crates/starknet-chain-components/src/components/starknet_to_cosmos.rs
+++ b/relayer/crates/starknet-chain-components/src/components/starknet_to_cosmos.rs
@@ -1,105 +1,108 @@
-use cgp::core::types::WithType;
-use cgp::prelude::*;
-use hermes_chain_components::traits::types::ibc::CounterpartyMessageHeightGetterComponent;
-use hermes_cosmos_chain_components::components::client::{
-    AckPacketMessageBuilderComponent, ChannelOpenAckMessageBuilderComponent,
-    ChannelOpenConfirmMessageBuilderComponent, ChannelOpenInitMessageBuilderComponent,
-    ChannelOpenTryMessageBuilderComponent, ClientStateFieldsComponent, ClientStateTypeComponent,
-    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
-    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
-    ConsensusStateHeightsQuerierComponent, ConsensusStateTypeComponent,
-    CreateClientMessageBuilderComponent, CreateClientMessageOptionsTypeComponent,
-    CreateClientPayloadBuilderComponent, CreateClientPayloadOptionsTypeComponent,
-    CreateClientPayloadTypeComponent, PacketDstChannelIdGetterComponent,
-    PacketDstPortIdGetterComponent, PacketSequenceGetterComponent,
-    PacketSrcChannelIdGetterComponent, PacketSrcPortIdGetterComponent,
-    PacketTimeoutHeightGetterComponent, PacketTimeoutTimestampGetterComponent,
-    ReceivePacketMessageBuilderComponent, TimeoutUnorderedPacketMessageBuilderComponent,
-    UpdateClientMessageBuilderComponent, UpdateClientPayloadBuilderComponent,
-    UpdateClientPayloadTypeComponent,
-};
-use hermes_cosmos_chain_components::components::cosmos_to_cosmos::CosmosToCosmosComponents;
-use hermes_cosmos_chain_components::impls::packet::packet_fields::CosmosPacketFieldReader;
-use hermes_cosmos_chain_components::impls::packet::packet_message::BuildCosmosPacketMessages;
-use hermes_relayer_components::chain::traits::queries::client_state::{
-    ClientStateQuerierComponent, ClientStateWithProofsQuerierComponent,
-};
-use hermes_relayer_components::chain::traits::queries::consensus_state::{
-    ConsensusStateQuerierComponent, ConsensusStateWithProofsQuerierComponent,
-};
+#[cgp::re_export_imports]
+mod preset {
+    use cgp::core::types::WithType;
+    use cgp::prelude::*;
+    use hermes_chain_components::traits::types::ibc::CounterpartyMessageHeightGetterComponent;
+    use hermes_cosmos_chain_components::components::client::{
+        AckPacketMessageBuilderComponent, ChannelOpenAckMessageBuilderComponent,
+        ChannelOpenConfirmMessageBuilderComponent, ChannelOpenInitMessageBuilderComponent,
+        ChannelOpenTryMessageBuilderComponent, ClientStateFieldsComponent,
+        ClientStateTypeComponent, ConnectionOpenAckMessageBuilderComponent,
+        ConnectionOpenConfirmMessageBuilderComponent, ConnectionOpenInitMessageBuilderComponent,
+        ConnectionOpenTryMessageBuilderComponent, ConsensusStateHeightsQuerierComponent,
+        ConsensusStateTypeComponent, CreateClientMessageBuilderComponent,
+        CreateClientMessageOptionsTypeComponent, CreateClientPayloadBuilderComponent,
+        CreateClientPayloadOptionsTypeComponent, CreateClientPayloadTypeComponent,
+        PacketDstChannelIdGetterComponent, PacketDstPortIdGetterComponent,
+        PacketSequenceGetterComponent, PacketSrcChannelIdGetterComponent,
+        PacketSrcPortIdGetterComponent, PacketTimeoutHeightGetterComponent,
+        PacketTimeoutTimestampGetterComponent, ReceivePacketMessageBuilderComponent,
+        TimeoutUnorderedPacketMessageBuilderComponent, UpdateClientMessageBuilderComponent,
+        UpdateClientPayloadBuilderComponent, UpdateClientPayloadTypeComponent,
+    };
+    use hermes_cosmos_chain_components::components::cosmos_to_cosmos::CosmosToCosmosComponents;
+    use hermes_cosmos_chain_components::impls::packet::packet_fields::CosmosPacketFieldReader;
+    use hermes_cosmos_chain_components::impls::packet::packet_message::BuildCosmosPacketMessages;
+    use hermes_relayer_components::chain::traits::queries::client_state::{
+        ClientStateQuerierComponent, ClientStateWithProofsQuerierComponent,
+    };
+    use hermes_relayer_components::chain::traits::queries::consensus_state::{
+        ConsensusStateQuerierComponent, ConsensusStateWithProofsQuerierComponent,
+    };
 
-use crate::impls::starknet_to_cosmos::channel_message::BuildStarknetToCosmosChannelHandshakeMessage;
-use crate::impls::starknet_to_cosmos::connection_message::BuildStarknetToCosmosConnectionHandshake;
-use crate::impls::starknet_to_cosmos::counterparty_message_height::GetCosmosCounterpartyMessageStarknetHeight;
-use crate::impls::starknet_to_cosmos::create_client_message::BuildStarknetCreateClientMessage;
-use crate::impls::starknet_to_cosmos::packet_fields::ReadPacketDstStarknetFields;
-use crate::impls::starknet_to_cosmos::query_consensus_state_height::QueryStarknetConsensusStateHeightsFromGrpc;
-use crate::impls::starknet_to_cosmos::update_client_message::BuildStarknetUpdateClientMessage;
-use crate::types::cosmos::client_state::UseCometClientState;
-use crate::types::cosmos::consensus_state::CometConsensusState;
+    use crate::impls::starknet_to_cosmos::channel_message::BuildStarknetToCosmosChannelHandshakeMessage;
+    use crate::impls::starknet_to_cosmos::connection_message::BuildStarknetToCosmosConnectionHandshake;
+    use crate::impls::starknet_to_cosmos::counterparty_message_height::GetCosmosCounterpartyMessageStarknetHeight;
+    use crate::impls::starknet_to_cosmos::create_client_message::BuildStarknetCreateClientMessage;
+    use crate::impls::starknet_to_cosmos::packet_fields::ReadPacketDstStarknetFields;
+    use crate::impls::starknet_to_cosmos::query_consensus_state_height::QueryStarknetConsensusStateHeightsFromGrpc;
+    use crate::impls::starknet_to_cosmos::update_client_message::BuildStarknetUpdateClientMessage;
+    use crate::types::cosmos::client_state::UseCometClientState;
+    use crate::types::cosmos::consensus_state::CometConsensusState;
 
-cgp_preset! {
-    StarknetToCosmosComponents {
-        [
-            ClientStateQuerierComponent,
-            ClientStateWithProofsQuerierComponent,
-            ConsensusStateQuerierComponent,
-            ConsensusStateWithProofsQuerierComponent,
-            CreateClientPayloadTypeComponent,
-            UpdateClientPayloadTypeComponent,
-            CreateClientMessageOptionsTypeComponent,
-            CreateClientPayloadOptionsTypeComponent,
-            CreateClientPayloadBuilderComponent,
-            UpdateClientPayloadBuilderComponent,
-            ChannelOpenInitMessageBuilderComponent,
-        ]:
-            CosmosToCosmosComponents,
-        CreateClientMessageBuilderComponent:
-            BuildStarknetCreateClientMessage,
-        [
-            ClientStateTypeComponent,
-            ClientStateFieldsComponent,
-        ]:
-            UseCometClientState,
-        ConsensusStateTypeComponent:
-            WithType<CometConsensusState>,
-        UpdateClientMessageBuilderComponent:
-            BuildStarknetUpdateClientMessage,
-        ConsensusStateHeightsQuerierComponent:
-            QueryStarknetConsensusStateHeightsFromGrpc,
-        CounterpartyMessageHeightGetterComponent:
-            GetCosmosCounterpartyMessageStarknetHeight,
-        [
-            ConnectionOpenInitMessageBuilderComponent,
-            ConnectionOpenTryMessageBuilderComponent,
-            ConnectionOpenAckMessageBuilderComponent,
-            ConnectionOpenConfirmMessageBuilderComponent,
-        ]:
-            BuildStarknetToCosmosConnectionHandshake,
-        [
-            ChannelOpenTryMessageBuilderComponent,
-            ChannelOpenAckMessageBuilderComponent,
-            ChannelOpenConfirmMessageBuilderComponent,
-        ]:
-            BuildStarknetToCosmosChannelHandshakeMessage,
-        [
-            PacketSrcChannelIdGetterComponent,
-            PacketSrcPortIdGetterComponent,
-            PacketDstPortIdGetterComponent,
-            PacketSequenceGetterComponent,
-            PacketTimeoutTimestampGetterComponent,
-        ]:
-            CosmosPacketFieldReader,
-        [
-            PacketTimeoutHeightGetterComponent,
-            PacketDstChannelIdGetterComponent,
-        ]:
-            ReadPacketDstStarknetFields,
-        [
-            ReceivePacketMessageBuilderComponent,
-            AckPacketMessageBuilderComponent,
-            TimeoutUnorderedPacketMessageBuilderComponent,
-        ]:
-            BuildCosmosPacketMessages,
+    cgp_preset! {
+        StarknetToCosmosComponents {
+            [
+                ClientStateQuerierComponent,
+                ClientStateWithProofsQuerierComponent,
+                ConsensusStateQuerierComponent,
+                ConsensusStateWithProofsQuerierComponent,
+                CreateClientPayloadTypeComponent,
+                UpdateClientPayloadTypeComponent,
+                CreateClientMessageOptionsTypeComponent,
+                CreateClientPayloadOptionsTypeComponent,
+                CreateClientPayloadBuilderComponent,
+                UpdateClientPayloadBuilderComponent,
+                ChannelOpenInitMessageBuilderComponent,
+            ]:
+                CosmosToCosmosComponents,
+            CreateClientMessageBuilderComponent:
+                BuildStarknetCreateClientMessage,
+            [
+                ClientStateTypeComponent,
+                ClientStateFieldsComponent,
+            ]:
+                UseCometClientState,
+            ConsensusStateTypeComponent:
+                WithType<CometConsensusState>,
+            UpdateClientMessageBuilderComponent:
+                BuildStarknetUpdateClientMessage,
+            ConsensusStateHeightsQuerierComponent:
+                QueryStarknetConsensusStateHeightsFromGrpc,
+            CounterpartyMessageHeightGetterComponent:
+                GetCosmosCounterpartyMessageStarknetHeight,
+            [
+                ConnectionOpenInitMessageBuilderComponent,
+                ConnectionOpenTryMessageBuilderComponent,
+                ConnectionOpenAckMessageBuilderComponent,
+                ConnectionOpenConfirmMessageBuilderComponent,
+            ]:
+                BuildStarknetToCosmosConnectionHandshake,
+            [
+                ChannelOpenTryMessageBuilderComponent,
+                ChannelOpenAckMessageBuilderComponent,
+                ChannelOpenConfirmMessageBuilderComponent,
+            ]:
+                BuildStarknetToCosmosChannelHandshakeMessage,
+            [
+                PacketSrcChannelIdGetterComponent,
+                PacketSrcPortIdGetterComponent,
+                PacketDstPortIdGetterComponent,
+                PacketSequenceGetterComponent,
+                PacketTimeoutTimestampGetterComponent,
+            ]:
+                CosmosPacketFieldReader,
+            [
+                PacketTimeoutHeightGetterComponent,
+                PacketDstChannelIdGetterComponent,
+            ]:
+                ReadPacketDstStarknetFields,
+            [
+                ReceivePacketMessageBuilderComponent,
+                AckPacketMessageBuilderComponent,
+                TimeoutUnorderedPacketMessageBuilderComponent,
+            ]:
+                BuildCosmosPacketMessages,
+        }
     }
 }

--- a/relayer/crates/starknet-chain-components/src/components/types.rs
+++ b/relayer/crates/starknet-chain-components/src/components/types.rs
@@ -1,19 +1,22 @@
-use cgp::prelude::*;
-use hermes_cosmos_chain_components::components::client::{
-    ChannelEndTypeComponent, ChannelIdTypeComponent, ClientIdTypeComponent,
-    ConnectionEndTypeComponent, ConnectionIdTypeComponent,
-};
+#[cgp::re_export_imports]
+mod preset {
+    use cgp::prelude::*;
+    use hermes_cosmos_chain_components::components::client::{
+        ChannelEndTypeComponent, ChannelIdTypeComponent, ClientIdTypeComponent,
+        ConnectionEndTypeComponent, ConnectionIdTypeComponent,
+    };
 
-use crate::types::channel_id::{ChannelEnd, ChannelId};
-use crate::types::client_id::ClientId;
-use crate::types::connection_id::{ConnectionEnd, ConnectionId};
+    use crate::types::channel_id::{ChannelEnd, ChannelId};
+    use crate::types::client_id::ClientId;
+    use crate::types::connection_id::{ConnectionEnd, ConnectionId};
 
-cgp_preset! {
-    StarknetChainTypes {
-        ClientIdTypeComponent: ClientId,
-        ConnectionIdTypeComponent: ConnectionId,
-        ChannelIdTypeComponent: ChannelId,
-        ConnectionEndTypeComponent: ConnectionEnd,
-        ChannelEndTypeComponent: ChannelEnd,
+    cgp_preset! {
+        StarknetChainTypes {
+            ClientIdTypeComponent: ClientId,
+            ConnectionIdTypeComponent: ConnectionId,
+            ChannelIdTypeComponent: ChannelId,
+            ConnectionEndTypeComponent: ConnectionEnd,
+            ChannelEndTypeComponent: ChannelEnd,
+        }
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/account.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/account.rs
@@ -5,10 +5,12 @@ use starknet::accounts::ConnectedAccount;
 
 use crate::traits::account::{
     HasStarknetAccountType, ProvideStarknetAccountType, StarknetAccountGetter,
+    StarknetAccountGetterComponent, StarknetAccountTypeComponent,
 };
 
 pub struct GetStarknetAccountField<Tag>(pub PhantomData<Tag>);
 
+#[cgp_provider(StarknetAccountTypeComponent)]
 impl<Chain, Tag> ProvideStarknetAccountType<Chain> for GetStarknetAccountField<Tag>
 where
     Chain: Async + HasField<Tag>,
@@ -18,6 +20,7 @@ where
     type Account = Chain::Value;
 }
 
+#[cgp_provider(StarknetAccountGetterComponent)]
 impl<Chain, Tag> StarknetAccountGetter<Chain> for GetStarknetAccountField<Tag>
 where
     Chain: Async + HasStarknetAccountType + HasField<Tag, Value = Chain::Account>,

--- a/relayer/crates/starknet-chain-components/src/impls/commitment_prefix.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/commitment_prefix.rs
@@ -1,11 +1,13 @@
 use std::sync::LazyLock;
 
+use cgp::prelude::*;
 use hermes_chain_components::traits::commitment_prefix::{
-    HasCommitmentPrefixType, IbcCommitmentPrefixGetter,
+    HasCommitmentPrefixType, IbcCommitmentPrefixGetter, IbcCommitmentPrefixGetterComponent,
 };
 
 pub struct GetStarknetCommitmentPrefix;
 
+#[cgp_provider(IbcCommitmentPrefixGetterComponent)]
 impl<Chain> IbcCommitmentPrefixGetter<Chain> for GetStarknetCommitmentPrefix
 where
     Chain: HasCommitmentPrefixType<CommitmentPrefix = Vec<u8>>,

--- a/relayer/crates/starknet-chain-components/src/impls/contract/call.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/call.rs
@@ -1,8 +1,9 @@
-use cgp::core::error::CanRaiseAsyncError;
+use cgp::prelude::*;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use starknet::core::types::{BlockId, BlockTag, Felt, FunctionCall};
 use starknet::providers::{Provider, ProviderError};
 
+use crate::components::chain::ContractCallerComponent;
 use crate::impls::types::address::StarknetAddress;
 use crate::traits::contract::call::ContractCaller;
 use crate::traits::provider::HasStarknetProvider;
@@ -11,6 +12,7 @@ use crate::traits::types::method::HasSelectorType;
 
 pub struct CallStarknetContract;
 
+#[cgp_provider(ContractCallerComponent)]
 impl<Chain> ContractCaller<Chain> for CallStarknetContract
 where
     Chain: HasAddressType<Address = StarknetAddress>

--- a/relayer/crates/starknet-chain-components/src/impls/contract/declare.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/declare.rs
@@ -5,6 +5,7 @@ use cairo_lang_starknet_classes::casm_contract_class::{
 };
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use cgp::core::error::CanRaiseAsyncError;
+use cgp::prelude::*;
 use hermes_relayer_components::transaction::traits::poll_tx_response::CanPollTxResponse;
 use starknet::accounts::Account;
 use starknet::core::types::contract::{
@@ -13,6 +14,7 @@ use starknet::core::types::contract::{
 use starknet::core::types::{BlockId, BlockTag, Felt, RevertedInvocation};
 use starknet::providers::Provider;
 
+use crate::components::chain::ContractDeclarerComponent;
 use crate::traits::account::{CanRaiseAccountErrors, HasStarknetAccount};
 use crate::traits::contract::declare::ContractDeclarer;
 use crate::traits::provider::HasStarknetProvider;
@@ -21,6 +23,7 @@ use crate::types::tx_response::TxResponse;
 
 pub struct DeclareSierraContract;
 
+#[cgp_provider(ContractDeclarerComponent)]
 impl<Chain> ContractDeclarer<Chain> for DeclareSierraContract
 where
     Chain: HasContractClassType<ContractClass = SierraClass>

--- a/relayer/crates/starknet-chain-components/src/impls/contract/deploy.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/deploy.rs
@@ -1,4 +1,4 @@
-use cgp::core::error::CanRaiseAsyncError;
+use cgp::prelude::*;
 use hermes_relayer_components::transaction::traits::poll_tx_response::CanPollTxResponse;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use starknet::contract::ContractFactory;
@@ -6,6 +6,7 @@ use starknet::core::types::{Felt, RevertedInvocation};
 use starknet::macros::felt;
 use starknet::signers::SigningKey;
 
+use crate::components::chain::ContractDeployerComponent;
 use crate::impls::types::address::StarknetAddress;
 use crate::traits::account::{CanRaiseAccountErrors, HasStarknetAccount};
 use crate::traits::contract::deploy::ContractDeployer;
@@ -18,6 +19,7 @@ pub struct DeployStarknetContract;
 const DEFAULT_UDC_ADDRESS: Felt =
     felt!("0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf");
 
+#[cgp_provider(ContractDeployerComponent)]
 impl<Chain> ContractDeployer<Chain> for DeployStarknetContract
 where
     Chain: HasContractClassHashType<ContractClassHash = Felt>

--- a/relayer/crates/starknet-chain-components/src/impls/contract/invoke.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/invoke.rs
@@ -1,10 +1,13 @@
+use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::send_message::CanSendSingleMessage;
 
+use crate::components::chain::ContractInvokerComponent;
 use crate::traits::contract::invoke::ContractInvoker;
 use crate::traits::contract::message::CanBuildInvokeContractMessage;
 
 pub struct InvokeStarknetContract;
 
+#[cgp_provider(ContractInvokerComponent)]
 impl<Chain> ContractInvoker<Chain> for InvokeStarknetContract
 where
     Chain: CanBuildInvokeContractMessage + CanSendSingleMessage,

--- a/relayer/crates/starknet-chain-components/src/impls/contract/message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/message.rs
@@ -1,8 +1,10 @@
+use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use starknet::accounts::Call;
 use starknet::core::types::Felt;
 
+use crate::components::chain::InvokeContractMessageBuilderComponent;
 use crate::impls::types::address::StarknetAddress;
 use crate::impls::types::message::StarknetMessage;
 use crate::traits::contract::message::InvokeContractMessageBuilder;
@@ -11,6 +13,7 @@ use crate::traits::types::method::HasSelectorType;
 
 pub struct BuildInvokeContractCall;
 
+#[cgp_provider(InvokeContractMessageBuilderComponent)]
 impl<Chain> InvokeContractMessageBuilder<Chain> for BuildInvokeContractCall
 where
     Chain: HasAddressType<Address = StarknetAddress>

--- a/relayer/crates/starknet-chain-components/src/impls/counterparty_message_height.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/counterparty_message_height.rs
@@ -1,12 +1,15 @@
+use cgp::prelude::*;
 use hermes_chain_components::traits::types::height::HasHeightType;
 use hermes_chain_components::traits::types::ibc::CounterpartyMessageHeightGetter;
 use hermes_chain_components::traits::types::message::HasMessageType;
+use hermes_cosmos_chain_components::components::client::CounterpartyMessageHeightGetterComponent;
 use ibc::core::client::types::Height;
 
 use crate::impls::types::message::StarknetMessage;
 
 pub struct GetCounterpartyCosmosHeightFromStarknetMessage;
 
+#[cgp_provider(CounterpartyMessageHeightGetterComponent)]
 impl<Chain, Counterparty> CounterpartyMessageHeightGetter<Chain, Counterparty>
     for GetCounterpartyCosmosHeightFromStarknetMessage
 where

--- a/relayer/crates/starknet-chain-components/src/impls/encoding/class_hash.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/encoding/class_hash.rs
@@ -1,14 +1,16 @@
 use core::marker::PhantomData;
 use std::collections::HashSet;
 
-use cgp::prelude::HasField;
+use cgp::prelude::*;
 use hermes_encoding_components::traits::decode::{CanDecode, Decoder};
+use hermes_wasm_encoding_components::components::DecoderComponent;
 use starknet::core::types::Felt;
 
 use crate::types::event::StarknetEvent;
 
 pub struct DecodeOptionalByClassHash<Tag>(pub PhantomData<Tag>);
 
+#[cgp_provider(DecoderComponent)]
 impl<Encoding, Strategy, Value, Tag> Decoder<Encoding, Strategy, Option<Value>>
     for DecodeOptionalByClassHash<Tag>
 where

--- a/relayer/crates/starknet-chain-components/src/impls/encoding/contract_address.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/encoding/contract_address.rs
@@ -1,14 +1,16 @@
 use core::marker::PhantomData;
 use std::collections::HashSet;
 
-use cgp::prelude::HasField;
+use cgp::prelude::*;
 use hermes_encoding_components::traits::decode::{CanDecode, Decoder};
+use hermes_wasm_encoding_components::components::DecoderComponent;
 
 use crate::impls::types::address::StarknetAddress;
 use crate::types::event::StarknetEvent;
 
 pub struct DecodeOptionalByContractAddress<Tag>(pub PhantomData<Tag>);
 
+#[cgp_provider(DecoderComponent)]
 impl<Encoding, Strategy, Value, Tag> Decoder<Encoding, Strategy, Option<Value>>
     for DecodeOptionalByContractAddress<Tag>
 where

--- a/relayer/crates/starknet-chain-components/src/impls/error/account.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/error/account.rs
@@ -1,11 +1,13 @@
 use core::fmt::Debug;
 
-use cgp::core::error::{CanRaiseAsyncError, ErrorRaiser};
+use cgp::core::error::{ErrorRaiser, ErrorRaiserComponent};
+use cgp::prelude::*;
 use starknet::accounts::AccountError;
 use starknet::providers::ProviderError;
 
 pub struct RaiseAccountError;
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl<Context, S> ErrorRaiser<Context, AccountError<S>> for RaiseAccountError
 where
     Context: CanRaiseAsyncError<ProviderError> + CanRaiseAsyncError<String>,

--- a/relayer/crates/starknet-chain-components/src/impls/error/provider.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/error/provider.rs
@@ -1,9 +1,11 @@
-use cgp::core::error::{CanRaiseAsyncError, ErrorRaiser};
+use cgp::core::error::{ErrorRaiser, ErrorRaiserComponent};
+use cgp::prelude::*;
 use starknet::core::types::StarknetError;
 use starknet::providers::ProviderError;
 
 pub struct RaiseProviderError;
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl<Context> ErrorRaiser<Context, ProviderError> for RaiseProviderError
 where
     Context: CanRaiseAsyncError<StarknetError> + CanRaiseAsyncError<String>,

--- a/relayer/crates/starknet-chain-components/src/impls/error/starknet.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/error/starknet.rs
@@ -1,8 +1,9 @@
-use cgp::core::error::{CanRaiseAsyncError, ErrorRaiser};
+use cgp::core::error::{ErrorRaiser, ErrorRaiserComponent};
+use cgp::prelude::*;
 use starknet::core::types::StarknetError;
-
 pub struct RaiseStarknetError;
 
+#[cgp_provider(ErrorRaiserComponent)]
 impl<Context> ErrorRaiser<Context, StarknetError> for RaiseStarknetError
 where
     Context: CanRaiseAsyncError<String>,

--- a/relayer/crates/starknet-chain-components/src/impls/events/ack.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/events/ack.rs
@@ -1,9 +1,9 @@
 use core::marker::PhantomData;
 
-use cgp::prelude::CanRaiseAsyncError;
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::strategy::ViaCairo;
 use hermes_cairo_encoding_components::types::as_starknet_event::AsStarknetEvent;
-use hermes_chain_components::traits::extract_data::EventExtractor;
+use hermes_chain_components::traits::extract_data::{EventExtractor, EventExtractorComponent};
 use hermes_chain_components::traits::packet::from_write_ack::PacketFromWriteAckEventBuilder;
 use hermes_chain_components::traits::types::event::HasEventType;
 use hermes_chain_components::traits::types::ibc_events::write_ack::{
@@ -11,6 +11,9 @@ use hermes_chain_components::traits::types::ibc_events::write_ack::{
 };
 use hermes_chain_components::traits::types::packet::HasOutgoingPacketType;
 use hermes_chain_components::traits::types::packets::ack::HasAcknowledgementType;
+use hermes_cosmos_chain_components::components::client::{
+    PacketFromWriteAckEventBuilderComponent, WriteAckEventComponent,
+};
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
@@ -22,6 +25,7 @@ use ibc::core::host::types::error::IdentifierError;
 use crate::impls::events::UseStarknetEvents;
 use crate::types::events::packet::{PacketRelayEvents, WriteAcknowledgementEvent};
 
+#[cgp_provider(WriteAckEventComponent)]
 impl<Chain, Counterparty> ProvideWriteAckEvent<Chain, Counterparty> for UseStarknetEvents
 where
     Chain: HasAcknowledgementType<Counterparty, Acknowledgement = Vec<u8>>,
@@ -29,6 +33,7 @@ where
     type WriteAckEvent = WriteAcknowledgementEvent;
 }
 
+#[cgp_provider(EventExtractorComponent)]
 impl<Chain, Encoding> EventExtractor<Chain, WriteAcknowledgementEvent> for UseStarknetEvents
 where
     Chain: HasEventType + HasEncoding<AsStarknetEvent, Encoding = Encoding>,
@@ -49,6 +54,7 @@ where
     }
 }
 
+#[cgp_provider(PacketFromWriteAckEventBuilderComponent)]
 impl<Chain, Counterparty> PacketFromWriteAckEventBuilder<Chain, Counterparty> for UseStarknetEvents
 where
     Chain: HasWriteAckEvent<Counterparty, WriteAckEvent = WriteAcknowledgementEvent>

--- a/relayer/crates/starknet-chain-components/src/impls/events/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/events/channel.rs
@@ -1,13 +1,19 @@
 use core::marker::PhantomData;
 
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::strategy::ViaCairo;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
-use hermes_chain_components::traits::extract_data::MessageResponseExtractor;
+use hermes_chain_components::traits::extract_data::{
+    MessageResponseExtractor, MessageResponseExtractorComponent,
+};
 use hermes_chain_components::traits::types::ibc::HasChannelIdType;
 use hermes_chain_components::traits::types::ibc_events::channel::{
     ProvideChannelOpenInitEvent, ProvideChannelOpenTryEvent,
 };
 use hermes_chain_type_components::traits::types::message_response::HasMessageResponseType;
+use hermes_cosmos_chain_components::components::client::{
+    ChannelOpenInitEventComponent, ChannelOpenTryEventComponent,
+};
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::has_encoding::HasDefaultEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
@@ -18,6 +24,7 @@ use crate::impls::types::events::{StarknetChannelOpenInitEvent, StarknetChannelO
 use crate::types::channel_id::ChannelId;
 use crate::types::message_response::StarknetMessageResponse;
 
+#[cgp_provider(ChannelOpenInitEventComponent)]
 impl<Chain, Counterparty> ProvideChannelOpenInitEvent<Chain, Counterparty> for UseStarknetEvents
 where
     Chain: HasChannelIdType<Counterparty, ChannelId = ChannelId>,
@@ -29,6 +36,7 @@ where
     }
 }
 
+#[cgp_provider(MessageResponseExtractorComponent)]
 impl<Chain, Encoding> MessageResponseExtractor<Chain, StarknetChannelOpenInitEvent>
     for UseStarknetEvents
 where
@@ -49,6 +57,7 @@ where
     }
 }
 
+#[cgp_provider(ChannelOpenTryEventComponent)]
 impl<Chain, Counterparty> ProvideChannelOpenTryEvent<Chain, Counterparty> for UseStarknetEvents
 where
     Chain: HasChannelIdType<Counterparty, ChannelId = ChannelId>,
@@ -60,6 +69,7 @@ where
     }
 }
 
+#[cgp_provider(MessageResponseExtractorComponent)]
 impl<Chain, Encoding> MessageResponseExtractor<Chain, StarknetChannelOpenTryEvent>
     for UseStarknetEvents
 where

--- a/relayer/crates/starknet-chain-components/src/impls/events/connection_id.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/events/connection_id.rs
@@ -1,13 +1,19 @@
 use core::marker::PhantomData;
 
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::strategy::ViaCairo;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
-use hermes_chain_components::traits::extract_data::MessageResponseExtractor;
+use hermes_chain_components::traits::extract_data::{
+    MessageResponseExtractor, MessageResponseExtractorComponent,
+};
 use hermes_chain_components::traits::types::ibc::HasConnectionIdType;
 use hermes_chain_components::traits::types::ibc_events::connection::{
     ProvideConnectionOpenInitEvent, ProvideConnectionOpenTryEvent,
 };
 use hermes_chain_type_components::traits::types::message_response::HasMessageResponseType;
+use hermes_cosmos_chain_components::components::client::{
+    ConnectionOpenInitEventComponent, ConnectionOpenTryEventComponent,
+};
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::has_encoding::HasDefaultEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
@@ -20,6 +26,7 @@ use crate::impls::types::events::{
 use crate::types::connection_id::ConnectionId;
 use crate::types::message_response::StarknetMessageResponse;
 
+#[cgp_provider(ConnectionOpenInitEventComponent)]
 impl<Chain, Counterparty> ProvideConnectionOpenInitEvent<Chain, Counterparty> for UseStarknetEvents
 where
     Chain: HasConnectionIdType<Counterparty, ConnectionId = ConnectionId>,
@@ -33,6 +40,7 @@ where
     }
 }
 
+#[cgp_provider(MessageResponseExtractorComponent)]
 impl<Chain, Encoding> MessageResponseExtractor<Chain, StarknetConnectionOpenInitEvent>
     for UseStarknetEvents
 where
@@ -53,6 +61,7 @@ where
     }
 }
 
+#[cgp_provider(ConnectionOpenTryEventComponent)]
 impl<Chain, Counterparty> ProvideConnectionOpenTryEvent<Chain, Counterparty> for UseStarknetEvents
 where
     Chain: HasConnectionIdType<Counterparty, ConnectionId = ConnectionId>,
@@ -66,6 +75,7 @@ where
     }
 }
 
+#[cgp_provider(MessageResponseExtractorComponent)]
 impl<Chain, Encoding> MessageResponseExtractor<Chain, StarknetConnectionOpenTryEvent>
     for UseStarknetEvents
 where

--- a/relayer/crates/starknet-chain-components/src/impls/events/create_client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/events/create_client.rs
@@ -1,11 +1,15 @@
 use core::marker::PhantomData;
 
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::strategy::ViaCairo;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
-use hermes_chain_components::traits::extract_data::MessageResponseExtractor;
+use hermes_chain_components::traits::extract_data::{
+    MessageResponseExtractor, MessageResponseExtractorComponent,
+};
 use hermes_chain_components::traits::types::create_client::ProvideCreateClientEvent;
 use hermes_chain_components::traits::types::ibc::HasClientIdType;
 use hermes_chain_type_components::traits::types::message_response::HasMessageResponseType;
+use hermes_cosmos_chain_components::components::client::CreateClientEventComponent;
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::has_encoding::HasDefaultEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
@@ -17,6 +21,7 @@ use crate::types::client_id::ClientId;
 use crate::types::message_response::StarknetMessageResponse;
 use crate::types::message_responses::create_client::CreateClientResponse;
 
+#[cgp_provider(CreateClientEventComponent)]
 impl<Chain, Counterparty, Encoding> ProvideCreateClientEvent<Chain, Counterparty>
     for UseStarknetEvents
 where
@@ -32,6 +37,7 @@ where
     }
 }
 
+#[cgp_provider(MessageResponseExtractorComponent)]
 impl<Chain, Encoding> MessageResponseExtractor<Chain, StarknetCreateClientEvent>
     for UseStarknetEvents
 where

--- a/relayer/crates/starknet-chain-components/src/impls/events/send_packet.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/events/send_packet.rs
@@ -1,16 +1,19 @@
 use core::marker::PhantomData;
 
-use cgp::prelude::CanRaiseAsyncError;
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::strategy::ViaCairo;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_cairo_encoding_components::types::as_starknet_event::AsStarknetEvent;
-use hermes_chain_components::traits::extract_data::EventExtractor;
+use hermes_chain_components::traits::extract_data::{EventExtractor, EventExtractorComponent};
 use hermes_chain_components::traits::packet::from_send_packet::PacketFromSendPacketEventBuilder;
 use hermes_chain_components::traits::types::event::HasEventType;
 use hermes_chain_components::traits::types::ibc_events::send_packet::{
     HasSendPacketEvent, ProvideSendPacketEvent,
 };
 use hermes_chain_components::traits::types::packet::HasOutgoingPacketType;
+use hermes_cosmos_chain_components::components::client::{
+    PacketFromSendPacketEventBuilderComponent, SendPacketEventComponent,
+};
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
@@ -26,6 +29,7 @@ use crate::impls::events::UseStarknetEvents;
 use crate::types::events::packet::{PacketRelayEvents, SendPacketEvent};
 use crate::types::messages::ibc::ibc_transfer::TransferPacketData;
 
+#[cgp_provider(SendPacketEventComponent)]
 impl<Chain, Counterparty> ProvideSendPacketEvent<Chain, Counterparty> for UseStarknetEvents
 where
     Chain: HasOutgoingPacketType<Counterparty, OutgoingPacket = Packet> + HasEventType,
@@ -33,6 +37,7 @@ where
     type SendPacketEvent = SendPacketEvent;
 }
 
+#[cgp_provider(PacketFromSendPacketEventBuilderComponent)]
 impl<Chain, Counterparty, Encoding> PacketFromSendPacketEventBuilder<Chain, Counterparty>
     for UseStarknetEvents
 where
@@ -117,6 +122,7 @@ where
     }
 }
 
+#[cgp_provider(EventExtractorComponent)]
 impl<Chain, Encoding> EventExtractor<Chain, SendPacketEvent> for UseStarknetEvents
 where
     Chain: HasEventType + HasEncoding<AsStarknetEvent, Encoding = Encoding>,

--- a/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/channel.rs
@@ -19,6 +19,10 @@ use hermes_chain_components::types::payloads::channel::{
     ChannelOpenAckPayload, ChannelOpenConfirmPayload, ChannelOpenTryPayload,
 };
 use hermes_chain_type_components::traits::types::address::HasAddressType;
+use hermes_cosmos_chain_components::components::client::{
+    ChannelOpenAckMessageBuilderComponent, ChannelOpenConfirmMessageBuilderComponent,
+    ChannelOpenInitMessageBuilderComponent, ChannelOpenTryMessageBuilderComponent,
+};
 use hermes_cosmos_chain_components::types::channel::CosmosInitChannelOptions;
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
@@ -41,6 +45,7 @@ use crate::types::messages::ibc::channel::{
 use crate::types::messages::ibc::packet::StateProof;
 pub struct BuildStarknetChannelHandshakeMessages;
 
+#[cgp_provider(ChannelOpenInitMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> ChannelOpenInitMessageBuilder<Chain, Counterparty>
     for BuildStarknetChannelHandshakeMessages
 where
@@ -104,6 +109,7 @@ where
     }
 }
 
+#[cgp_provider(ChannelOpenTryMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> ChannelOpenTryMessageBuilder<Chain, Counterparty>
     for BuildStarknetChannelHandshakeMessages
 where
@@ -188,6 +194,7 @@ where
     }
 }
 
+#[cgp_provider(ChannelOpenAckMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> ChannelOpenAckMessageBuilder<Chain, Counterparty>
     for BuildStarknetChannelHandshakeMessages
 where
@@ -253,6 +260,7 @@ where
     }
 }
 
+#[cgp_provider(ChannelOpenConfirmMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> ChannelOpenConfirmMessageBuilder<Chain, Counterparty>
     for BuildStarknetChannelHandshakeMessages
 where

--- a/relayer/crates/starknet-chain-components/src/impls/messages/connection.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/connection.rs
@@ -25,6 +25,10 @@ use hermes_chain_components::types::payloads::connection::{
     ConnectionOpenTryPayload,
 };
 use hermes_chain_type_components::traits::types::address::HasAddressType;
+use hermes_cosmos_chain_components::components::client::{
+    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
+    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
+};
 use hermes_cosmos_chain_components::types::connection::CosmosInitConnectionOptions;
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
@@ -51,6 +55,7 @@ use crate::types::messages::ibc::packet::StateProof;
 
 pub struct BuildStarknetConnectionHandshakeMessages;
 
+#[cgp_provider(ConnectionOpenInitMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> ConnectionOpenInitMessageBuilder<Chain, Counterparty>
     for BuildStarknetConnectionHandshakeMessages
 where
@@ -109,6 +114,7 @@ where
     }
 }
 
+#[cgp_provider(ConnectionOpenTryMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> ConnectionOpenTryMessageBuilder<Chain, Counterparty>
     for BuildStarknetConnectionHandshakeMessages
 where
@@ -186,6 +192,7 @@ where
     }
 }
 
+#[cgp_provider(ConnectionOpenAckMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> ConnectionOpenAckMessageBuilder<Chain, Counterparty>
     for BuildStarknetConnectionHandshakeMessages
 where
@@ -256,6 +263,7 @@ where
     }
 }
 
+#[cgp_provider(ConnectionOpenConfirmMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> ConnectionOpenConfirmMessageBuilder<Chain, Counterparty>
     for BuildStarknetConnectionHandshakeMessages
 where

--- a/relayer/crates/starknet-chain-components/src/impls/messages/create_client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/create_client.rs
@@ -9,6 +9,7 @@ use hermes_chain_components::traits::types::create_client::{
 };
 use hermes_chain_components::traits::types::message::HasMessageType;
 use hermes_chain_type_components::traits::types::address::HasAddressType;
+use hermes_cosmos_chain_components::components::client::CreateClientMessageBuilderComponent;
 use hermes_cosmos_chain_components::types::payloads::client::CosmosCreateClientPayload;
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
@@ -26,6 +27,7 @@ use crate::types::cosmos::height::Height;
 
 pub struct BuildCreateCometClientMessage;
 
+#[cgp_provider(CreateClientMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> CreateClientMessageBuilder<Chain, Counterparty>
     for BuildCreateCometClientMessage
 where

--- a/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
@@ -1,10 +1,12 @@
-use cgp::prelude::HasAsyncErrorType;
+use cgp::prelude::*;
 use hermes_chain_components::traits::types::height::HasHeightType;
 use hermes_chain_components::traits::types::ibc::{HasChannelIdType, HasPortIdType};
 use hermes_chain_components::traits::types::message::HasMessageType;
 use hermes_chain_components::traits::types::timestamp::HasTimeoutType;
 use hermes_chain_type_components::traits::types::address::HasAddressType;
-use hermes_test_components::chain::traits::messages::ibc_transfer::IbcTokenTransferMessageBuilder;
+use hermes_test_components::chain::traits::messages::ibc_transfer::{
+    IbcTokenTransferMessageBuilder, IbcTokenTransferMessageBuilderComponent,
+};
 use hermes_test_components::chain::traits::types::amount::HasAmountType;
 use hermes_test_components::chain::traits::types::memo::HasMemoType;
 use ibc::core::host::types::identifiers::PortId;
@@ -16,6 +18,7 @@ use crate::types::channel_id::ChannelId;
 
 pub struct BuildStarknetIbcTransferMessage;
 
+#[cgp_provider(IbcTokenTransferMessageBuilderComponent)]
 impl<Chain, Counterparty> IbcTokenTransferMessageBuilder<Chain, Counterparty>
     for BuildStarknetIbcTransferMessage
 where

--- a/relayer/crates/starknet-chain-components/src/impls/messages/packet.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/packet.rs
@@ -19,6 +19,10 @@ use hermes_chain_components::types::payloads::packet::{
     AckPacketPayload, ReceivePacketPayload, TimeoutUnorderedPacketPayload,
 };
 use hermes_chain_type_components::traits::types::address::HasAddressType;
+use hermes_cosmos_chain_components::components::client::{
+    AckPacketMessageBuilderComponent, ReceivePacketMessageBuilderComponent,
+    TimeoutUnorderedPacketMessageBuilderComponent,
+};
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
@@ -45,6 +49,7 @@ use crate::types::messages::ibc::packet::{
 
 pub struct BuildStarknetPacketMessages;
 
+#[cgp_provider(ReceivePacketMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> ReceivePacketMessageBuilder<Chain, Counterparty>
     for BuildStarknetPacketMessages
 where
@@ -105,6 +110,7 @@ where
     }
 }
 
+#[cgp_provider(AckPacketMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> AckPacketMessageBuilder<Chain, Counterparty>
     for BuildStarknetPacketMessages
 where
@@ -171,6 +177,7 @@ where
     }
 }
 
+#[cgp_provider(TimeoutUnorderedPacketMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> TimeoutUnorderedPacketMessageBuilder<Chain, Counterparty>
     for BuildStarknetPacketMessages
 where

--- a/relayer/crates/starknet-chain-components/src/impls/messages/update_client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/update_client.rs
@@ -9,6 +9,7 @@ use hermes_chain_components::traits::types::ibc::HasClientIdType;
 use hermes_chain_components::traits::types::message::HasMessageType;
 use hermes_chain_components::traits::types::update_client::HasUpdateClientPayloadType;
 use hermes_chain_type_components::traits::types::address::HasAddressType;
+use hermes_cosmos_chain_components::components::client::UpdateClientMessageBuilderComponent;
 use hermes_cosmos_chain_components::types::payloads::client::CosmosUpdateClientPayload;
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
@@ -25,6 +26,7 @@ use crate::types::cosmos::update::CometUpdateHeader;
 
 pub struct BuildUpdateCometClientMessage;
 
+#[cgp_provider(UpdateClientMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> UpdateClientMessageBuilder<Chain, Counterparty>
     for BuildUpdateCometClientMessage
 where

--- a/relayer/crates/starknet-chain-components/src/impls/packet_fields.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/packet_fields.rs
@@ -1,12 +1,15 @@
+use cgp::prelude::*;
 use hermes_chain_components::traits::packet::fields::PacketSrcChannelIdGetter;
 use hermes_chain_components::traits::types::ibc::HasChannelIdType;
 use hermes_chain_components::traits::types::packet::HasOutgoingPacketType;
+use hermes_cosmos_chain_components::components::client::PacketSrcChannelIdGetterComponent;
 use ibc::core::channel::types::packet::Packet;
 
 use crate::types::channel_id::ChannelId;
 
 pub struct ReadPacketSrcStarknetFields;
 
+#[cgp_provider(PacketSrcChannelIdGetterComponent)]
 impl<Chain, Counterparty> PacketSrcChannelIdGetter<Chain, Counterparty>
     for ReadPacketSrcStarknetFields
 where

--- a/relayer/crates/starknet-chain-components/src/impls/packet_filter.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/packet_filter.rs
@@ -1,11 +1,15 @@
-use cgp::prelude::HasAsyncErrorType;
+use cgp::prelude::*;
 use hermes_chain_components::traits::packet::filter::{IncomingPacketFilter, OutgoingPacketFilter};
 use hermes_chain_components::traits::types::packet::{
     HasIncomingPacketType, HasOutgoingPacketType,
 };
+use hermes_cosmos_chain_components::components::client::{
+    IncomingPacketFilterComponent, OutgoingPacketFilterComponent,
+};
 
 pub struct FilterStarknetPackets;
 
+#[cgp_provider(OutgoingPacketFilterComponent)]
 impl<Chain, Counterparty> OutgoingPacketFilter<Chain, Counterparty> for FilterStarknetPackets
 where
     Chain: HasOutgoingPacketType<Counterparty> + HasAsyncErrorType,
@@ -18,6 +22,7 @@ where
     }
 }
 
+#[cgp_provider(IncomingPacketFilterComponent)]
 impl<Chain, Counterparty> IncomingPacketFilter<Chain, Counterparty> for FilterStarknetPackets
 where
     Chain: HasIncomingPacketType<Counterparty> + HasAsyncErrorType,

--- a/relayer/crates/starknet-chain-components/src/impls/payload_builders/create_client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/payload_builders/create_client.rs
@@ -1,5 +1,6 @@
-use cgp::prelude::CanRaiseAsyncError;
+use cgp::prelude::*;
 use hermes_chain_components::traits::types::chain_id::HasChainId;
+use hermes_cosmos_chain_components::components::client::CreateClientPayloadBuilderComponent;
 use hermes_cosmos_chain_components::types::key_types::secp256k1::Secp256k1KeyPair;
 use hermes_relayer_components::chain::traits::payload_builders::create_client::CreateClientPayloadBuilder;
 use hermes_relayer_components::chain::traits::queries::chain_status::CanQueryChainStatus;
@@ -20,6 +21,7 @@ use crate::types::status::StarknetChainStatus;
 
 pub struct BuildStarknetCreateClientPayload;
 
+#[cgp_provider(CreateClientPayloadBuilderComponent)]
 impl<Chain, Counterparty> CreateClientPayloadBuilder<Chain, Counterparty>
     for BuildStarknetCreateClientPayload
 where

--- a/relayer/crates/starknet-chain-components/src/impls/payload_builders/update_client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/payload_builders/update_client.rs
@@ -1,4 +1,5 @@
-use cgp::prelude::{Async, CanRaiseAsyncError};
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::client::UpdateClientPayloadBuilderComponent;
 use hermes_cosmos_chain_components::types::key_types::secp256k1::Secp256k1KeyPair;
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::has_encoding::HasDefaultEncoding;
@@ -23,6 +24,7 @@ use crate::types::status::StarknetChainStatus;
 
 pub struct BuildStarknetUpdateClientPayload;
 
+#[cgp_provider(UpdateClientPayloadBuilderComponent)]
 impl<Chain, Counterparty, Encoding> UpdateClientPayloadBuilder<Chain, Counterparty>
     for BuildStarknetUpdateClientPayload
 where

--- a/relayer/crates/starknet-chain-components/src/impls/proof_signer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/proof_signer.rs
@@ -4,10 +4,12 @@ use cgp::prelude::*;
 
 use crate::traits::proof_signer::{
     HasStarknetProofSignerType, ProvideStarknetProofSignerType, StarknetProofSignerGetter,
+    StarknetProofSignerGetterComponent, StarknetProofSignerTypeComponent,
 };
 
 pub struct GetStarknetProofSignerField<Tag>(pub PhantomData<Tag>);
 
+#[cgp_provider(StarknetProofSignerTypeComponent)]
 impl<Chain, Tag> ProvideStarknetProofSignerType<Chain> for GetStarknetProofSignerField<Tag>
 where
     Chain: Async + HasField<Tag>,
@@ -17,6 +19,7 @@ where
     type ProofSigner = Chain::Value;
 }
 
+#[cgp_provider(StarknetProofSignerGetterComponent)]
 impl<Chain, Tag> StarknetProofSignerGetter<Chain> for GetStarknetProofSignerField<Tag>
 where
     Chain: Async + HasStarknetProofSignerType + HasField<Tag, Value = Chain::ProofSigner>,

--- a/relayer/crates/starknet-chain-components/src/impls/provider.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/provider.rs
@@ -5,10 +5,12 @@ use starknet::providers::Provider;
 
 use crate::traits::provider::{
     HasStarknetProviderType, ProvideStarknetProviderType, StarknetProviderGetter,
+    StarknetProviderGetterComponent, StarknetProviderTypeComponent,
 };
 
 pub struct GetStarknetProviderField<Tag>(pub PhantomData<Tag>);
 
+#[cgp_provider(StarknetProviderTypeComponent)]
 impl<Chain, Tag> ProvideStarknetProviderType<Chain> for GetStarknetProviderField<Tag>
 where
     Chain: Async + HasField<Tag>,
@@ -18,6 +20,7 @@ where
     type StarknetProvider = Chain::Value;
 }
 
+#[cgp_provider(StarknetProviderGetterComponent)]
 impl<Chain, Tag> StarknetProviderGetter<Chain> for GetStarknetProviderField<Tag>
 where
     Chain: Async + HasStarknetProviderType + HasField<Tag, Value = Chain::StarknetProvider>,

--- a/relayer/crates/starknet-chain-components/src/impls/queries/channel_end.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/channel_end.rs
@@ -14,7 +14,9 @@ use hermes_chain_components::traits::types::channel::HasChannelEndType;
 use hermes_chain_components::traits::types::height::HasHeightType;
 use hermes_chain_components::traits::types::ibc::{HasChannelIdType, HasPortIdType};
 use hermes_chain_components::traits::types::proof::HasCommitmentProofType;
-use hermes_cosmos_chain_components::components::client::ChannelEndQuerierComponent;
+use hermes_cosmos_chain_components::components::client::{
+    ChannelEndQuerierComponent, ChannelEndWithProofsQuerierComponent,
+};
 use hermes_cosmos_chain_components::types::key_types::secp256k1::Secp256k1KeyPair;
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::encode::CanEncode;
@@ -80,6 +82,7 @@ where
     }
 }
 
+#[cgp_provider(ChannelEndWithProofsQuerierComponent)]
 impl<Chain, Counterparty, Encoding> ChannelEndWithProofsQuerier<Chain, Counterparty>
     for QueryChannelEndFromStarknet
 where

--- a/relayer/crates/starknet-chain-components/src/impls/queries/client_state.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/client_state.rs
@@ -12,7 +12,9 @@ use hermes_chain_components::traits::types::client_state::HasClientStateType;
 use hermes_chain_components::traits::types::height::HasHeightType;
 use hermes_chain_components::traits::types::ibc::HasClientIdType;
 use hermes_chain_components::traits::types::proof::HasCommitmentProofType;
-use hermes_cosmos_chain_components::components::client::ClientStateQuerierComponent;
+use hermes_cosmos_chain_components::components::client::{
+    ClientStateQuerierComponent, ClientStateWithProofsQuerierComponent,
+};
 use hermes_cosmos_chain_components::types::key_types::secp256k1::Secp256k1KeyPair;
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::encode::CanEncode;
@@ -90,6 +92,7 @@ where
     }
 }
 
+#[cgp_provider(ClientStateWithProofsQuerierComponent)]
 impl<Chain, Counterparty> ClientStateWithProofsQuerier<Chain, Counterparty>
     for QueryCometClientState
 where

--- a/relayer/crates/starknet-chain-components/src/impls/queries/connection_end.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/connection_end.rs
@@ -12,7 +12,9 @@ use hermes_chain_components::traits::types::connection::HasConnectionEndType;
 use hermes_chain_components::traits::types::height::HasHeightType;
 use hermes_chain_components::traits::types::ibc::HasConnectionIdType;
 use hermes_chain_components::traits::types::proof::HasCommitmentProofType;
-use hermes_cosmos_chain_components::components::client::ConnectionEndQuerierComponent;
+use hermes_cosmos_chain_components::components::client::{
+    ConnectionEndQuerierComponent, ConnectionEndWithProofsQuerierComponent,
+};
 use hermes_cosmos_chain_components::types::key_types::secp256k1::Secp256k1KeyPair;
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::encode::CanEncode;

--- a/relayer/crates/starknet-chain-components/src/impls/queries/connection_end.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/connection_end.rs
@@ -73,6 +73,7 @@ where
     }
 }
 
+#[cgp_provider(ConnectionEndWithProofsQuerierComponent)]
 impl<Chain, Counterparty, Encoding> ConnectionEndWithProofsQuerier<Chain, Counterparty>
     for QueryConnectionEndFromStarknet
 where

--- a/relayer/crates/starknet-chain-components/src/impls/queries/consensus_state.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/consensus_state.rs
@@ -12,7 +12,9 @@ use hermes_chain_components::traits::types::consensus_state::HasConsensusStateTy
 use hermes_chain_components::traits::types::height::{HasHeightFields, HasHeightType};
 use hermes_chain_components::traits::types::ibc::HasClientIdType;
 use hermes_chain_components::traits::types::proof::HasCommitmentProofType;
-use hermes_cosmos_chain_components::components::client::ConsensusStateQuerierComponent;
+use hermes_cosmos_chain_components::components::client::{
+    ConsensusStateQuerierComponent, ConsensusStateWithProofsQuerierComponent,
+};
 use hermes_cosmos_chain_components::types::key_types::secp256k1::Secp256k1KeyPair;
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::encode::CanEncode;

--- a/relayer/crates/starknet-chain-components/src/impls/queries/consensus_state.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/consensus_state.rs
@@ -115,6 +115,7 @@ where
     }
 }
 
+#[cgp_provider(ConsensusStateWithProofsQuerierComponent)]
 impl<Chain, Counterparty> ConsensusStateWithProofsQuerier<Chain, Counterparty>
     for QueryCometConsensusState
 where

--- a/relayer/crates/starknet-chain-components/src/impls/send_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/send_message.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
-use cgp::core::error::CanRaiseAsyncError;
-use cgp::prelude::HasAsyncErrorType;
+use cgp::prelude::*;
+use hermes_chain_components::traits::send_message::MessageSenderComponent;
 use hermes_chain_type_components::traits::types::message_response::HasMessageResponseType;
 use hermes_relayer_components::chain::traits::send_message::MessageSender;
 use hermes_relayer_components::chain::traits::types::message::HasMessageType;
@@ -24,6 +24,7 @@ pub struct UnexpectedTransactionTraceType {
     pub trace: TransactionTrace,
 }
 
+#[cgp_provider(MessageSenderComponent)]
 impl<Chain> MessageSender<Chain> for SendCallMessages
 where
     Chain: HasMessageType<Message = StarknetMessage>

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/channel_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/channel_message.rs
@@ -16,6 +16,10 @@ use hermes_chain_components::traits::types::proof::HasCommitmentProofType;
 use hermes_chain_components::types::payloads::channel::{
     ChannelOpenAckPayload, ChannelOpenConfirmPayload, ChannelOpenTryPayload,
 };
+use hermes_cosmos_chain_components::components::client::{
+    ChannelOpenAckMessageBuilderComponent, ChannelOpenConfirmMessageBuilderComponent,
+    ChannelOpenTryMessageBuilderComponent,
+};
 use hermes_cosmos_chain_components::traits::message::{CosmosMessage, ToCosmosMessage};
 use hermes_cosmos_chain_components::types::messages::channel::open_ack::CosmosChannelOpenAckMessage;
 use hermes_cosmos_chain_components::types::messages::channel::open_confirm::CosmosChannelOpenConfirmMessage;
@@ -33,6 +37,7 @@ use crate::types::commitment_proof::StarknetCommitmentProof;
 
 pub struct BuildStarknetToCosmosChannelHandshakeMessage;
 
+#[cgp_provider(ChannelOpenTryMessageBuilderComponent)]
 impl<Chain, Counterparty> ChannelOpenTryMessageBuilder<Chain, Counterparty>
     for BuildStarknetToCosmosChannelHandshakeMessage
 where
@@ -90,6 +95,7 @@ where
     }
 }
 
+#[cgp_provider(ChannelOpenAckMessageBuilderComponent)]
 impl<Chain, Counterparty> ChannelOpenAckMessageBuilder<Chain, Counterparty>
     for BuildStarknetToCosmosChannelHandshakeMessage
 where
@@ -130,6 +136,7 @@ where
     }
 }
 
+#[cgp_provider(ChannelOpenConfirmMessageBuilderComponent)]
 impl<Chain, Counterparty> ChannelOpenConfirmMessageBuilder<Chain, Counterparty>
     for BuildStarknetToCosmosChannelHandshakeMessage
 where

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/connection_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/connection_message.rs
@@ -22,6 +22,10 @@ use hermes_chain_components::types::payloads::connection::{
     ConnectionOpenAckPayload, ConnectionOpenConfirmPayload, ConnectionOpenInitPayload,
     ConnectionOpenTryPayload,
 };
+use hermes_cosmos_chain_components::components::client::{
+    ConnectionOpenAckMessageBuilderComponent, ConnectionOpenConfirmMessageBuilderComponent,
+    ConnectionOpenInitMessageBuilderComponent, ConnectionOpenTryMessageBuilderComponent,
+};
 use hermes_cosmos_chain_components::traits::message::{CosmosMessage, ToCosmosMessage};
 use hermes_cosmos_chain_components::types::connection::CosmosInitConnectionOptions;
 use hermes_cosmos_chain_components::types::messages::connection::open_ack::CosmosConnectionOpenAckMessage;
@@ -45,6 +49,7 @@ use crate::types::consensus_state::WasmStarknetConsensusState;
 use crate::types::cosmos::client_state::CometClientState;
 pub struct BuildStarknetToCosmosConnectionHandshake;
 
+#[cgp_provider(ConnectionOpenInitMessageBuilderComponent)]
 impl<Chain, Counterparty> ConnectionOpenInitMessageBuilder<Chain, Counterparty>
     for BuildStarknetToCosmosConnectionHandshake
 where
@@ -80,6 +85,7 @@ where
     }
 }
 
+#[cgp_provider(ConnectionOpenTryMessageBuilderComponent)]
 impl<Chain, Counterparty> ConnectionOpenTryMessageBuilder<Chain, Counterparty>
     for BuildStarknetToCosmosConnectionHandshake
 where
@@ -141,6 +147,7 @@ where
     }
 }
 
+#[cgp_provider(ConnectionOpenAckMessageBuilderComponent)]
 impl<Chain, Counterparty> ConnectionOpenAckMessageBuilder<Chain, Counterparty>
     for BuildStarknetToCosmosConnectionHandshake
 where
@@ -192,6 +199,7 @@ where
     }
 }
 
+#[cgp_provider(ConnectionOpenConfirmMessageBuilderComponent)]
 impl<Chain, Counterparty> ConnectionOpenConfirmMessageBuilder<Chain, Counterparty>
     for BuildStarknetToCosmosConnectionHandshake
 where

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/counterparty_message_height.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/counterparty_message_height.rs
@@ -1,3 +1,5 @@
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::client::CounterpartyMessageHeightGetterComponent;
 use hermes_cosmos_chain_components::traits::message::CosmosMessage;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::ibc::CounterpartyMessageHeightGetter;
@@ -5,6 +7,7 @@ use hermes_relayer_components::chain::traits::types::message::HasMessageType;
 
 pub struct GetCosmosCounterpartyMessageStarknetHeight;
 
+#[cgp_provider(CounterpartyMessageHeightGetterComponent)]
 impl<Chain, Counterparty> CounterpartyMessageHeightGetter<Chain, Counterparty>
     for GetCosmosCounterpartyMessageStarknetHeight
 where

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/create_client_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/create_client_message.rs
@@ -1,4 +1,5 @@
 use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::client::CreateClientMessageBuilderComponent;
 use hermes_cosmos_chain_components::traits::message::{CosmosMessage, ToCosmosMessage};
 use hermes_cosmos_chain_components::types::messages::client::create::CosmosCreateClientMessage;
 use hermes_encoding_components::traits::convert::CanConvert;
@@ -20,6 +21,7 @@ use crate::types::payloads::client::StarknetCreateClientPayload;
 
 pub struct BuildStarknetCreateClientMessage;
 
+#[cgp_provider(CreateClientMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> CreateClientMessageBuilder<Chain, Counterparty>
     for BuildStarknetCreateClientMessage
 where

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/packet_fields.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/packet_fields.rs
@@ -1,9 +1,13 @@
+use cgp::prelude::*;
 use hermes_chain_components::traits::packet::fields::{
     PacketDstChannelIdGetter, PacketTimeoutHeightGetter,
 };
 use hermes_chain_components::traits::types::height::HasHeightType;
 use hermes_chain_components::traits::types::ibc::HasChannelIdType;
 use hermes_chain_components::traits::types::packet::HasOutgoingPacketType;
+use hermes_cosmos_chain_components::components::client::{
+    PacketDstChannelIdGetterComponent, PacketTimeoutHeightGetterComponent,
+};
 use ibc::core::channel::types::packet::Packet;
 use ibc::core::channel::types::timeout::TimeoutHeight;
 
@@ -11,6 +15,7 @@ use crate::types::channel_id::ChannelId;
 
 pub struct ReadPacketDstStarknetFields;
 
+#[cgp_provider(PacketDstChannelIdGetterComponent)]
 impl<Chain, Counterparty> PacketDstChannelIdGetter<Chain, Counterparty>
     for ReadPacketDstStarknetFields
 where
@@ -22,6 +27,7 @@ where
     }
 }
 
+#[cgp_provider(PacketTimeoutHeightGetterComponent)]
 impl<Chain, Counterparty> PacketTimeoutHeightGetter<Chain, Counterparty>
     for ReadPacketDstStarknetFields
 where

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/query_consensus_state_height.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/query_consensus_state_height.rs
@@ -1,4 +1,5 @@
-use cgp::core::error::CanRaiseAsyncError;
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::client::ConsensusStateHeightsQuerierComponent;
 use hermes_cosmos_chain_components::traits::grpc_address::HasGrpcAddress;
 use hermes_relayer_components::chain::traits::queries::consensus_state_height::ConsensusStateHeightsQuerier;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
@@ -13,6 +14,7 @@ use tonic::Status;
 
 pub struct QueryStarknetConsensusStateHeightsFromGrpc;
 
+#[cgp_provider(ConsensusStateHeightsQuerierComponent)]
 impl<Chain, Counterparty> ConsensusStateHeightsQuerier<Chain, Counterparty>
     for QueryStarknetConsensusStateHeightsFromGrpc
 where

--- a/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/update_client_message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/starknet_to_cosmos/update_client_message.rs
@@ -1,4 +1,5 @@
 use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::client::UpdateClientMessageBuilderComponent;
 use hermes_cosmos_chain_components::traits::message::{CosmosMessage, ToCosmosMessage};
 use hermes_cosmos_chain_components::types::messages::client::update::CosmosUpdateClientMessage;
 use hermes_encoding_components::traits::convert::CanConvert;
@@ -18,6 +19,7 @@ use crate::types::payloads::client::StarknetUpdateClientPayload;
 
 pub struct BuildStarknetUpdateClientMessage;
 
+#[cgp_provider(UpdateClientMessageBuilderComponent)]
 impl<Chain, Counterparty, Encoding> UpdateClientMessageBuilder<Chain, Counterparty>
     for BuildStarknetUpdateClientMessage
 where

--- a/relayer/crates/starknet-chain-components/src/impls/submit_tx.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/submit_tx.rs
@@ -1,3 +1,5 @@
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::transaction::TxSubmitterComponent;
 use hermes_relayer_components::transaction::traits::submit_tx::TxSubmitter;
 use hermes_relayer_components::transaction::traits::types::transaction::HasTransactionType;
 use hermes_relayer_components::transaction::traits::types::tx_hash::HasTransactionHashType;
@@ -9,6 +11,7 @@ use crate::traits::provider::HasStarknetProvider;
 
 pub struct SubmitCallTransaction;
 
+#[cgp_provider(TxSubmitterComponent)]
 impl<Chain> TxSubmitter<Chain> for SubmitCallTransaction
 where
     Chain: HasTransactionType<Transaction = Vec<Call>>

--- a/relayer/crates/starknet-chain-components/src/impls/transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/transfer.rs
@@ -1,3 +1,4 @@
+use cgp::prelude::*;
 use hermes_relayer_components::chain::traits::send_message::CanSendSingleMessage;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use hermes_test_components::chain::traits::types::amount::HasAmountType;
@@ -5,7 +6,7 @@ use starknet::core::types::Felt;
 use starknet::macros::selector;
 
 use crate::traits::messages::transfer::CanBuildTransferTokenMessage;
-use crate::traits::transfer::TokenTransferer;
+use crate::traits::transfer::{TokenTransferComponent, TokenTransferer};
 use crate::traits::types::blob::HasBlobType;
 use crate::traits::types::method::HasSelectorType;
 
@@ -13,6 +14,7 @@ pub const TRANSFER_SELECTOR: Felt = selector!("transfer");
 
 pub struct TransferErc20Token;
 
+#[cgp_provider(TokenTransferComponent)]
 impl<Chain> TokenTransferer<Chain> for TransferErc20Token
 where
     Chain: HasAddressType

--- a/relayer/crates/starknet-chain-components/src/impls/tx_response.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/tx_response.rs
@@ -1,6 +1,9 @@
 use core::time::Duration;
 
-use cgp::core::error::CanRaiseAsyncError;
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::transaction::{
+    PollTimeoutGetterComponent, TxResponseQuerierComponent,
+};
 use hermes_relayer_components::transaction::impls::poll_tx_response::PollTimeoutGetter;
 use hermes_relayer_components::transaction::traits::query_tx_response::TxResponseQuerier;
 use hermes_relayer_components::transaction::traits::types::tx_hash::HasTransactionHashType;
@@ -15,6 +18,7 @@ use crate::types::tx_response::TxResponse;
 
 pub struct QueryTransactionReceipt;
 
+#[cgp_provider(TxResponseQuerierComponent)]
 impl<Chain> TxResponseQuerier<Chain> for QueryTransactionReceipt
 where
     Chain: HasTransactionHashType<TxHash = Felt>
@@ -52,6 +56,7 @@ where
 
 pub struct DefaultPollTimeout;
 
+#[cgp_provider(PollTimeoutGetterComponent)]
 impl<Chain> PollTimeoutGetter<Chain> for DefaultPollTimeout {
     fn poll_timeout(_chain: &Chain) -> Duration {
         Duration::from_secs(300)

--- a/relayer/crates/starknet-chain-components/src/impls/types/address.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/address.rs
@@ -1,12 +1,15 @@
-use cgp::core::Async;
+use cgp::prelude::*;
 use derive_more::{Deref, Display, From, FromStr};
+use hermes_chain_type_components::traits::types::address::AddressTypeComponent;
 use hermes_test_components::chain::traits::types::address::ProvideAddressType;
+use hermes_wasm_encoding_components::components::{MutDecoderComponent, MutEncoderComponent};
 use serde::{Deserialize, Serialize};
 use starknet::core::types::Felt;
 pub struct ProvideFeltAddressType;
 use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
 
+#[cgp_provider(AddressTypeComponent)]
 impl<Chain: Async> ProvideAddressType<Chain> for ProvideFeltAddressType {
     type Address = StarknetAddress;
 }
@@ -33,6 +36,7 @@ pub struct StarknetAddress(Felt);
 
 pub struct EncodeStarknetAddress;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, StarknetAddress> for EncodeStarknetAddress
 where
     Encoding: CanEncodeMut<Strategy, Felt>,
@@ -47,6 +51,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, StarknetAddress> for EncodeStarknetAddress
 where
     Encoding: CanDecodeMut<Strategy, Felt>,

--- a/relayer/crates/starknet-chain-components/src/impls/types/amount.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/amount.rs
@@ -1,5 +1,7 @@
-use cgp::core::Async;
-use hermes_test_components::chain::traits::types::amount::ProvideAmountType;
+use cgp::prelude::*;
+use hermes_test_components::chain::traits::types::amount::{
+    AmountTypeComponent, ProvideAmountType,
+};
 use hermes_test_components::chain::traits::types::denom::HasDenomType;
 
 use super::address::StarknetAddress;
@@ -7,6 +9,7 @@ use crate::types::amount::StarknetAmount;
 
 pub struct ProvideU256Amount;
 
+#[cgp_provider(AmountTypeComponent)]
 impl<Chain: Async> ProvideAmountType<Chain> for ProvideU256Amount
 where
     Chain: HasDenomType<Denom = StarknetAddress>,

--- a/relayer/crates/starknet-chain-components/src/impls/types/blob.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/blob.rs
@@ -1,10 +1,12 @@
-use cgp::core::Async;
+use cgp::prelude::*;
 use starknet::core::types::Felt;
 
+use crate::components::chain::BlobTypeComponent;
 use crate::traits::types::blob::ProvideBlobType;
 
 pub struct ProvideFeltBlobType;
 
+#[cgp_provider(BlobTypeComponent)]
 impl<Chain: Async> ProvideBlobType<Chain> for ProvideFeltBlobType {
     type Blob = Vec<Felt>;
 }

--- a/relayer/crates/starknet-chain-components/src/impls/types/chain_id.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/chain_id.rs
@@ -1,9 +1,11 @@
-use cgp::core::Async;
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::client::ChainIdTypeComponent;
 use hermes_relayer_components::chain::traits::types::chain_id::ProvideChainIdType;
 use ibc::core::host::types::identifiers::ChainId;
 
 pub struct ProvideFeltChainId;
 
+#[cgp_provider(ChainIdTypeComponent)]
 impl<Chain: Async> ProvideChainIdType<Chain> for ProvideFeltChainId {
     type ChainId = ChainId;
 }

--- a/relayer/crates/starknet-chain-components/src/impls/types/client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/client.rs
@@ -1,7 +1,10 @@
 use core::time::Duration;
 
-use cgp::core::Async;
+use cgp::prelude::*;
 use hermes_chain_components::traits::types::chain_id::HasChainIdType;
+use hermes_cosmos_chain_components::components::client::{
+    ClientStateFieldsComponent, ClientStateTypeComponent, ConsensusStateTypeComponent,
+};
 use hermes_relayer_components::chain::traits::types::client_state::{
     ClientStateFieldsGetter, HasClientStateType, ProvideClientStateType,
 };
@@ -14,18 +17,21 @@ use crate::types::consensus_state::WasmStarknetConsensusState;
 
 pub struct ProvideStarknetIbcClientTypes;
 
+#[cgp_provider(ClientStateTypeComponent)]
 impl<Chain: Async, Counterparty> ProvideClientStateType<Chain, Counterparty>
     for ProvideStarknetIbcClientTypes
 {
     type ClientState = WasmStarknetClientState;
 }
 
+#[cgp_provider(ConsensusStateTypeComponent)]
 impl<Chain: Async, Counterparty> ProvideConsensusStateType<Chain, Counterparty>
     for ProvideStarknetIbcClientTypes
 {
     type ConsensusState = WasmStarknetConsensusState;
 }
 
+#[cgp_provider(ClientStateFieldsComponent)]
 impl<Chain, Counterparty> ClientStateFieldsGetter<Chain, Counterparty>
     for ProvideStarknetIbcClientTypes
 where

--- a/relayer/crates/starknet-chain-components/src/impls/types/commitment_proof.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/commitment_proof.rs
@@ -1,18 +1,24 @@
-use cgp::core::Async;
+use cgp::prelude::*;
 use hermes_chain_components::traits::types::height::HasHeightType;
 use hermes_chain_components::traits::types::proof::{
     CommitmentProofBytesGetter, CommitmentProofHeightGetter, HasCommitmentProofType,
     ProvideCommitmentProofType,
+};
+use hermes_cosmos_chain_components::components::client::{
+    CommitmentProofBytesGetterComponent, CommitmentProofHeightGetterComponent,
+    CommitmentProofTypeComponent,
 };
 
 use crate::types::commitment_proof::StarknetCommitmentProof;
 
 pub struct UseStarknetCommitmentProof;
 
+#[cgp_provider(CommitmentProofTypeComponent)]
 impl<Chain: Async> ProvideCommitmentProofType<Chain> for UseStarknetCommitmentProof {
     type CommitmentProof = StarknetCommitmentProof;
 }
 
+#[cgp_provider(CommitmentProofHeightGetterComponent)]
 impl<Chain> CommitmentProofHeightGetter<Chain> for UseStarknetCommitmentProof
 where
     Chain: HasCommitmentProofType<CommitmentProof = StarknetCommitmentProof>
@@ -23,6 +29,7 @@ where
     }
 }
 
+#[cgp_provider(CommitmentProofBytesGetterComponent)]
 impl<Chain> CommitmentProofBytesGetter<Chain> for UseStarknetCommitmentProof
 where
     Chain: HasCommitmentProofType<CommitmentProof = StarknetCommitmentProof>,

--- a/relayer/crates/starknet-chain-components/src/impls/types/contract.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/contract.rs
@@ -1,17 +1,20 @@
-use cgp::core::Async;
+use cgp::prelude::*;
 use starknet::core::types::contract::SierraClass;
 use starknet::core::types::Felt;
 
+use crate::components::chain::{ContractClassHashTypeComponent, ContractClassTypeComponent};
 use crate::traits::types::contract_class::{
     ProvideContractClassHashType, ProvideContractClassType,
 };
 
 pub struct ProvideStarknetContractTypes;
 
+#[cgp_provider(ContractClassTypeComponent)]
 impl<Chain: Async> ProvideContractClassType<Chain> for ProvideStarknetContractTypes {
     type ContractClass = SierraClass;
 }
 
+#[cgp_provider(ContractClassHashTypeComponent)]
 impl<Chain: Async> ProvideContractClassHashType<Chain> for ProvideStarknetContractTypes {
     type ContractClassHash = Felt;
 }

--- a/relayer/crates/starknet-chain-components/src/impls/types/denom.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/denom.rs
@@ -1,8 +1,11 @@
+use cgp::prelude::*;
+use hermes_chain_type_components::traits::types::denom::DenomTypeComponent;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use hermes_test_components::chain::traits::types::denom::ProvideDenomType;
 
 pub struct ProvideTokenAddressDenom;
 
+#[cgp_provider(DenomTypeComponent)]
 impl<Chain> ProvideDenomType<Chain> for ProvideTokenAddressDenom
 where
     Chain: HasAddressType,

--- a/relayer/crates/starknet-chain-components/src/impls/types/event.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/event.rs
@@ -1,10 +1,12 @@
-use cgp::core::Async;
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::client::EventTypeComponent;
 use hermes_relayer_components::chain::traits::types::event::ProvideEventType;
 
 use crate::types::event::StarknetEvent;
 
 pub struct ProvideStarknetEvent;
 
+#[cgp_provider(EventTypeComponent)]
 impl<Chain: Async> ProvideEventType<Chain> for ProvideStarknetEvent {
     type Event = StarknetEvent;
 }

--- a/relayer/crates/starknet-chain-components/src/impls/types/height.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/height.rs
@@ -1,16 +1,20 @@
-use cgp::core::Async;
-use cgp::prelude::CanRaiseAsyncError;
+use cgp::prelude::*;
 use hermes_chain_components::traits::types::height::HeightIncrementer;
+use hermes_cosmos_chain_components::components::client::{
+    HeightFieldComponent, HeightIncrementerComponent, HeightTypeComponent,
+};
 use hermes_relayer_components::chain::traits::types::height::{
     HasHeightType, HeightFieldGetter, ProvideHeightType,
 };
 
 pub struct ProvideStarknetHeight;
 
+#[cgp_provider(HeightTypeComponent)]
 impl<Chain: Async> ProvideHeightType<Chain> for ProvideStarknetHeight {
     type Height = u64;
 }
 
+#[cgp_provider(HeightFieldComponent)]
 impl<Chain> HeightFieldGetter<Chain> for ProvideStarknetHeight
 where
     Chain: HasHeightType<Height = u64>,
@@ -24,6 +28,7 @@ where
     }
 }
 
+#[cgp_provider(HeightIncrementerComponent)]
 impl<Chain> HeightIncrementer<Chain> for ProvideStarknetHeight
 where
     Chain: HasHeightType<Height = u64> + CanRaiseAsyncError<&'static str>,

--- a/relayer/crates/starknet-chain-components/src/impls/types/message.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/message.rs
@@ -1,4 +1,5 @@
-use cgp::core::Async;
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::client::MessageTypeComponent;
 use hermes_relayer_components::chain::traits::types::message::ProvideMessageType;
 use ibc::core::client::types::Height as CosmosHeight;
 use starknet::accounts::Call;
@@ -30,6 +31,7 @@ impl StarknetMessage {
 
 pub struct ProvideCallMessage;
 
+#[cgp_provider(MessageTypeComponent)]
 impl<Chain: Async> ProvideMessageType<Chain> for ProvideCallMessage {
     type Message = StarknetMessage;
 }

--- a/relayer/crates/starknet-chain-components/src/impls/types/method.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/method.rs
@@ -1,10 +1,12 @@
-use cgp::core::Async;
+use cgp::prelude::*;
 use starknet::core::types::Felt;
 
+use crate::components::chain::SelectorTypeComponent;
 use crate::traits::types::method::ProvideSelectorType;
 
 pub struct ProvideFeltSelector;
 
+#[cgp_provider(SelectorTypeComponent)]
 impl<Chain: Async> ProvideSelectorType<Chain> for ProvideFeltSelector {
     type Selector = Felt;
 }

--- a/relayer/crates/starknet-chain-components/src/impls/types/payloads.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/payloads.rs
@@ -1,4 +1,8 @@
-use cgp::core::Async;
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::client::{
+    CreateClientPayloadOptionsTypeComponent, CreateClientPayloadTypeComponent,
+    UpdateClientPayloadTypeComponent,
+};
 use hermes_relayer_components::chain::traits::types::create_client::{
     ProvideCreateClientPayloadOptionsType, ProvideCreateClientPayloadType,
 };
@@ -10,18 +14,21 @@ use crate::types::payloads::client::{
 
 pub struct ProvideStarknetPayloadTypes;
 
+#[cgp_provider(CreateClientPayloadTypeComponent)]
 impl<Chain: Async, Counterparty> ProvideCreateClientPayloadType<Chain, Counterparty>
     for ProvideStarknetPayloadTypes
 {
     type CreateClientPayload = StarknetCreateClientPayload;
 }
 
+#[cgp_provider(CreateClientPayloadOptionsTypeComponent)]
 impl<Chain: Async, Counterparty> ProvideCreateClientPayloadOptionsType<Chain, Counterparty>
     for ProvideStarknetPayloadTypes
 {
     type CreateClientPayloadOptions = StarknetCreateClientPayloadOptions;
 }
 
+#[cgp_provider(UpdateClientPayloadTypeComponent)]
 impl<Chain: Async, Counterparty> ProvideUpdateClientPayloadType<Chain, Counterparty>
     for ProvideStarknetPayloadTypes
 {

--- a/relayer/crates/starknet-chain-components/src/impls/types/status.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/status.rs
@@ -1,4 +1,6 @@
+use cgp::prelude::*;
 use hermes_chain_type_components::traits::types::time::HasTimeType;
+use hermes_cosmos_chain_components::components::client::ChainStatusTypeComponent;
 use hermes_cosmos_chain_components::types::status::Time;
 use hermes_relayer_components::chain::traits::types::height::HasHeightType;
 use hermes_relayer_components::chain::traits::types::status::ProvideChainStatusType;
@@ -7,6 +9,7 @@ use crate::types::status::StarknetChainStatus;
 
 pub struct ProvideStarknetChainStatusType;
 
+#[cgp_provider(ChainStatusTypeComponent)]
 impl<Chain> ProvideChainStatusType<Chain> for ProvideStarknetChainStatusType
 where
     Chain: HasHeightType<Height = u64> + HasTimeType<Time = Time>,

--- a/relayer/crates/starknet-chain-components/src/impls/types/timestamp.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/timestamp.rs
@@ -1,8 +1,10 @@
-use cgp::core::Async;
+use cgp::prelude::*;
 use hermes_chain_type_components::traits::types::time::ProvideTimeType;
+use hermes_cosmos_chain_components::components::client::TimeTypeComponent;
 
 pub struct ProvideStarknetTimeType;
 
+#[cgp_provider(TimeTypeComponent)]
 impl<Chain: Async> ProvideTimeType<Chain> for ProvideStarknetTimeType {
     // Dummy implementation for now
     type Time = ();

--- a/relayer/crates/starknet-chain-components/src/impls/types/transaction.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/transaction.rs
@@ -1,9 +1,11 @@
-use cgp::core::Async;
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::transaction::TransactionTypeComponent;
 use hermes_relayer_components::transaction::traits::types::transaction::ProvideTransactionType;
 use starknet::accounts::Call;
 
 pub struct ProvideCallTransaction;
 
+#[cgp_provider(TransactionTypeComponent)]
 impl<Chain: Async> ProvideTransactionType<Chain> for ProvideCallTransaction {
     type Transaction = Vec<Call>;
 

--- a/relayer/crates/starknet-chain-components/src/impls/types/tx_hash.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/tx_hash.rs
@@ -1,9 +1,11 @@
-use cgp::core::Async;
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::transaction::TransactionHashTypeComponent;
 use hermes_relayer_components::transaction::traits::types::tx_hash::ProvideTransactionHashType;
 use starknet::core::types::Felt;
 
 pub struct ProvideFeltTxHash;
 
+#[cgp_provider(TransactionHashTypeComponent)]
 impl<Chain: Async> ProvideTransactionHashType<Chain> for ProvideFeltTxHash {
     type TxHash = Felt;
 }

--- a/relayer/crates/starknet-chain-components/src/impls/types/tx_response.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/tx_response.rs
@@ -1,10 +1,12 @@
-use cgp::core::Async;
+use cgp::prelude::*;
+use hermes_cosmos_chain_components::components::transaction::TxResponseTypeComponent;
 use hermes_relayer_components::transaction::traits::types::tx_response::ProvideTxResponseType;
 
 use crate::types::tx_response::TxResponse;
 
 pub struct ProvideStarknetTxResponse;
 
+#[cgp_provider(TxResponseTypeComponent)]
 impl<Chain: Async> ProvideTxResponseType<Chain> for ProvideStarknetTxResponse {
     type TxResponse = TxResponse;
 }

--- a/relayer/crates/starknet-chain-components/src/types/channel_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/channel_id.rs
@@ -14,6 +14,7 @@ use super::messages::ibc::channel::{AppVersion, ChannelOrdering, PortId};
 
 pub struct EncodeChannelId;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ChannelId> for EncodeChannelId
 where
     Encoding: CanEncodeMut<Strategy, Product![String]>,
@@ -28,6 +29,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ChannelId> for EncodeChannelId
 where
     Encoding: CanDecodeMut<Strategy, Product![String]> + CanRaiseAsyncError<&'static str>,
@@ -93,6 +95,7 @@ impl Transformer for EncodeChannelState {
 
 pub struct EncodeChannelCounterparty;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ChannelCounterparty>
     for EncodeChannelCounterparty
 where
@@ -121,6 +124,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ChannelCounterparty>
     for EncodeChannelCounterparty
 where
@@ -149,6 +153,7 @@ where
 
 pub struct EncodeChannelEnd;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ChannelEnd> for EncodeChannelEnd
 where
     Encoding: CanEncodeMut<
@@ -185,6 +190,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ChannelEnd> for EncodeChannelEnd
 where
     Encoding: CanDecodeMut<

--- a/relayer/crates/starknet-chain-components/src/types/client_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/client_id.rs
@@ -1,6 +1,7 @@
 use cgp::prelude::*;
 use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use hermes_wasm_encoding_components::components::{MutDecoderComponent, MutEncoderComponent};
 pub use ibc::core::host::types::identifiers::ClientId;
 use starknet::core::types::Felt;
 
@@ -8,6 +9,7 @@ use super::utils::{felt_to_string, string_to_felt};
 
 pub struct EncodeClientId;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ClientId> for EncodeClientId
 where
     Encoding: CanEncodeMut<Strategy, Product![Felt, u64]> + CanRaiseError<&'static str>,
@@ -32,6 +34,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ClientId> for EncodeClientId
 where
     Encoding: CanDecodeMut<Strategy, Product![Felt, u64]> + CanRaiseAsyncError<&'static str>,

--- a/relayer/crates/starknet-chain-components/src/types/client_state.rs
+++ b/relayer/crates/starknet-chain-components/src/types/client_state.rs
@@ -1,8 +1,10 @@
+use cgp::prelude::*;
 use hermes_encoding_components::traits::convert::{CanConvert, Converter};
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
 use hermes_protobuf_encoding_components::types::strategy::ViaAny;
+use hermes_wasm_encoding_components::components::ConverterComponent;
 use hermes_wasm_encoding_components::types::client_state::WasmClientState;
 pub use ibc_client_starknet_types::StarknetClientState;
 use prost_types::Any;
@@ -21,6 +23,7 @@ impl From<WasmStarknetClientState> for StarknetClientState {
 
 pub struct ConvertWasmStarknetClientState;
 
+#[cgp_provider(ConverterComponent)]
 impl<Encoding> Converter<Encoding, WasmStarknetClientState, Any> for ConvertWasmStarknetClientState
 where
     Encoding: HasEncodedType<Encoded = Vec<u8>>
@@ -45,6 +48,7 @@ where
     }
 }
 
+#[cgp_provider(ConverterComponent)]
 impl<Encoding> Converter<Encoding, Any, WasmStarknetClientState> for ConvertWasmStarknetClientState
 where
     Encoding: HasEncodedType<Encoded = Vec<u8>>

--- a/relayer/crates/starknet-chain-components/src/types/connection_id.rs
+++ b/relayer/crates/starknet-chain-components/src/types/connection_id.rs
@@ -16,6 +16,7 @@ use crate::types::messages::ibc::connection::{BasePrefix, ConnectionVersion};
 
 pub struct EncodeConnectionId;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ConnectionId> for EncodeConnectionId
 where
     Encoding: CanEncodeMut<Strategy, Product![String]>,
@@ -30,6 +31,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ConnectionId> for EncodeConnectionId
 where
     Encoding: CanDecodeMut<Strategy, Product![String]> + CanRaiseAsyncError<&'static str>,
@@ -47,6 +49,7 @@ where
 
 pub struct EncodeDuration;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, Duration> for EncodeDuration
 where
     Encoding: CanEncodeMut<Strategy, Product![u64]>,
@@ -61,6 +64,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, Duration> for EncodeDuration
 where
     Encoding: CanDecodeMut<Strategy, Product![u64]>,
@@ -76,6 +80,7 @@ where
 
 pub struct EncodeConnectionEnd;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ConnectionEnd> for EncodeConnectionEnd
 where
     Encoding: CanEncodeMut<
@@ -129,6 +134,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ConnectionEnd> for EncodeConnectionEnd
 where
     Encoding: CanDecodeMut<
@@ -196,6 +202,7 @@ impl Transformer for EncodeConnectionState {
 
 pub struct EncodeConnectionCounterparty;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ConnectionCounterparty>
     for EncodeConnectionCounterparty
 where
@@ -229,6 +236,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ConnectionCounterparty>
     for EncodeConnectionCounterparty
 where

--- a/relayer/crates/starknet-chain-components/src/types/consensus_state.rs
+++ b/relayer/crates/starknet-chain-components/src/types/consensus_state.rs
@@ -1,5 +1,6 @@
-use cgp::prelude::HasAsyncErrorType;
+use cgp::prelude::*;
 use hermes_encoding_components::traits::convert::Converter;
+use hermes_wasm_encoding_components::components::ConverterComponent;
 use hermes_wasm_encoding_components::impls::strategies::consensus_state::{
     DecodeViaWasmConsensusState, EncodeViaWasmConsensusState,
 };
@@ -13,6 +14,7 @@ pub struct WasmStarknetConsensusState {
 
 pub struct ConvertWasmStarknetConsensusState;
 
+#[cgp_provider(ConverterComponent)]
 impl<Encoding> Converter<Encoding, WasmStarknetConsensusState, Any>
     for ConvertWasmStarknetConsensusState
 where
@@ -27,6 +29,7 @@ where
     }
 }
 
+#[cgp_provider(ConverterComponent)]
 impl<Encoding> Converter<Encoding, Any, WasmStarknetConsensusState>
     for ConvertWasmStarknetConsensusState
 where

--- a/relayer/crates/starknet-chain-components/src/types/cosmos/client_state.rs
+++ b/relayer/crates/starknet-chain-components/src/types/cosmos/client_state.rs
@@ -9,7 +9,9 @@ use hermes_chain_components::traits::types::client_state::{
     ClientStateFieldsGetter, HasClientStateType,
 };
 use hermes_chain_components::traits::types::height::HasHeightType;
-use hermes_cosmos_chain_components::components::client::ClientStateTypeComponent;
+use hermes_cosmos_chain_components::components::client::{
+    ClientStateFieldsComponent, ClientStateTypeComponent,
+};
 use hermes_encoding_components::impls::encode_mut::combine::CombineEncoders;
 use hermes_encoding_components::impls::encode_mut::field::EncodeField;
 use hermes_encoding_components::impls::encode_mut::from::DecodeFrom;
@@ -56,6 +58,7 @@ delegate_components! {
     }
 }
 
+#[cgp_provider(ClientStateFieldsComponent)]
 impl<Chain, Counterparty> ClientStateFieldsGetter<Chain, Counterparty> for UseCometClientState
 where
     Chain: HasClientStateType<Counterparty, ClientState = CometClientState>
@@ -189,6 +192,7 @@ impl From<CometClientState> for Any {
 
 pub struct EncodeChainId;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ChainId> for EncodeChainId
 where
     Encoding: CanEncodeMut<Strategy, String>,
@@ -204,6 +208,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ChainId> for EncodeChainId
 where
     Encoding: CanDecodeMut<Strategy, String> + CanRaiseAsyncError<&'static str>,

--- a/relayer/crates/starknet-chain-components/src/types/cosmos/timestamp.rs
+++ b/relayer/crates/starknet-chain-components/src/types/cosmos/timestamp.rs
@@ -1,10 +1,12 @@
 use cgp::prelude::*;
 use hermes_encoding_components::traits::decode_mut::{CanDecodeMut, MutDecoder};
 use hermes_encoding_components::traits::encode_mut::{CanEncodeMut, MutEncoder};
+use hermes_wasm_encoding_components::components::{MutDecoderComponent, MutEncoderComponent};
 pub use ibc::primitives::Timestamp;
 
 pub struct EncodeTimestamp;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, Timestamp> for EncodeTimestamp
 where
     Encoding: CanEncodeMut<Strategy, Product![u64]>,
@@ -20,6 +22,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, Timestamp> for EncodeTimestamp
 where
     Encoding: CanDecodeMut<Strategy, Product![u64]>,

--- a/relayer/crates/starknet-chain-components/src/types/events/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/types/events/channel.rs
@@ -1,9 +1,10 @@
-use cgp::prelude::{CanRaiseAsyncError, *};
+use cgp::prelude::*;
 use hermes_cairo_encoding_components::strategy::ViaCairo;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_encoding_components::traits::decode::{CanDecode, Decoder};
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
+use hermes_wasm_encoding_components::components::DecoderComponent;
 use starknet::core::types::Felt;
 use starknet::macros::selector;
 
@@ -59,6 +60,7 @@ pub struct ChanOpenConfirmEvent {
 
 pub struct DecodeChannelHandshakeEvents;
 
+#[cgp_provider(DecoderComponent)]
 impl<Encoding, Strategy> Decoder<Encoding, Strategy, ChannelHandshakeEvents>
     for DecodeChannelHandshakeEvents
 where
@@ -91,6 +93,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, ChanOpenInitEvent>
     for DecodeChannelHandshakeEvents
 where
@@ -131,6 +134,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, ChanOpenTryEvent>
     for DecodeChannelHandshakeEvents
 where
@@ -183,6 +187,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, ChanOpenAckEvent>
     for DecodeChannelHandshakeEvents
 where
@@ -223,6 +228,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, ChanOpenConfirmEvent>
     for DecodeChannelHandshakeEvents
 where

--- a/relayer/crates/starknet-chain-components/src/types/events/connection.rs
+++ b/relayer/crates/starknet-chain-components/src/types/events/connection.rs
@@ -4,6 +4,7 @@ use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_encoding_components::traits::decode::{CanDecode, Decoder};
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
+use hermes_wasm_encoding_components::components::DecoderComponent;
 use starknet::core::types::Felt;
 use starknet::macros::selector;
 
@@ -52,6 +53,7 @@ pub struct ConnOpenConfirmEvent {
 
 pub struct DecodeConnectionHandshakeEvents;
 
+#[cgp_provider(DecoderComponent)]
 impl<Encoding, Strategy> Decoder<Encoding, Strategy, ConnectionHandshakeEvents>
     for DecodeConnectionHandshakeEvents
 where
@@ -84,6 +86,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, ConnOpenInitEvent>
     for DecodeConnectionHandshakeEvents
 where
@@ -116,6 +119,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, ConnOpenTryEvent>
     for DecodeConnectionHandshakeEvents
 where
@@ -154,6 +158,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, ConnOpenAckEvent>
     for DecodeConnectionHandshakeEvents
 where
@@ -192,6 +197,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, ConnOpenConfirmEvent>
     for DecodeConnectionHandshakeEvents
 where

--- a/relayer/crates/starknet-chain-components/src/types/events/erc20.rs
+++ b/relayer/crates/starknet-chain-components/src/types/events/erc20.rs
@@ -4,6 +4,7 @@ use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_encoding_components::traits::decode::{CanDecode, Decoder};
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
+use hermes_wasm_encoding_components::components::DecoderComponent;
 use starknet::core::types::{Felt, U256};
 use starknet::macros::selector;
 
@@ -32,6 +33,7 @@ pub struct ApprovalEvent {
 
 pub struct DecodeErc20Events;
 
+#[cgp_provider(DecoderComponent)]
 impl<Encoding, Strategy> Decoder<Encoding, Strategy, Erc20Event> for DecodeErc20Events
 where
     Encoding: HasEncodedType<Encoded = StarknetEvent>
@@ -54,6 +56,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, TransferEvent>
     for DecodeErc20Events
 where
@@ -82,6 +85,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, ApprovalEvent>
     for DecodeErc20Events
 where

--- a/relayer/crates/starknet-chain-components/src/types/events/ics20.rs
+++ b/relayer/crates/starknet-chain-components/src/types/events/ics20.rs
@@ -4,6 +4,7 @@ use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_encoding_components::traits::decode::{CanDecode, Decoder};
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
+use hermes_wasm_encoding_components::components::DecoderComponent;
 use starknet::core::types::{Felt, U256};
 use starknet::macros::selector;
 
@@ -75,6 +76,7 @@ pub struct CreateIbcTokenEvent {
 
 pub struct DecodeIbcTransferEvents;
 
+#[cgp_provider(DecoderComponent)]
 impl<Encoding, Strategy> Decoder<Encoding, Strategy, IbcTransferEvent> for DecodeIbcTransferEvents
 where
     Encoding: HasEncodedType<Encoded = StarknetEvent>
@@ -112,6 +114,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, SendIbcTransferEvent>
     for DecodeIbcTransferEvents
 where
@@ -146,6 +149,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy>
     Decoder<EventEncoding, Strategy, ReceiveIbcTransferEvent> for DecodeIbcTransferEvents
 where
@@ -181,6 +185,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, AckIbcTransferEvent>
     for DecodeIbcTransferEvents
 where
@@ -216,6 +221,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy>
     Decoder<EventEncoding, Strategy, AckStatusIbcTransferEvent> for DecodeIbcTransferEvents
 where
@@ -243,6 +249,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy>
     Decoder<EventEncoding, Strategy, TimeoutIbcTransferEvent> for DecodeIbcTransferEvents
 where
@@ -276,6 +283,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, CreateIbcTokenEvent>
     for DecodeIbcTransferEvents
 where

--- a/relayer/crates/starknet-chain-components/src/types/events/packet.rs
+++ b/relayer/crates/starknet-chain-components/src/types/events/packet.rs
@@ -1,7 +1,7 @@
 use cgp::prelude::{CanRaiseAsyncError, *};
 use hermes_cairo_encoding_components::strategy::ViaCairo;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
-use hermes_encoding_components::traits::decode::{CanDecode, Decoder};
+use hermes_encoding_components::traits::decode::{CanDecode, Decoder, DecoderComponent};
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
 use starknet::core::types::Felt;
@@ -89,6 +89,7 @@ pub struct TimeoutPacketEvent {
 
 pub struct DecodePacketRelayEvents;
 
+#[cgp_provider(DecoderComponent)]
 impl<Encoding, Strategy> Decoder<Encoding, Strategy, PacketRelayEvents> for DecodePacketRelayEvents
 where
     Encoding: HasEncodedType<Encoded = StarknetEvent>
@@ -125,6 +126,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, SendPacketEvent>
     for DecodePacketRelayEvents
 where
@@ -184,6 +186,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, ReceivePacketEvent>
     for DecodePacketRelayEvents
 where
@@ -243,6 +246,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy>
     Decoder<EventEncoding, Strategy, WriteAcknowledgementEvent> for DecodePacketRelayEvents
 where
@@ -285,6 +289,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy>
     Decoder<EventEncoding, Strategy, AcknowledgePacketEvent> for DecodePacketRelayEvents
 where
@@ -343,6 +348,7 @@ where
     }
 }
 
+#[cgp_provider(DecoderComponent)]
 impl<EventEncoding, CairoEncoding, Strategy> Decoder<EventEncoding, Strategy, TimeoutPacketEvent>
     for DecodePacketRelayEvents
 where

--- a/relayer/crates/starknet-chain-components/src/types/message_response.rs
+++ b/relayer/crates/starknet-chain-components/src/types/message_response.rs
@@ -1,8 +1,11 @@
-use cgp::core::Async;
+use cgp::prelude::*;
 use hermes_chain_components::traits::types::event::HasEventType;
 use hermes_chain_type_components::traits::fields::message_response_events::MessageResponseEventsGetter;
 use hermes_chain_type_components::traits::types::message_response::{
     HasMessageResponseType, ProvideMessageResponseType,
+};
+use hermes_cosmos_chain_components::components::client::{
+    MessageResponseEventsGetterComponent, MessageResponseTypeComponent,
 };
 use starknet::core::types::Felt;
 
@@ -16,10 +19,12 @@ pub struct StarknetMessageResponse {
 
 pub struct UseStarknetMessageResponse;
 
+#[cgp_provider(MessageResponseTypeComponent)]
 impl<Chain: Async> ProvideMessageResponseType<Chain> for UseStarknetMessageResponse {
     type MessageResponse = StarknetMessageResponse;
 }
 
+#[cgp_provider(MessageResponseEventsGetterComponent)]
 impl<Chain> MessageResponseEventsGetter<Chain> for UseStarknetMessageResponse
 where
     Chain: HasEventType<Event = StarknetEvent>

--- a/relayer/crates/starknet-chain-components/src/types/messages/erc20/transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/erc20/transfer.rs
@@ -13,6 +13,7 @@ use starknet::accounts::Call;
 use starknet::core::types::{Felt, U256};
 use starknet::macros::selector;
 
+use crate::components::chain::TransferTokenMessageBuilderComponent;
 use crate::impls::types::address::StarknetAddress;
 use crate::impls::types::message::StarknetMessage;
 use crate::traits::messages::transfer::TransferTokenMessageBuilder;
@@ -37,6 +38,7 @@ pub type EncodeTransferErc20TokenMessage = CombineEncoders<
     ],
 >;
 
+#[cgp_provider(TransferTokenMessageBuilderComponent)]
 impl<Chain, Encoding> TransferTokenMessageBuilder<Chain> for BuildTransferErc20TokenMessage
 where
     Chain: HasAddressType<Address = StarknetAddress>

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/channel.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/channel.rs
@@ -22,6 +22,7 @@ use crate::types::cosmos::height::Height;
 
 pub struct EncodePortId;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, PortId> for EncodePortId
 where
     Encoding: CanEncodeMut<Strategy, Product![String]>,
@@ -36,6 +37,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, PortId> for EncodePortId
 where
     Encoding: CanDecodeMut<Strategy, Product![String]> + CanRaiseAsyncError<&'static str>,
@@ -50,6 +52,7 @@ where
 }
 pub struct EncodeAppVersion;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, AppVersion> for EncodeAppVersion
 where
     Encoding: CanEncodeMut<Strategy, Product![String]>,
@@ -64,6 +67,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, AppVersion> for EncodeAppVersion
 where
     Encoding: CanDecodeMut<Strategy, Product![String]> + CanRaiseAsyncError<&'static str>,

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/connection.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/connection.rs
@@ -20,6 +20,7 @@ use crate::types::cosmos::height::Height;
 
 pub struct EncodeConnectionVersion;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, ConnectionVersion>
     for EncodeConnectionVersion
 where
@@ -50,6 +51,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, ConnectionVersion>
     for EncodeConnectionVersion
 where
@@ -82,6 +84,7 @@ where
 
 pub struct EncodeBasePrefix;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, BasePrefix> for EncodeBasePrefix
 where
     Encoding: CanEncodeMut<Strategy, Product![String]> + CanRaiseAsyncError<&'static str>,
@@ -101,6 +104,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, BasePrefix> for EncodeBasePrefix
 where
     Encoding: CanDecodeMut<Strategy, Product![String]> + CanRaiseAsyncError<&'static str>,

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/packet.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/packet.rs
@@ -215,6 +215,7 @@ impl Transformer for EncodeMsgAckPacket {
 
 pub struct EncodeSequence;
 
+#[cgp_provider(MutEncoderComponent)]
 impl<Encoding, Strategy> MutEncoder<Encoding, Strategy, Sequence> for EncodeSequence
 where
     Encoding: CanEncodeMut<Strategy, Product![u64]>,
@@ -229,6 +230,7 @@ where
     }
 }
 
+#[cgp_provider(MutDecoderComponent)]
 impl<Encoding, Strategy> MutDecoder<Encoding, Strategy, Sequence> for EncodeSequence
 where
     Encoding: CanDecodeMut<Strategy, Product![u64]>,

--- a/relayer/crates/starknet-chain-context/src/contexts/chain.rs
+++ b/relayer/crates/starknet-chain-context/src/contexts/chain.rs
@@ -7,7 +7,7 @@ use cgp::core::types::WithType;
 use cgp::prelude::*;
 use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_cairo_encoding_components::types::as_starknet_event::AsStarknetEvent;
-use hermes_chain_type_components::traits::fields::chain_id::HasChainId;
+use hermes_chain_type_components::traits::fields::chain_id::{ChainIdGetterComponent, HasChainId};
 use hermes_chain_type_components::traits::types::commitment_proof::HasCommitmentProofType;
 use hermes_chain_type_components::traits::types::height::HasHeightType;
 use hermes_chain_type_components::traits::types::message_response::HasMessageResponseType;
@@ -18,7 +18,8 @@ use hermes_cosmos_chain_components::types::payloads::client::CosmosUpdateClientP
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_cosmos_relayer::presets::chain::PacketCommitmentQuerierComponent;
 use hermes_encoding_components::traits::has_encoding::{
-    DefaultEncodingGetter, EncodingGetter, HasDefaultEncoding, ProvideEncodingType,
+    DefaultEncodingGetter, DefaultEncodingGetterComponent, EncodingGetter, EncodingGetterComponent,
+    EncodingTypeComponent, HasDefaultEncoding, ProvideEncodingType,
 };
 use hermes_encoding_components::types::AsBytes;
 use hermes_error::impls::ProvideHermesError;
@@ -140,7 +141,9 @@ use hermes_starknet_chain_components::impls::types::events::StarknetCreateClient
 use hermes_starknet_chain_components::traits::account::{
     HasStarknetAccount, StarknetAccountGetterComponent, StarknetAccountTypeComponent,
 };
-use hermes_starknet_chain_components::traits::client::JsonRpcClientGetter;
+use hermes_starknet_chain_components::traits::client::{
+    JsonRpcClientGetter, JsonRpcClientGetterComponent,
+};
 use hermes_starknet_chain_components::traits::contract::call::CanCallContract;
 use hermes_starknet_chain_components::traits::contract::declare::CanDeclareContract;
 use hermes_starknet_chain_components::traits::contract::deploy::CanDeployContract;
@@ -242,48 +245,57 @@ delegate_components! {
     }
 }
 
+#[cgp_provider(EncodingTypeComponent)]
 impl ProvideEncodingType<StarknetChain, AsFelt> for StarknetChainContextComponents {
     type Encoding = StarknetCairoEncoding;
 }
 
+#[cgp_provider(EncodingTypeComponent)]
 impl ProvideEncodingType<StarknetChain, AsStarknetEvent> for StarknetChainContextComponents {
     type Encoding = StarknetEventEncoding;
 }
 
+#[cgp_provider(DefaultEncodingGetterComponent)]
 impl DefaultEncodingGetter<StarknetChain, AsFelt> for StarknetChainContextComponents {
     fn default_encoding() -> &'static StarknetCairoEncoding {
         &StarknetCairoEncoding
     }
 }
 
+#[cgp_provider(EncodingGetterComponent)]
 impl EncodingGetter<StarknetChain, AsFelt> for StarknetChainContextComponents {
     fn encoding(_chain: &StarknetChain) -> &StarknetCairoEncoding {
         &StarknetCairoEncoding
     }
 }
 
+#[cgp_provider(EncodingGetterComponent)]
 impl EncodingGetter<StarknetChain, AsStarknetEvent> for StarknetChainContextComponents {
     fn encoding(chain: &StarknetChain) -> &StarknetEventEncoding {
         &chain.event_encoding
     }
 }
 
+#[cgp_provider(EncodingTypeComponent)]
 impl ProvideEncodingType<StarknetChain, AsBytes> for StarknetChainContextComponents {
     type Encoding = StarknetProtobufEncoding;
 }
 
+#[cgp_provider(DefaultEncodingGetterComponent)]
 impl DefaultEncodingGetter<StarknetChain, AsBytes> for StarknetChainContextComponents {
     fn default_encoding() -> &'static StarknetProtobufEncoding {
         &StarknetProtobufEncoding
     }
 }
 
+#[cgp_provider(JsonRpcClientGetterComponent)]
 impl JsonRpcClientGetter<StarknetChain> for StarknetChainContextComponents {
     fn json_rpc_client(chain: &StarknetChain) -> &JsonRpcClient<HttpTransport> {
         &chain.rpc_client
     }
 }
 
+#[cgp_provider(ChainIdGetterComponent)]
 impl ChainIdGetter<StarknetChain> for StarknetChainContextComponents {
     fn chain_id(chain: &StarknetChain) -> &ChainId {
         &chain.chain_id

--- a/relayer/crates/starknet-chain-context/src/contexts/encoding/cairo.rs
+++ b/relayer/crates/starknet-chain-context/src/contexts/encoding/cairo.rs
@@ -13,7 +13,8 @@ use hermes_encoding_components::traits::decode_mut::CanPeekDecodeBuffer;
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::encode_and_decode::CanEncodeAndDecode;
 use hermes_encoding_components::traits::has_encoding::{
-    DefaultEncodingGetter, EncodingGetterComponent, HasEncodingType, ProvideEncodingType,
+    DefaultEncodingGetter, DefaultEncodingGetterComponent, EncodingGetterComponent,
+    EncodingTypeComponent, HasEncodingType, ProvideEncodingType,
 };
 use hermes_encoding_components::traits::types::decode_buffer::HasDecodeBufferType;
 use hermes_encoding_components::traits::types::encode_buffer::HasEncodeBufferType;
@@ -71,6 +72,7 @@ delegate_components! {
     }
 }
 
+#[cgp_provider(EncodingTypeComponent)]
 impl<Context> ProvideEncodingType<Context, AsFelt> for ProvideCairoEncoding
 where
     Context: Async,
@@ -78,6 +80,7 @@ where
     type Encoding = StarknetCairoEncoding;
 }
 
+#[cgp_provider(DefaultEncodingGetterComponent)]
 impl<Context> DefaultEncodingGetter<Context, AsFelt> for ProvideCairoEncoding
 where
     Context: HasEncodingType<AsFelt, Encoding = StarknetCairoEncoding>,

--- a/relayer/crates/starknet-cli/src/commands/create/subcommand.rs
+++ b/relayer/crates/starknet-cli/src/commands/create/subcommand.rs
@@ -1,5 +1,8 @@
+use cgp::prelude::*;
 use hermes_cli::commands::client::create::CreateClientArgs;
-use hermes_cli_components::traits::command::{CanRunCommand, CommandRunner};
+use hermes_cli_components::traits::command::{
+    CanRunCommand, CommandRunner, CommandRunnerComponent,
+};
 
 #[derive(Debug, clap::Subcommand)]
 pub enum CreateSubCommand {
@@ -8,6 +11,7 @@ pub enum CreateSubCommand {
 
 pub struct RunCreateSubCommand;
 
+#[cgp_provider(CommandRunnerComponent)]
 impl<App> CommandRunner<App, CreateSubCommand> for RunCreateSubCommand
 where
     App: CanRunCommand<CreateClientArgs>,

--- a/relayer/crates/starknet-cli/src/commands/query/subcommand.rs
+++ b/relayer/crates/starknet-cli/src/commands/query/subcommand.rs
@@ -1,8 +1,11 @@
+use cgp::prelude::*;
 use hermes_cli_components::impls::commands::queries::balance::QueryBalanceArgs;
 use hermes_cli_components::impls::commands::queries::chain_status::QueryChainStatusArgs;
 use hermes_cli_components::impls::commands::queries::client_state::QueryClientStateArgs;
 use hermes_cli_components::impls::commands::queries::consensus_state::QueryConsensusStateArgs;
-use hermes_cli_components::traits::command::{CanRunCommand, CommandRunner};
+use hermes_cli_components::traits::command::{
+    CanRunCommand, CommandRunner, CommandRunnerComponent,
+};
 
 #[derive(Debug, clap::Subcommand)]
 pub enum QuerySubCommand {
@@ -14,6 +17,7 @@ pub enum QuerySubCommand {
 
 pub struct RunQuerySubCommand;
 
+#[cgp_provider(CommandRunnerComponent)]
 impl<App> CommandRunner<App, QuerySubCommand> for RunQuerySubCommand
 where
     App: CanRunCommand<QueryClientStateArgs>

--- a/relayer/crates/starknet-cli/src/commands/update/subcommand.rs
+++ b/relayer/crates/starknet-cli/src/commands/update/subcommand.rs
@@ -1,5 +1,8 @@
+use cgp::prelude::*;
 use hermes_cli_components::impls::commands::client::update::UpdateClientArgs;
-use hermes_cli_components::traits::command::{CanRunCommand, CommandRunner};
+use hermes_cli_components::traits::command::{
+    CanRunCommand, CommandRunner, CommandRunnerComponent,
+};
 
 #[derive(Debug, clap::Subcommand)]
 pub enum UpdateSubCommand {
@@ -8,6 +11,7 @@ pub enum UpdateSubCommand {
 
 pub struct RunUpdateSubCommand;
 
+#[cgp_provider(CommandRunnerComponent)]
 impl<App> CommandRunner<App, UpdateSubCommand> for RunUpdateSubCommand
 where
     App: CanRunCommand<UpdateClientArgs>,

--- a/relayer/crates/starknet-cli/src/contexts/app.rs
+++ b/relayer/crates/starknet-cli/src/contexts/app.rs
@@ -9,7 +9,7 @@ use cgp::prelude::*;
 use hermes_cli::commands::client::create::CreateClientArgs;
 use hermes_cli_components::impls::commands::bootstrap::chain::RunBootstrapChainCommand;
 use hermes_cli_components::impls::commands::client::create::{
-    CreateClientOptionsParser, RunCreateClientCommand,
+    CreateClientOptionsParser, CreateClientOptionsParserComponent, RunCreateClientCommand,
 };
 use hermes_cli_components::impls::commands::client::update::{
     RunUpdateClientCommand, UpdateClientArgs,
@@ -31,7 +31,9 @@ use hermes_cli_components::impls::config::get_config_path::GetDefaultConfigField
 use hermes_cli_components::impls::config::load_toml_config::LoadTomlConfig;
 use hermes_cli_components::impls::config::save_toml_config::WriteTomlConfig;
 use hermes_cli_components::impls::parse::string::{ParseFromOptionalString, ParseFromString};
-use hermes_cli_components::traits::any_counterparty::ProvideAnyCounterparty;
+use hermes_cli_components::traits::any_counterparty::{
+    AnyCounterpartyComponent, ProvideAnyCounterparty,
+};
 use hermes_cli_components::traits::bootstrap::{
     BootstrapLoaderComponent, BootstrapTypeComponent, CanLoadBootstrap,
 };
@@ -45,7 +47,7 @@ use hermes_cli_components::traits::config::config_path::{
 use hermes_cli_components::traits::config::load_config::{CanLoadConfig, ConfigLoaderComponent};
 use hermes_cli_components::traits::config::write_config::{CanWriteConfig, ConfigWriterComponent};
 use hermes_cli_components::traits::output::{
-    CanProduceOutput, OutputProducer, OutputTypeComponent,
+    CanProduceOutput, OutputProducer, OutputProducerComponent, OutputTypeComponent,
 };
 use hermes_cli_components::traits::parse::ArgParserComponent;
 use hermes_cli_components::traits::types::config::ConfigTypeComponent;
@@ -72,7 +74,7 @@ use hermes_starknet_chain_context::contexts::chain::StarknetChain;
 use hermes_starknet_integration_tests::contexts::bootstrap::StarknetBootstrap;
 use hermes_starknet_integration_tests::contexts::chain_driver::StarknetChainDriver;
 use hermes_starknet_relayer::contexts::builder::StarknetBuilder;
-use hermes_test_components::chain_driver::traits::config::ConfigUpdater;
+use hermes_test_components::chain_driver::traits::config::{ConfigUpdater, ConfigUpdaterComponent};
 use ibc::core::client::types::Height;
 use ibc::core::host::types::identifiers::{ChainId, ClientId as CosmosClientId};
 use toml::to_string_pretty;
@@ -196,6 +198,7 @@ delegate_components! {
     }
 }
 
+#[cgp_provider(AnyCounterpartyComponent)]
 impl<App> ProvideAnyCounterparty<App> for StarknetAppComponents
 where
     App: Async,
@@ -203,10 +206,12 @@ where
     type AnyCounterparty = CosmosChain;
 }
 
+#[cgp_provider(OutputProducerComponent)]
 impl<Value> OutputProducer<StarknetApp, Value> for StarknetAppComponents {
     fn produce_output(_app: &StarknetApp, _value: Value) {}
 }
 
+#[cgp_provider(ConfigUpdaterComponent)]
 impl ConfigUpdater<StarknetChainDriver, StarknetRelayerConfig> for UpdateStarknetConfig {
     fn update_config(
         chain_driver: &StarknetChainDriver,
@@ -240,6 +245,7 @@ impl ConfigUpdater<StarknetChainDriver, StarknetRelayerConfig> for UpdateStarkne
     }
 }
 
+#[cgp_provider(CreateClientOptionsParserComponent)]
 impl CreateClientOptionsParser<StarknetApp, CreateClientArgs, Index<0>, Index<1>>
     for StarknetAppComponents
 {
@@ -273,6 +279,7 @@ impl CreateClientOptionsParser<StarknetApp, CreateClientArgs, Index<0>, Index<1>
 // TODO(seanchen1991): Implement Cosmos-to-Starknet client creation
 pub struct CreateCosmosClientOnStarknetArgs;
 
+#[cgp_provider(CreateClientOptionsParserComponent)]
 impl CreateClientOptionsParser<StarknetApp, CreateCosmosClientOnStarknetArgs, Index<1>, Index<0>>
     for StarknetAppComponents
 {

--- a/relayer/crates/starknet-cli/src/impls/bootstrap/starknet_chain.rs
+++ b/relayer/crates/starknet-cli/src/impls/bootstrap/starknet_chain.rs
@@ -1,5 +1,7 @@
 use cgp::prelude::*;
-use hermes_cli_components::traits::bootstrap::{BootstrapLoader, HasBootstrapType};
+use hermes_cli_components::traits::bootstrap::{
+    BootstrapLoader, BootstrapLoaderComponent, HasBootstrapType,
+};
 use hermes_runtime::types::runtime::HermesRuntime;
 use hermes_runtime_components::traits::runtime::HasRuntime;
 use hermes_starknet_integration_tests::contexts::bootstrap::StarknetBootstrap;
@@ -18,6 +20,7 @@ pub struct BootstrapStarknetChainArgs {
 
 pub struct LoadStarknetBootstrap;
 
+#[cgp_provider(BootstrapLoaderComponent)]
 impl<App> BootstrapLoader<App, BootstrapStarknetChainArgs> for LoadStarknetBootstrap
 where
     App: HasBootstrapType<Bootstrap = StarknetBootstrap>

--- a/relayer/crates/starknet-cli/src/impls/bootstrap/subcommand.rs
+++ b/relayer/crates/starknet-cli/src/impls/bootstrap/subcommand.rs
@@ -1,4 +1,7 @@
-use hermes_cli_components::traits::command::{CanRunCommand, CommandRunner};
+use cgp::prelude::*;
+use hermes_cli_components::traits::command::{
+    CanRunCommand, CommandRunner, CommandRunnerComponent,
+};
 
 use crate::impls::bootstrap::starknet_chain::BootstrapStarknetChainArgs;
 
@@ -9,6 +12,7 @@ pub enum BootstrapSubCommand {
 
 pub struct RunBootstrapSubCommand;
 
+#[cgp_provider(CommandRunnerComponent)]
 impl<App> CommandRunner<App, BootstrapSubCommand> for RunBootstrapSubCommand
 where
     App: CanRunCommand<BootstrapStarknetChainArgs>,

--- a/relayer/crates/starknet-cli/src/impls/build.rs
+++ b/relayer/crates/starknet-cli/src/impls/build.rs
@@ -1,5 +1,5 @@
-use cgp::prelude::CanRaiseAsyncError;
-use hermes_cli_components::traits::build::{BuilderLoader, HasBuilderType};
+use cgp::prelude::*;
+use hermes_cli_components::traits::build::{BuilderLoader, BuilderLoaderComponent, HasBuilderType};
 use hermes_cli_components::traits::config::load_config::CanLoadConfig;
 use hermes_cli_components::traits::types::config::HasConfigType;
 use hermes_cosmos_relayer::contexts::build::CosmosBuilder;
@@ -10,6 +10,7 @@ use hermes_starknet_relayer::contexts::builder::StarknetBuilder;
 
 pub struct LoadStarknetBuilder;
 
+#[cgp_provider(BuilderLoaderComponent)]
 impl<App> BuilderLoader<App> for LoadStarknetBuilder
 where
     App: HasBuilderType<Builder = StarknetBuilder>

--- a/relayer/crates/starknet-cli/src/impls/subcommand.rs
+++ b/relayer/crates/starknet-cli/src/impls/subcommand.rs
@@ -1,5 +1,8 @@
+use cgp::prelude::*;
 use hermes_cli_components::impls::commands::start::StartRelayerArgs;
-use hermes_cli_components::traits::command::{CanRunCommand, CommandRunner};
+use hermes_cli_components::traits::command::{
+    CanRunCommand, CommandRunner, CommandRunnerComponent,
+};
 
 use crate::commands::create::subcommand::CreateSubCommand;
 use crate::commands::query::subcommand::QuerySubCommand;
@@ -22,6 +25,7 @@ pub enum AllSubCommands {
 
 pub struct RunAllSubCommand;
 
+#[cgp_provider(CommandRunnerComponent)]
 impl<App> CommandRunner<App, AllSubCommands> for RunAllSubCommand
 where
     App: CanRunCommand<BootstrapSubCommand>

--- a/relayer/crates/starknet-cli/src/lib.rs
+++ b/relayer/crates/starknet-cli/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 extern crate alloc;
 
 pub mod commands;

--- a/relayer/crates/starknet-integration-tests/src/contexts/bootstrap.rs
+++ b/relayer/crates/starknet-integration-tests/src/contexts/bootstrap.rs
@@ -11,12 +11,18 @@ use hermes_cosmos_chain_components::types::key_types::secp256k1::Secp256k1KeyPai
 use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::{
     ChainGenesisConfigTypeComponent, ChainNodeConfigTypeComponent,
 };
-use hermes_cosmos_test_components::bootstrap::traits::chain::build_chain_driver::ChainDriverBuilder;
+use hermes_cosmos_test_components::bootstrap::traits::chain::build_chain_driver::{
+    ChainDriverBuilder, ChainDriverBuilderComponent,
+};
 use hermes_cosmos_test_components::bootstrap::traits::chain::start_chain::{
     CanStartChainFullNode, ChainFullNodeStarterComponent,
 };
-use hermes_cosmos_test_components::bootstrap::traits::fields::chain_command_path::ChainCommandPathGetter;
-use hermes_cosmos_test_components::bootstrap::traits::fields::chain_store_dir::ChainStoreDirGetter;
+use hermes_cosmos_test_components::bootstrap::traits::fields::chain_command_path::{
+    ChainCommandPathGetter, ChainCommandPathGetterComponent,
+};
+use hermes_cosmos_test_components::bootstrap::traits::fields::chain_store_dir::{
+    ChainStoreDirGetter, ChainStoreDirGetterComponent,
+};
 use hermes_error::impls::ProvideHermesError;
 use hermes_error::types::HermesError;
 use hermes_runtime::types::runtime::HermesRuntime;
@@ -35,8 +41,12 @@ use hermes_starknet_test_components::types::node_config::StarknetNodeConfig;
 use hermes_test_components::bootstrap::traits::chain::{
     CanBootstrapChain, ChainBootstrapperComponent,
 };
-use hermes_test_components::chain_driver::traits::types::chain::ProvideChainType;
-use hermes_test_components::driver::traits::types::chain_driver::ProvideChainDriverType;
+use hermes_test_components::chain_driver::traits::types::chain::{
+    ChainTypeComponent, ProvideChainType,
+};
+use hermes_test_components::driver::traits::types::chain_driver::{
+    ChainDriverTypeComponent, ProvideChainDriverType,
+};
 use starknet::accounts::{ExecutionEncoding, SingleOwnerAccount};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
@@ -71,26 +81,31 @@ delegate_components! {
     }
 }
 
+#[cgp_provider(ChainTypeComponent)]
 impl ProvideChainType<StarknetBootstrap> for StarknetBootstrapComponents {
     type Chain = StarknetChain;
 }
 
+#[cgp_provider(ChainDriverTypeComponent)]
 impl ProvideChainDriverType<StarknetBootstrap> for StarknetBootstrapComponents {
     type ChainDriver = StarknetChainDriver;
 }
 
+#[cgp_provider(ChainCommandPathGetterComponent)]
 impl ChainCommandPathGetter<StarknetBootstrap> for StarknetBootstrapComponents {
     fn chain_command_path(bootstrap: &StarknetBootstrap) -> &PathBuf {
         &bootstrap.chain_command_path
     }
 }
 
+#[cgp_provider(ChainStoreDirGetterComponent)]
 impl ChainStoreDirGetter<StarknetBootstrap> for StarknetBootstrapComponents {
     fn chain_store_dir(bootstrap: &StarknetBootstrap) -> &PathBuf {
         &bootstrap.chain_store_dir
     }
 }
 
+#[cgp_provider(ChainDriverBuilderComponent)]
 impl ChainDriverBuilder<StarknetBootstrap> for StarknetBootstrapComponents {
     async fn build_chain_driver(
         bootstrap: &StarknetBootstrap,

--- a/relayer/crates/starknet-integration-tests/src/contexts/chain_driver.rs
+++ b/relayer/crates/starknet-integration-tests/src/contexts/chain_driver.rs
@@ -15,9 +15,11 @@ use hermes_starknet_chain_context::contexts::chain::StarknetChain;
 use hermes_starknet_chain_context::impls::error::HandleStarknetChainError;
 use hermes_starknet_test_components::types::genesis_config::StarknetGenesisConfig;
 use hermes_starknet_test_components::types::node_config::StarknetNodeConfig;
-use hermes_test_components::chain_driver::traits::chain_process::ChainProcessTaker;
+use hermes_test_components::chain_driver::traits::chain_process::{
+    ChainProcessTaker, ChainProcessTakerComponent,
+};
 use hermes_test_components::chain_driver::traits::types::chain::{
-    ChainGetter, HasChain, ProvideChainType,
+    ChainGetter, ChainGetterComponent, ChainTypeComponent, HasChain, ProvideChainType,
 };
 use tokio::process::Child;
 
@@ -44,16 +46,19 @@ delegate_components! {
     }
 }
 
+#[cgp_provider(ChainTypeComponent)]
 impl ProvideChainType<StarknetChainDriver> for StarknetChainDriverComponents {
     type Chain = StarknetChain;
 }
 
+#[cgp_provider(ChainGetterComponent)]
 impl ChainGetter<StarknetChainDriver> for StarknetChainDriverComponents {
     fn chain(driver: &StarknetChainDriver) -> &StarknetChain {
         &driver.chain
     }
 }
 
+#[cgp_provider(ChainProcessTakerComponent)]
 impl ChainProcessTaker<StarknetChainDriver> for StarknetChainDriverComponents {
     fn take_chain_process(chain_driver: &mut StarknetChainDriver) -> Option<Child> {
         chain_driver.chain_process.take()

--- a/relayer/crates/starknet-relayer/src/build/components/relay/build.rs
+++ b/relayer/crates/starknet-relayer/src/build/components/relay/build.rs
@@ -1,14 +1,17 @@
 use core::marker::PhantomData;
 
 use cgp::core::field::Index;
+use cgp::prelude::*;
 use hermes_error::HermesError;
 use hermes_relayer_components::build::traits::builders::relay_builder::RelayBuilder;
+use hermes_relayer_components::components::default::build::RelayBuilderComponent;
 use hermes_starknet_chain_components::types::client_id::ClientId as StarknetClientId;
 use ibc::core::host::types::identifiers::{ChainId, ClientId as CosmosClientId};
 
 use crate::contexts::builder::{StarknetBuildComponents, StarknetBuilder};
 use crate::contexts::starknet_to_cosmos_relay::StarknetToCosmosRelay;
 
+#[cgp_provider(RelayBuilderComponent)]
 impl RelayBuilder<StarknetBuilder, Index<0>, Index<1>> for StarknetBuildComponents {
     async fn build_relay(
         build: &StarknetBuilder,

--- a/relayer/crates/starknet-relayer/src/contexts/birelay.rs
+++ b/relayer/crates/starknet-relayer/src/contexts/birelay.rs
@@ -6,7 +6,9 @@ use cgp::extra::run::RunnerComponent;
 use cgp::prelude::*;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_error::impls::ProvideHermesError;
-use hermes_relayer_components::birelay::traits::two_way::TwoWayRelayGetter;
+use hermes_relayer_components::birelay::traits::two_way::{
+    TwoWayRelayGetter, TwoWayRelayGetterComponent,
+};
 use hermes_relayer_components::components::default::birelay::{
     DefaultBiRelayComponents, IsDefaultBiRelayComponents,
 };
@@ -43,6 +45,7 @@ delegate_components! {
     }
 }
 
+#[cgp_provider(TwoWayRelayGetterComponent)]
 impl TwoWayRelayGetter<StarknetCosmosBiRelay> for StarknetCosmosBiRelayComponents {
     fn relay_a_to_b(birelay: &StarknetCosmosBiRelay) -> &StarknetToCosmosRelay {
         &birelay.relay_a_to_b

--- a/relayer/crates/starknet-relayer/src/contexts/builder.rs
+++ b/relayer/crates/starknet-relayer/src/contexts/builder.rs
@@ -18,6 +18,9 @@ use hermes_relayer_components::build::traits::builders::birelay_builder::BiRelay
 use hermes_relayer_components::build::traits::builders::chain_builder::{
     CanBuildChain, ChainBuilder,
 };
+use hermes_relayer_components::components::default::build::{
+    BiRelayBuilderComponent, ChainBuilderComponent,
+};
 use hermes_relayer_components::multi::traits::birelay_at::BiRelayTypeAtComponent;
 use hermes_relayer_components::multi::traits::chain_at::ChainTypeAtComponent;
 use hermes_relayer_components::multi::traits::relay_at::RelayTypeAtComponent;
@@ -87,6 +90,7 @@ delegate_components! {
     }
 }
 
+#[cgp_provider(ChainBuilderComponent)]
 impl ChainBuilder<StarknetBuilder, Index<0>> for StarknetBuildComponents {
     async fn build_chain(
         build: &StarknetBuilder,
@@ -97,6 +101,7 @@ impl ChainBuilder<StarknetBuilder, Index<0>> for StarknetBuildComponents {
     }
 }
 
+#[cgp_provider(ChainBuilderComponent)]
 impl ChainBuilder<StarknetBuilder, Index<1>> for StarknetBuildComponents {
     async fn build_chain(
         build: &StarknetBuilder,
@@ -107,6 +112,7 @@ impl ChainBuilder<StarknetBuilder, Index<1>> for StarknetBuildComponents {
     }
 }
 
+#[cgp_provider(BiRelayBuilderComponent)]
 impl BiRelayBuilder<StarknetBuilder, Index<0>, Index<1>> for StarknetBuildComponents {
     async fn build_birelay(
         build: &StarknetBuilder,

--- a/relayer/crates/starknet-relayer/src/contexts/cosmos_to_starknet_relay.rs
+++ b/relayer/crates/starknet-relayer/src/contexts/cosmos_to_starknet_relay.rs
@@ -6,7 +6,7 @@ use cgp::prelude::*;
 use futures::lock::Mutex;
 use hermes_cosmos_relayer::contexts::chain::CosmosChain;
 use hermes_logging_components::traits::has_logger::HasLogger;
-use hermes_relayer_components::components::default::relay::MainSink;
+use hermes_relayer_components::components::default::relay::{IbcMessageSenderComponent, MainSink};
 use hermes_relayer_components::multi::traits::chain_at::{
     ChainGetterAtComponent, ChainTypeAtComponent,
 };
@@ -29,9 +29,6 @@ use hermes_relayer_components::relay::traits::connection::open_confirm::CanRelay
 use hermes_relayer_components::relay::traits::connection::open_init::CanInitConnection;
 use hermes_relayer_components::relay::traits::connection::open_try::CanRelayConnectionOpenTry;
 use hermes_relayer_components::relay::traits::event_relayer::CanRelayEvent;
-use hermes_relayer_components::relay::traits::ibc_message_sender::{
-    CanSendIbcMessages, CanSendSingleIbcMessage,
-};
 use hermes_relayer_components::relay::traits::packet_lock::HasPacketLock;
 use hermes_relayer_components::relay::traits::packet_relayer::CanRelayPacket;
 use hermes_relayer_components::relay::traits::target::{
@@ -128,14 +125,10 @@ pub trait CanUseCosmosToStarknetRelay:
     + HasTargetClientIds<DestinationTarget>
     + CanCreateClient<DestinationTarget>
     + CanCreateClient<SourceTarget>
-    + CanSendSingleIbcMessage<MainSink, SourceTarget>
-    + CanSendSingleIbcMessage<MainSink, DestinationTarget>
     + CanBuildTargetUpdateClientMessage<SourceTarget>
     + CanBuildTargetUpdateClientMessage<DestinationTarget>
     + CanSendTargetUpdateClientMessage<SourceTarget>
     + CanSendTargetUpdateClientMessage<DestinationTarget>
-    + CanSendIbcMessages<MainSink, SourceTarget>
-    + CanSendIbcMessages<MainSink, DestinationTarget>
     + CanInitConnection
     + CanRelayConnectionOpenTry
     + CanRelayConnectionOpenAck
@@ -152,6 +145,8 @@ pub trait CanUseCosmosToStarknetRelay:
     + CanRelayEvent<DestinationTarget>
     + CanAutoRelay<SourceTarget>
     + CanAutoRelay<DestinationTarget>
+    + CanUseComponent<IbcMessageSenderComponent<MainSink>, (MainSink, SourceTarget)>
+    + CanUseComponent<IbcMessageSenderComponent<MainSink>, (MainSink, DestinationTarget)>
 {
 }
 

--- a/relayer/crates/starknet-relayer/src/lib.rs
+++ b/relayer/crates/starknet-relayer/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 extern crate alloc;
 
 pub mod build;

--- a/relayer/crates/starknet-relayer/src/presets/relay.rs
+++ b/relayer/crates/starknet-relayer/src/presets/relay.rs
@@ -1,55 +1,58 @@
-use cgp::core::component::UseDelegate;
-pub use cgp::core::error::{ErrorRaiserComponent, ErrorTypeProviderComponent};
-use cgp::core::field::{Index, UseField, WithField};
-use cgp::core::types::WithType;
-use cgp::prelude::*;
-use hermes_cosmos_relayer::contexts::chain::CosmosChain;
-use hermes_error::impls::ProvideHermesError;
-use hermes_logger::ProvideHermesLogger;
-pub use hermes_logging_components::traits::has_logger::{
-    GlobalLoggerGetterComponent, LoggerGetterComponent, LoggerTypeComponent,
-};
-use hermes_relayer_components::components::default::relay::*;
-pub use hermes_relayer_components::multi::traits::chain_at::{
-    ChainGetterAtComponent, ChainTypeAtComponent,
-};
-pub use hermes_relayer_components::multi::traits::client_id_at::ClientIdAtGetterComponent;
-use hermes_relayer_components::relay::impls::packet_lock::PacketMutexGetterComponent;
-use hermes_runtime::types::runtime::HermesRuntime;
-pub use hermes_runtime_components::traits::runtime::{
-    RuntimeGetterComponent, RuntimeTypeProviderComponent,
-};
-use hermes_starknet_chain_context::contexts::chain::StarknetChain;
+#[cgp::re_export_imports]
+mod preset {
+    use cgp::core::component::UseDelegate;
+    use cgp::core::error::{ErrorRaiserComponent, ErrorTypeProviderComponent};
+    use cgp::core::field::{Index, UseField, WithField};
+    use cgp::core::types::WithType;
+    use cgp::prelude::*;
+    use hermes_cosmos_relayer::contexts::chain::CosmosChain;
+    use hermes_error::impls::ProvideHermesError;
+    use hermes_logger::ProvideHermesLogger;
+    use hermes_logging_components::traits::has_logger::{
+        GlobalLoggerGetterComponent, LoggerGetterComponent, LoggerTypeComponent,
+    };
+    use hermes_relayer_components::components::default::relay::*;
+    use hermes_relayer_components::multi::traits::chain_at::{
+        ChainGetterAtComponent, ChainTypeAtComponent,
+    };
+    use hermes_relayer_components::multi::traits::client_id_at::ClientIdAtGetterComponent;
+    use hermes_relayer_components::relay::impls::packet_lock::PacketMutexGetterComponent;
+    use hermes_runtime::types::runtime::HermesRuntime;
+    use hermes_runtime_components::traits::runtime::{
+        RuntimeGetterComponent, RuntimeTypeProviderComponent,
+    };
+    use hermes_starknet_chain_context::contexts::chain::StarknetChain;
 
-use crate::impls::error::HandleStarknetRelayError;
+    use crate::impls::error::HandleStarknetRelayError;
 
-with_default_relay_preset! {
-    | Components | {
-        cgp_preset! {
-            StarknetCommonRelayContextPreset {
-                ErrorTypeProviderComponent: ProvideHermesError,
-                ErrorRaiserComponent: UseDelegate<HandleStarknetRelayError>,
-                RuntimeTypeProviderComponent: WithType<HermesRuntime>,
-                RuntimeGetterComponent: WithField<symbol!("runtime")>,
-                [
-                    LoggerTypeComponent,
-                    LoggerGetterComponent,
-                    GlobalLoggerGetterComponent,
-                ]:
-                    ProvideHermesLogger,
-                ChainTypeAtComponent<Index<0>>: WithType<CosmosChain>,
-                ChainTypeAtComponent<Index<1>>: WithType<StarknetChain>,
-                ChainGetterAtComponent<Index<0>>:
-                    UseField<symbol!("chain_a")>,
-                ChainGetterAtComponent<Index<1>>:
-                    UseField<symbol!("chain_b")>,
-                ClientIdAtGetterComponent<Index<0>, Index<1>>:
-                    UseField<symbol!("client_id_a")>,
-                ClientIdAtGetterComponent<Index<1>, Index<0>>:
-                    UseField<symbol!("client_id_b")>,
-                PacketMutexGetterComponent:
-                    UseField<symbol!("packet_lock_mutex")>,
-                Components: DefaultRelayPreset,
+    with_default_relay_preset! {
+        | Components | {
+            cgp_preset! {
+                StarknetCommonRelayContextPreset {
+                    ErrorTypeProviderComponent: ProvideHermesError,
+                    ErrorRaiserComponent: UseDelegate<HandleStarknetRelayError>,
+                    RuntimeTypeProviderComponent: WithType<HermesRuntime>,
+                    RuntimeGetterComponent: WithField<symbol!("runtime")>,
+                    [
+                        LoggerTypeComponent,
+                        LoggerGetterComponent,
+                        GlobalLoggerGetterComponent,
+                    ]:
+                        ProvideHermesLogger,
+                    ChainTypeAtComponent<Index<0>>: WithType<CosmosChain>,
+                    ChainTypeAtComponent<Index<1>>: WithType<StarknetChain>,
+                    ChainGetterAtComponent<Index<0>>:
+                        UseField<symbol!("chain_a")>,
+                    ChainGetterAtComponent<Index<1>>:
+                        UseField<symbol!("chain_b")>,
+                    ClientIdAtGetterComponent<Index<0>, Index<1>>:
+                        UseField<symbol!("client_id_a")>,
+                    ClientIdAtGetterComponent<Index<1>, Index<0>>:
+                        UseField<symbol!("client_id_b")>,
+                    PacketMutexGetterComponent:
+                        UseField<symbol!("packet_lock_mutex")>,
+                    Components: DefaultRelayPreset,
+                }
             }
         }
     }

--- a/relayer/crates/starknet-test-components/src/impls/bootstrap/bootstrap_chain.rs
+++ b/relayer/crates/starknet-test-components/src/impls/bootstrap/bootstrap_chain.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr};
 
 use cgp::core::error::CanRaiseAsyncError;
+use cgp::prelude::*;
 use hermes_cosmos_test_components::bootstrap::traits::chain::build_chain_driver::CanBuildChainDriver;
 use hermes_cosmos_test_components::bootstrap::traits::chain::start_chain::CanStartChainFullNode;
 use hermes_cosmos_test_components::bootstrap::traits::fields::chain_store_dir::HasChainStoreDir;
@@ -14,7 +15,9 @@ use hermes_runtime_components::traits::os::reserve_port::CanReserveTcpPort;
 use hermes_runtime_components::traits::random::CanGenerateRandom;
 use hermes_runtime_components::traits::runtime::HasRuntime;
 use hermes_starknet_chain_components::types::wallet::StarknetWallet;
-use hermes_test_components::bootstrap::traits::chain::ChainBootstrapper;
+use hermes_test_components::bootstrap::traits::chain::{
+    ChainBootstrapper, ChainBootstrapperComponent,
+};
 use hermes_test_components::chain::traits::types::wallet::HasWalletType;
 use hermes_test_components::chain_driver::traits::types::chain::HasChainType;
 use starknet::macros::felt;
@@ -24,6 +27,7 @@ use crate::types::node_config::StarknetNodeConfig;
 
 pub struct BootstrapStarknetDevnet;
 
+#[cgp_provider(ChainBootstrapperComponent)]
 impl<Bootstrap, Runtime> ChainBootstrapper<Bootstrap> for BootstrapStarknetDevnet
 where
     Bootstrap: HasRuntime<Runtime = Runtime>

--- a/relayer/crates/starknet-test-components/src/impls/bootstrap/start_chain.rs
+++ b/relayer/crates/starknet-test-components/src/impls/bootstrap/start_chain.rs
@@ -1,4 +1,5 @@
-use cgp::core::error::CanRaiseAsyncError;
+use cgp::prelude::*;
+use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::ChainFullNodeStarterComponent;
 use hermes_cosmos_test_components::bootstrap::traits::chain::start_chain::ChainFullNodeStarter;
 use hermes_cosmos_test_components::bootstrap::traits::fields::chain_command_path::HasChainCommandPath;
 use hermes_cosmos_test_components::bootstrap::traits::types::chain_node_config::HasChainNodeConfigType;
@@ -12,6 +13,7 @@ use crate::types::node_config::StarknetNodeConfig;
 
 pub struct StartStarknetDevnet;
 
+#[cgp_provider(ChainFullNodeStarterComponent)]
 impl<Bootstrap, Runtime> ChainFullNodeStarter<Bootstrap> for StartStarknetDevnet
 where
     Bootstrap: HasRuntime<Runtime = Runtime>

--- a/relayer/crates/starknet-test-components/src/impls/types/genesis_config.rs
+++ b/relayer/crates/starknet-test-components/src/impls/types/genesis_config.rs
@@ -1,10 +1,13 @@
-use cgp::core::Async;
-use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::ProvideChainGenesisConfigType;
+use cgp::prelude::*;
+use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::{
+    ChainGenesisConfigTypeComponent, ProvideChainGenesisConfigType,
+};
 
 use crate::types::genesis_config::StarknetGenesisConfig;
 
 pub struct ProvideStarknetGenesisConfigType;
 
+#[cgp_provider(ChainGenesisConfigTypeComponent)]
 impl<Bootstrap: Async> ProvideChainGenesisConfigType<Bootstrap>
     for ProvideStarknetGenesisConfigType
 {

--- a/relayer/crates/starknet-test-components/src/impls/types/node_config.rs
+++ b/relayer/crates/starknet-test-components/src/impls/types/node_config.rs
@@ -1,10 +1,13 @@
-use cgp::core::Async;
-use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::ProvideChainNodeConfigType;
+use cgp::prelude::*;
+use hermes_cosmos_test_components::bootstrap::components::cosmos_sdk::{
+    ChainNodeConfigTypeComponent, ProvideChainNodeConfigType,
+};
 
 use crate::types::node_config::StarknetNodeConfig;
 
 pub struct ProvideStarknetNodeConfigType;
 
+#[cgp_provider(ChainNodeConfigTypeComponent)]
 impl<Bootstrap: Async> ProvideChainNodeConfigType<Bootstrap> for ProvideStarknetNodeConfigType {
     type ChainNodeConfig = StarknetNodeConfig;
 }

--- a/relayer/crates/starknet-test-components/src/impls/types/wallet.rs
+++ b/relayer/crates/starknet-test-components/src/impls/types/wallet.rs
@@ -1,3 +1,5 @@
+use cgp::prelude::*;
+use hermes_cosmos_test_components::chain::components::WalletTypeComponent;
 use hermes_starknet_chain_components::impls::types::address::StarknetAddress;
 use hermes_starknet_chain_components::types::wallet::StarknetWallet;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
@@ -5,6 +7,7 @@ use hermes_test_components::chain::traits::types::wallet::ProvideWalletType;
 
 pub struct ProvideStarknetWalletType;
 
+#[cgp_provider(WalletTypeComponent)]
 impl<Bootstrap> ProvideWalletType<Bootstrap> for ProvideStarknetWalletType
 where
     Bootstrap: HasAddressType<Address = StarknetAddress>,

--- a/relayer/crates/tools/src/commands/starknet/subcommand.rs
+++ b/relayer/crates/tools/src/commands/starknet/subcommand.rs
@@ -1,5 +1,7 @@
-use cgp::core::Async;
-use hermes_cli_components::traits::command::{CanRunCommand, CommandRunner};
+use cgp::prelude::*;
+use hermes_cli_components::traits::command::{
+    CanRunCommand, CommandRunner, CommandRunnerComponent,
+};
 
 use crate::commands::starknet::transfer_args::TransferArgs;
 
@@ -13,6 +15,7 @@ pub enum StarknetSubCommand {
 
 pub struct RunStarknetSubCommand;
 
+#[cgp_provider(CommandRunnerComponent)]
 impl<App> CommandRunner<App, StarknetSubCommand> for RunStarknetSubCommand
 where
     App: CanRunCommand<TransferArgs>,

--- a/relayer/crates/tools/src/commands/starknet/transfer_args.rs
+++ b/relayer/crates/tools/src/commands/starknet/transfer_args.rs
@@ -1,5 +1,5 @@
 use cgp::prelude::*;
-use hermes_cli_components::traits::command::CommandRunner;
+use hermes_cli_components::traits::command::{CommandRunner, CommandRunnerComponent};
 use hermes_cli_components::traits::output::HasOutputType;
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_logging_components::traits::has_logger::HasLogger;
@@ -68,6 +68,7 @@ pub struct TransferArgs {
 
 pub struct RunTransferArgs;
 
+#[cgp_provider(CommandRunnerComponent)]
 #[async_trait]
 impl CommandRunner<ToolApp, TransferArgs> for RunTransferArgs {
     async fn run_command(

--- a/relayer/crates/tools/src/commands/subcommand.rs
+++ b/relayer/crates/tools/src/commands/subcommand.rs
@@ -1,4 +1,7 @@
-use hermes_cli_components::traits::command::{CanRunCommand, CommandRunner};
+use cgp::prelude::*;
+use hermes_cli_components::traits::command::{
+    CanRunCommand, CommandRunner, CommandRunnerComponent,
+};
 
 use crate::commands::starknet::subcommand::StarknetSubCommand;
 
@@ -10,6 +13,7 @@ pub enum AllSubCommands {
 
 pub struct RunAllSubCommand;
 
+#[cgp_provider(CommandRunnerComponent)]
 impl<App> CommandRunner<App, AllSubCommands> for RunAllSubCommand
 where
     App: CanRunCommand<StarknetSubCommand>,

--- a/relayer/crates/tools/src/contexts/app.rs
+++ b/relayer/crates/tools/src/contexts/app.rs
@@ -21,7 +21,7 @@ use hermes_cli_components::traits::config::config_path::{
 use hermes_cli_components::traits::config::load_config::{CanLoadConfig, ConfigLoaderComponent};
 use hermes_cli_components::traits::config::write_config::{CanWriteConfig, ConfigWriterComponent};
 use hermes_cli_components::traits::output::{
-    CanProduceOutput, OutputProducer, OutputTypeComponent,
+    CanProduceOutput, OutputProducer, OutputProducerComponent, OutputTypeComponent,
 };
 use hermes_cli_components::traits::types::config::{ConfigTypeComponent, HasConfigType};
 use hermes_error::traits::wrap::CanWrapError;
@@ -104,6 +104,7 @@ delegate_components! {
     }
 }
 
+#[cgp_provider(OutputProducerComponent)]
 impl<Value> OutputProducer<ToolApp, Value> for ToolAppComponents {
     fn produce_output(_app: &ToolApp, _value: Value) {}
 }


### PR DESCRIPTION
This follows the changes in https://github.com/informalsystems/hermes-sdk/pull/534 to apply `#[cgp_provider]` to all provider implementations. With this, we can now get much better error diagnostics by probling the error from `Context: CanUseComponent<ComponentName>`.


We also follow https://github.com/informalsystems/hermes-sdk/pull/541 to apply `#[cgp::re_export_imports]` to simplify the re-exporting of component constructs when defining presets.