### PR TITLE
fix: printing `call_data_str` in `starknet transfer-args` cli

### DIFF
--- a/light-client/ibc-client-starknet-types/src/client_state.rs
+++ b/light-client/ibc-client-starknet-types/src/client_state.rs
@@ -5,7 +5,7 @@ use ibc_core::host::types::identifiers::ChainId;
 pub const STARKNET_CLIENT_STATE_TYPE_URL: &str = "/StarknetClientState";
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Debug, PartialEq, derive_more::From, HasField)]
+#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, HasField)]
 pub struct StarknetClientState {
     pub latest_height: Height,
     pub chain_id: ChainId,

--- a/light-client/ibc-client-starknet-types/src/consensus_state.rs
+++ b/light-client/ibc-client-starknet-types/src/consensus_state.rs
@@ -5,7 +5,7 @@ use ibc_core::primitives::Timestamp;
 pub const STARKNET_CONSENSUS_STATE_TYPE_URL: &str = "/StarknetConsensusState";
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Debug, PartialEq, derive_more::From, HasField)]
+#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, HasField)]
 pub struct StarknetConsensusState {
     pub root: CommitmentRoot,
     pub time: Timestamp,

--- a/light-client/ibc-client-starknet/src/client_state/mod.rs
+++ b/light-client/ibc-client-starknet/src/client_state/mod.rs
@@ -12,7 +12,7 @@ use prost_types::Any as ProstAny;
 use crate::encoding::context::StarknetLightClientEncoding;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Debug, PartialEq, derive_more::From)]
+#[derive(Clone, Debug, PartialEq, Eq, derive_more::From)]
 pub struct ClientState(pub ClientStateType);
 
 impl Protobuf<Any> for ClientState {}

--- a/light-client/ibc-client-starknet/src/consensus_state.rs
+++ b/light-client/ibc-client-starknet/src/consensus_state.rs
@@ -10,7 +10,7 @@ use prost_types::Any as ProstAny;
 use crate::encoding::context::StarknetLightClientEncoding;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Debug, PartialEq, derive_more::From)]
+#[derive(Clone, Debug, PartialEq, Eq, derive_more::From)]
 pub struct ConsensusState(pub ConsensusStateType);
 
 impl Protobuf<Any> for ConsensusState {}

--- a/relayer/crates/starknet-chain-components/Cargo.toml
+++ b/relayer/crates/starknet-chain-components/Cargo.toml
@@ -43,4 +43,4 @@ starknet                    = { workspace = true }
 tonic                       = { workspace = true }
 futures                     = { workspace = true }
 crypto-bigint               = "0.5.5"
-derive_more                 = { version = "2.0", features = [ "deref", "display", "from", "from_str" ], default-features = false }
+derive_more                 = { version = "2.0", features = [ "constructor", "deref", "display", "from", "from_str" ], default-features = false }

--- a/relayer/crates/starknet-chain-components/src/impls/types/address.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/address.rs
@@ -1,5 +1,5 @@
 use cgp::prelude::*;
-use derive_more::{Deref, Display, From, FromStr};
+use derive_more::{Constructor, Deref, Display, From, FromStr};
 use hermes_chain_type_components::traits::types::address::AddressTypeComponent;
 use hermes_test_components::chain::traits::types::address::ProvideAddressType;
 use hermes_wasm_encoding_components::components::{MutDecoderComponent, MutEncoderComponent};
@@ -24,6 +24,7 @@ impl<Chain: Async> ProvideAddressType<Chain> for ProvideFeltAddressType {
     Hash,
     Debug,
     Default,
+    Constructor,
     Deref,
     Display,
     From,

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/denom.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/denom.rs
@@ -9,7 +9,6 @@ use hermes_encoding_components::impls::encode_mut::from::DecodeFrom;
 use hermes_encoding_components::traits::decode_mut::MutDecoderComponent;
 use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
 use hermes_encoding_components::traits::transform::{Transformer, TransformerRef};
-use starknet::core::types::Felt;
 
 use crate::impls::types::address::StarknetAddress;
 
@@ -114,23 +113,23 @@ delegate_components! {
 
 impl TransformerRef for EncodeDenom {
     type From = Denom;
-    type To<'a> = Sum![Felt, &'a String];
+    type To<'a> = Sum![StarknetAddress, &'a String];
 
-    fn transform<'a>(from: &'a Denom) -> Sum![Felt, &'a String] {
+    fn transform<'a>(from: &'a Denom) -> Sum![StarknetAddress, &'a String] {
         match from {
-            Denom::Native(denom) => Either::Left(**denom),
+            Denom::Native(denom) => Either::Left(*denom),
             Denom::Hosted(denom) => Either::Right(Either::Left(denom)),
         }
     }
 }
 
 impl Transformer for EncodeDenom {
-    type From = Sum![Felt, String];
+    type From = Sum![StarknetAddress, String];
     type To = Denom;
 
-    fn transform(value: Sum![Felt, String]) -> Denom {
+    fn transform(value: Sum![StarknetAddress, String]) -> Denom {
         match value {
-            Either::Left(value) => Denom::Native(value.into()),
+            Either::Left(value) => Denom::Native(value),
             Either::Right(Either::Left(value)) => Denom::Hosted(value),
             Either::Right(Either::Right(value)) => match value {},
         }

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/ibc_transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/ibc_transfer.rs
@@ -9,7 +9,7 @@ use hermes_encoding_components::impls::encode_mut::from::DecodeFrom;
 use hermes_encoding_components::traits::decode_mut::MutDecoderComponent;
 use hermes_encoding_components::traits::encode_mut::MutEncoderComponent;
 use hermes_encoding_components::traits::transform::{Transformer, TransformerRef};
-use starknet::core::types::{Felt, U256};
+use starknet::core::types::U256;
 
 use super::channel::PortId;
 use crate::impls::types::address::StarknetAddress;
@@ -120,23 +120,23 @@ delegate_components! {
 
 impl TransformerRef for EncodeParticipant {
     type From = Participant;
-    type To<'a> = Sum![Felt, &'a String];
+    type To<'a> = Sum![StarknetAddress, &'a String];
 
-    fn transform<'a>(from: &'a Participant) -> Sum![Felt, &'a String] {
+    fn transform<'a>(from: &'a Participant) -> Sum![StarknetAddress, &'a String] {
         match from {
-            Participant::Native(address) => Either::Left(**address),
+            Participant::Native(address) => Either::Left(*address),
             Participant::External(address) => Either::Right(Either::Left(address)),
         }
     }
 }
 
 impl Transformer for EncodeParticipant {
-    type From = Sum![Felt, String];
+    type From = Sum![StarknetAddress, String];
     type To = Participant;
 
-    fn transform(value: Sum![Felt, String]) -> Participant {
+    fn transform(value: Sum![StarknetAddress, String]) -> Participant {
         match value {
-            Either::Left(value) => Participant::Native(value.into()),
+            Either::Left(value) => Participant::Native(value),
             Either::Right(Either::Left(value)) => Participant::External(value),
             Either::Right(Either::Right(value)) => match value {},
         }

--- a/relayer/crates/tools/src/commands/starknet/transfer_args.rs
+++ b/relayer/crates/tools/src/commands/starknet/transfer_args.rs
@@ -126,7 +126,9 @@ impl CommandRunner<ToolApp, TransferArgs> for RunTransferArgs {
 
         logger
             .log(
-                "Arguments to send transaction using `starkli invoke` are: {call_data_str}",
+                &format!(
+                    "Arguments to send transaction using `starkli invoke` are: {call_data_str}"
+                ),
                 &LevelInfo,
             )
             .await;


### PR DESCRIPTION
I mistakenly removed the `format!()` in #284

caught by `cargo +nightly clippy -- -W clippy::nursery`

Also, added some other touch ups.

- derive `Eq`
- derive `const fn new` for `StarknetAddress`
- use `StarknetAddress` directly while decoding Felt data.