### PR TITLE
fix: pre-create IBC token in test to reduce flakiness

### DIFF
--- a/relayer/crates/starknet-chain-components/src/impls/types/address.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/address.rs
@@ -36,7 +36,7 @@ impl<Chain: Async> ProvideAddressType<Chain> for ProvideFeltAddressType {
     Deserialize,
 )]
 #[display("0x{_0:x}")]
-pub struct StarknetAddress(Felt);
+pub struct StarknetAddress(pub Felt);
 
 pub struct EncodeStarknetAddress;
 


### PR DESCRIPTION
Fixes the issue discussed in #313.

This PR uses the new `create_ibc_token` Cairo contract call introduced in #321 to pre-allocate the token address for tokens transferred from Cosmos to Starknet. This allows us to use the `assert_eventual_amount` method to poll for the transfer status, since we can now know the transferred address beforehand.