### PR TITLE
fix: use `max_clock_drift` in comet light client

### DIFF
--- a/cairo-contracts/packages/clients/src/cometbft/client_state.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/client_state.cairo
@@ -7,6 +7,7 @@ pub struct CometClientState {
     pub latest_height: Height,
     pub trusting_period: u64,
     pub unbonding_period: u64,
+    pub max_clock_drift: u64,
     pub status: Status,
     pub chain_id: ByteArray,
 }

--- a/cairo-contracts/packages/clients/src/cometbft/component.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/component.cairo
@@ -436,7 +436,7 @@ pub mod CometClientComponent {
             let host_timestamp = get_block_timestamp();
 
             let consensus_state_status = consensus_state
-                .status(host_timestamp, client_state.trusting_period);
+                .status(host_timestamp, client_state.trusting_period, client_state.max_clock_drift);
 
             if !consensus_state_status.is_active() {
                 return consensus_state_status;

--- a/cairo-contracts/packages/clients/src/cometbft/errors.cairo
+++ b/cairo-contracts/packages/clients/src/cometbft/errors.cairo
@@ -4,7 +4,7 @@ pub mod CometErrors {
     pub const INVALID_CLIENT_STATE: felt252 = 'ICS07: invalid client state';
     pub const INVALID_CONSENSUS_STATE: felt252 = 'ICS07: invalid consensus state';
     pub const INVALID_HEADER: felt252 = 'ICS07: invalid header';
-    pub const INVALID_HEADER_TIMESTAMP: felt252 = 'ICS07: invalid header timestamp';
+    pub const HEADER_TIMESTAMP_FROM_FUTURE: felt252 = 'ICS07: header ts from future';
     pub const INVALID_OWNER: felt252 = 'ICS07: invalid owner';
     pub const MISSING_CLIENT_STATE: felt252 = 'ICS07: missing client state';
     pub const MISSING_CONSENSUS_STATE: felt252 = 'ICS07: missing consensus state';

--- a/cairo-contracts/packages/testkit/src/configs/cometbft.cairo
+++ b/cairo-contracts/packages/testkit/src/configs/cometbft.cairo
@@ -14,6 +14,7 @@ pub struct CometClientConfig {
     pub latest_timestamp: u64,
     pub trusting_period: u64,
     pub unbonding_period: u64,
+    pub max_clock_drift: u64,
 }
 
 #[generate_trait]
@@ -25,6 +26,7 @@ pub impl CometClientConfigImpl of CometClientConfigTrait {
             latest_timestamp: 10,
             trusting_period: 100,
             unbonding_period: 200,
+            max_clock_drift: 10,
         }
     }
 
@@ -35,6 +37,7 @@ pub impl CometClientConfigImpl of CometClientConfigTrait {
             latest_height: self.latest_height.clone(),
             trusting_period: *self.trusting_period,
             unbonding_period: *self.unbonding_period,
+            max_clock_drift: *self.max_clock_drift,
             status: Status::Active,
             chain_id: "dummy_chain",
         };

--- a/relayer/crates/starknet-chain-components/src/impls/messages/create_client.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/create_client.rs
@@ -64,6 +64,7 @@ where
             latest_height: height,
             trusting_period: payload.client_state.trusting_period.as_secs(),
             unbonding_period: payload.client_state.unbonding_period.as_secs(),
+            max_clock_drift: payload.client_state.max_clock_drift.as_secs(),
             status: ClientStatus::Active,
             chain_id: payload.client_state.chain_id,
         };

--- a/relayer/crates/starknet-chain-components/src/types/cosmos/client_state.rs
+++ b/relayer/crates/starknet-chain-components/src/types/cosmos/client_state.rs
@@ -32,6 +32,7 @@ pub struct CometClientState {
     pub latest_height: Height,
     pub trusting_period: u64,
     pub unbonding_period: u64,
+    pub max_clock_drift: u64,
     pub status: ClientStatus,
     pub chain_id: ChainId,
 }
@@ -90,6 +91,7 @@ delegate_components! {
                 EncodeField<symbol!("latest_height"), UseContext>,
                 EncodeField<symbol!("trusting_period"), UseContext>,
                 EncodeField<symbol!("unbonding_period"), UseContext>,
+                EncodeField<symbol!("max_clock_drift"), UseContext>,
                 EncodeField<symbol!("status"), UseContext>,
                 EncodeField<symbol!("chain_id"), UseContext>,
             ],
@@ -99,7 +101,7 @@ delegate_components! {
 }
 
 impl Transformer for EncodeCometClientState {
-    type From = Product![Height, u64, u64, ClientStatus, ChainId];
+    type From = Product![Height, u64, u64, u64, ClientStatus, ChainId];
     type To = CometClientState;
 
     fn transform(
@@ -107,6 +109,7 @@ impl Transformer for EncodeCometClientState {
             latest_height,
             trusting_period,
             unbonding_period,
+            max_clock_drift,
             status,
             chain_id
         ]: Self::From,
@@ -115,6 +118,7 @@ impl Transformer for EncodeCometClientState {
             latest_height,
             trusting_period,
             unbonding_period,
+            max_clock_drift,
             status,
             chain_id,
         }
@@ -164,7 +168,7 @@ impl From<CometClientState> for IbcCometClientState {
             TrustThreshold::ONE_THIRD,
             Duration::from_secs(client_state.trusting_period),
             Duration::from_secs(client_state.unbonding_period),
-            Duration::from_secs(3),
+            Duration::from_secs(client_state.max_clock_drift),
             CosmosHeight::new(
                 client_state.latest_height.revision_number,
                 client_state.latest_height.revision_height,


### PR DESCRIPTION
closes #288