### PR TITLE
build(deps): update Hermes SDK

### DIFF
--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -61,6 +61,7 @@ jobs:
       - name: Run Integration Tests
         env:
           RUST_BACKTRACE: 1
+          RUST_LOG: debug
         working-directory: ./relayer
         run: |
           export ERC20_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_ERC20Mintable.contract_class.json"

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -1857,7 +1857,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hermes-any-counterparty"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-cosmos-chain-components",
@@ -1874,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "hermes-async-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "async-trait",
  "cgp",
@@ -1897,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-type-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
 ]
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "clap",
@@ -1954,7 +1954,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "clap",
@@ -1974,7 +1974,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli-framework"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "clap",
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2003,7 +2003,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-context"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "eyre",
@@ -2019,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-integration-tests"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "eyre",
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "dirs-next",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hdpath",
@@ -2195,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-wasm-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "eyre",
@@ -2244,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "hermes-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
 ]
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "hermes-error"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "eyre",
@@ -2262,7 +2262,7 @@ dependencies = [
 [[package]]
 name = "hermes-ibc-test-suite"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "hermes-logger"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "hermes-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
 ]
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "hermes-protobuf-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -2306,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-chain-components",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components-extra"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-async-runtime-components",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
 ]
@@ -2569,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "hermes-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2581,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "hermes-tokio-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "futures",
@@ -2595,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "hermes-tracing-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2607,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-cosmos-chain-components",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-cosmos-encoding-components",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#742385b1db8d59949fd31e286b67a4debd8d521b"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#b7735c878d9527f2219d64320bf44f94a4a572d2"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",


### PR DESCRIPTION
Closes: #261

This PR updates Hermes SDK to commit https://github.com/informalsystems/hermes-sdk/commit/b7735c878d9527f2219d64320bf44f94a4a572d2 which adds logs for client update and sets logs when relaying receive, timeout and ack packets from `trace` to `debug`