### PR TITLE
Improve test error log

### DIFF
--- a/relayer/crates/starknet-integration-tests/src/tests/clear_packets.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/clear_packets.rs
@@ -60,6 +60,7 @@ use hermes_starknet_chain_components::types::register::{MsgRegisterApp, MsgRegis
 use hermes_starknet_chain_context::contexts::chain::StarknetChain;
 use hermes_starknet_chain_context::contexts::encoding::cairo::StarknetCairoEncoding;
 use hermes_starknet_chain_context::contexts::encoding::event::StarknetEventEncoding;
+use hermes_starknet_chain_context::impls::error::SignError;
 use hermes_starknet_relayer::contexts::cosmos_to_starknet_relay::CosmosToStarknetRelay;
 use hermes_starknet_relayer::contexts::starknet_to_cosmos_relay::StarknetToCosmosRelay;
 use hermes_test_components::bootstrap::traits::chain::CanBootstrapChain;
@@ -69,7 +70,7 @@ use ibc::core::connection::types::version::Version as IbcConnectionVersion;
 use ibc::core::host::types::identifiers::{PortId as IbcPortId, Sequence};
 use poseidon::Poseidon3Hasher;
 use sha2::{Digest, Sha256};
-use starknet::accounts::{Account, Call, ExecutionEncoding, SingleOwnerAccount};
+use starknet::accounts::{Account, AccountError, Call, ExecutionEncoding, SingleOwnerAccount};
 use starknet::core::types::U256;
 use starknet::macros::{selector, short_string};
 use starknet::providers::Provider;
@@ -566,7 +567,11 @@ fn test_query_unreceived_packets() -> Result<(), Error> {
 
             let execution = starknet_account_b.execute_v3(vec![call]);
 
-            let tx_hash = execution.send().await?.transaction_hash;
+            let tx_hash = execution
+                .send()
+                .await
+                .map_err(<StarknetChain as CanRaiseError<AccountError<SignError>>>::raise_error)?
+                .transaction_hash;
 
             starknet_chain.poll_tx_response(&tx_hash).await?;
         }
@@ -613,7 +618,11 @@ fn test_query_unreceived_packets() -> Result<(), Error> {
 
             let execution = starknet_account_b.execute_v3(vec![call]);
 
-            let tx_hash = execution.send().await?.transaction_hash;
+            let tx_hash = execution
+                .send()
+                .await
+                .map_err(<StarknetChain as CanRaiseError<AccountError<SignError>>>::raise_error)?
+                .transaction_hash;
 
             starknet_chain.poll_tx_response(&tx_hash).await?;
         };

--- a/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
@@ -50,6 +50,7 @@ use hermes_starknet_chain_components::types::register::{MsgRegisterApp, MsgRegis
 use hermes_starknet_chain_context::contexts::chain::StarknetChain;
 use hermes_starknet_chain_context::contexts::encoding::cairo::StarknetCairoEncoding;
 use hermes_starknet_chain_context::contexts::encoding::event::StarknetEventEncoding;
+use hermes_starknet_chain_context::impls::error::SignError;
 use hermes_starknet_relayer::contexts::cosmos_to_starknet_relay::CosmosToStarknetRelay;
 use hermes_starknet_relayer::contexts::starknet_to_cosmos_relay::StarknetToCosmosRelay;
 use hermes_test_components::bootstrap::traits::chain::CanBootstrapChain;
@@ -60,7 +61,7 @@ use ibc::core::connection::types::version::Version as IbcConnectionVersion;
 use ibc::core::host::types::identifiers::PortId as IbcPortId;
 use poseidon::Poseidon3Hasher;
 use sha2::{Digest, Sha256};
-use starknet::accounts::{Account, Call, ExecutionEncoding, SingleOwnerAccount};
+use starknet::accounts::{Account, AccountError, Call, ExecutionEncoding, SingleOwnerAccount};
 use starknet::core::types::U256;
 use starknet::macros::{selector, short_string};
 use starknet::providers::Provider;
@@ -529,7 +530,11 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
 
             let execution = starknet_account_b.execute_v3(vec![call]);
 
-            let tx_hash = execution.send().await?.transaction_hash;
+            let tx_hash = execution
+                .send()
+                .await
+                .map_err(<StarknetChain as CanRaiseError<AccountError<SignError>>>::raise_error)?
+                .transaction_hash;
 
             starknet_chain.poll_tx_response(&tx_hash).await?;
         }
@@ -577,7 +582,11 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
 
             let execution = starknet_account_b.execute_v3(vec![call]);
 
-            let tx_hash = execution.send().await?.transaction_hash;
+            let tx_hash = execution
+                .send()
+                .await
+                .map_err(<StarknetChain as CanRaiseError<AccountError<SignError>>>::raise_error)?
+                .transaction_hash;
 
             starknet_chain.poll_tx_response(&tx_hash).await?;
         };
@@ -624,7 +633,11 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
 
             let execution = starknet_account_b.execute_v3(vec![call]);
 
-            let tx_hash = execution.send().await?.transaction_hash;
+            let tx_hash = execution
+                .send()
+                .await
+                .map_err(<StarknetChain as CanRaiseError<AccountError<SignError>>>::raise_error)?
+                .transaction_hash;
 
             starknet_chain.poll_tx_response(&tx_hash).await?;
         }
@@ -668,7 +681,11 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
 
             let execution = starknet_account_b.execute_v3(vec![call]);
 
-            let tx_hash = execution.send().await?.transaction_hash;
+            let tx_hash = execution
+                .send()
+                .await
+                .map_err(<StarknetChain as CanRaiseError<AccountError<SignError>>>::raise_error)?
+                .transaction_hash;
 
             starknet_chain.poll_tx_response(&tx_hash).await?;
         };


### PR DESCRIPTION
This PR map the `execution.send()` error to be display as Debug in tests

Old error:
```
Error: TransactionExecutionError
```
New error:
```
Error: StarknetError: TransactionExecutionError(TransactionExecutionErrorData { transaction_index: 0, execution_error:
"Transaction execution has failed:\n0: Error in the called contract (contract address:
0x049dfb8ce986e21d354ac93ea65e6a11f639c1934ea253e5ff14ca62eca0f38e, class hash:
0x061dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f, selector:
0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nError at pc=0:4835:\nCairo
traceback (most recent call last):\nUnknown location (pc=0:67)\nUnknown location (pc=0:1835)\nUnknown location
(pc=0:2554)\nUnknown location (pc=0:3436)\nUnknown location (pc=0:4040)\n\n1: Error in the called contract (contract
address: 0x046dcfe2e7f9bbb71dd8f9812b5a9cb76ae7685d3d5af0d0bf11bab2c3f2feab, class hash:
0x0000000000000000000000000000000000000000000000000000000000000000, selector:
0x0219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c):\nRequested contract address
0x046dcfe2e7f9bbb71dd8f9812b5a9cb76ae7685d3d5af0d0bf11bab2c3f2feab is not deployed.\n" })
```
