### PR TITLE
fix: use `BlockTag::Latest` when querying Starknet

### DIFF
--- a/relayer/crates/starknet-chain-components/src/impls/contract/call.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/call.rs
@@ -26,7 +26,7 @@ where
         entry_point_selector: &Felt,
         calldata: &Vec<Felt>,
     ) -> Result<Vec<Felt>, Chain::Error> {
-        let block_id = BlockId::Tag(BlockTag::Pending);
+        let block_id = BlockId::Tag(BlockTag::Latest);
 
         let res = chain
             .provider()

--- a/relayer/crates/starknet-chain-components/src/impls/contract/declare.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/contract/declare.rs
@@ -47,7 +47,7 @@ where
         let class_hash = contract_class.class_hash().map_err(Chain::raise_error)?;
 
         let class_exist_result = provider
-            .get_class(BlockId::Tag(BlockTag::Pending), class_hash)
+            .get_class(BlockId::Tag(BlockTag::Latest), class_hash)
             .await;
 
         if class_exist_result.is_ok() {


### PR DESCRIPTION
closes #259 