### PR TITLE
fix: ensure adequate checks and tests for `create_ibc_token`

### DIFF
--- a/cairo-contracts/packages/apps/src/tests/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/tests/transfer.cairo
@@ -13,8 +13,8 @@ use starknet_ibc_core::router::{AppContract, AppContractTrait};
 use starknet_ibc_testkit::configs::{TransferAppConfig, TransferAppConfigTrait};
 use starknet_ibc_testkit::dummies::CLASS_HASH;
 use starknet_ibc_testkit::dummies::{
-    AMOUNT, CHANNEL_ID, COSMOS, CS_USER, DECIMAL_ZERO, EMPTY_MEMO, HOSTED_DENOM, NAME, OWNER,
-    SN_USER, STARKNET, SUPPLY, SYMBOL,
+    AMOUNT, COSMOS, CS_USER, DECIMAL_ZERO, EMPTY_MEMO, HOSTED_DENOM, NAME, OWNER, SN_USER, STARKNET,
+    SUPPLY, SYMBOL,
 };
 use starknet_ibc_testkit::event_spy::{ERC20EventSpyExt, TransferEventSpyExt};
 use starknet_ibc_testkit::handles::{AppHandle, ERC20Handle};
@@ -75,15 +75,6 @@ fn test_missing_salt() {
 fn test_missing_ibc_token_address() {
     let state = setup_component();
     state.ibc_token_address(0);
-}
-
-#[test]
-fn test_create_ibc_token() {
-    let (mut ics20, _, cfg, mut spy) = setup();
-    let address = ics20.create_ibc_token(CHANNEL_ID(0), NAME());
-    spy.assert_create_token_event(ics20.address, NAME(), SYMBOL(), DECIMAL_ZERO, address, 0);
-    let queried = ics20.ibc_token_address(cfg.prefix_hosted_denom().key());
-    assert_eq!(address, queried);
 }
 
 #[test]
@@ -194,33 +185,6 @@ fn test_mint_ok() {
 
     // Check the total supply of the ERC20 contract.
     erc20.assert_total_supply(cfg.amount * 2);
-}
-
-#[test]
-fn test_mint_with_pre_created_ibc_token() {
-    let (ics20, _, cfg, mut spy) = setup();
-
-    let recv_packet = cfg.dummy_incoming_packet(cfg.hosted_denom.clone(), COSMOS(), STARKNET());
-
-    /// Pre-creates the IBC token
-    let token_address = ics20.create_ibc_token(CHANNEL_ID(0), NAME());
-
-    ics20.on_recv_packet(recv_packet.clone());
-
-    let prefixed_denom = cfg.prefix_hosted_denom();
-
-    spy
-        .assert_recv_event(
-            ics20.address, CS_USER(), SN_USER(), prefixed_denom.clone(), cfg.amount, true,
-        );
-
-    let erc20: ERC20Contract = token_address.into();
-
-    spy.assert_transfer_event(erc20.address, ics20.address, SN_USER(), cfg.amount);
-
-    erc20.assert_balance(SN_USER(), cfg.amount);
-
-    erc20.assert_total_supply(cfg.amount);
 }
 
 #[test]

--- a/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
@@ -291,6 +291,9 @@ pub mod TokenTransferComponent {
         fn create_ibc_token(
             ref self: ComponentState<TContractState>, denom: PrefixedDenom,
         ) -> ContractAddress {
+            let mut token = self.get_token(denom.key());
+            assert(token.is_zero(), TransferErrors::TOKEN_ALREADY_EXISTS);
+
             let channel: ChannelContract = self.owner().into();
 
             let maybe_prefix = denom.first_prefix();

--- a/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
@@ -300,6 +300,8 @@ pub mod TokenTransferComponent {
             assert(maybe_prefix.is_some(), TransferErrors::MISSING_TRACE_PREFIX);
             let prefix = maybe_prefix.unwrap();
 
+            assert(prefix.port_id == @TRANSFER_PORT_ID(), TransferErrors::INVALID_PORT_ID);
+
             let chan_end_on_b = channel
                 .channel_end(prefix.port_id.clone(), prefix.channel_id.clone());
             assert(chan_end_on_b.is_open(), ChannelErrors::INVALID_CHANNEL_STATE);

--- a/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/components/transfer.cairo
@@ -293,7 +293,7 @@ pub mod TokenTransferComponent {
         ) -> ContractAddress {
             let channel: ChannelContract = self.owner().into();
 
-            let maybe_prefix = denom.last_prefix();
+            let maybe_prefix = denom.first_prefix();
             assert(maybe_prefix.is_some(), TransferErrors::MISSING_TRACE_PREFIX);
             let prefix = maybe_prefix.unwrap();
 

--- a/cairo-contracts/packages/apps/src/transfer/erc20_call.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/erc20_call.cairo
@@ -2,7 +2,7 @@ use core::num::traits::Zero;
 use core::starknet::SyscallResultTrait;
 use openzeppelin_token::erc20::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
 use starknet::syscalls::deploy_syscall;
-use starknet::{ClassHash, ContractAddress};
+use starknet::{ClassHash, ContractAddress, contract_address_const};
 use starknet_ibc_utils::mintable::{IERC20MintableDispatcher, IERC20MintableDispatcherTrait};
 
 #[derive(Copy, Debug, Drop, Serde)]
@@ -24,10 +24,6 @@ impl ERC20ContractIntoFelt252 of Into<ERC20Contract, felt252> {
 
 #[generate_trait]
 pub impl ERC20ContractImpl of ERC20ContractTrait {
-    fn is_non_zero(self: @ERC20Contract) -> bool {
-        self.address.is_non_zero()
-    }
-
     fn dispatcher(self: @ERC20Contract) -> ERC20ABIDispatcher {
         ERC20ABIDispatcher { contract_address: *self.address }
     }
@@ -80,5 +76,19 @@ pub impl ERC20ContractImpl of ERC20ContractTrait {
 
     fn total_supply(self: @ERC20Contract) -> u256 {
         self.dispatcher().total_supply()
+    }
+}
+
+impl ERC20ContractZero of Zero<ERC20Contract> {
+    fn zero() -> ERC20Contract {
+        ERC20Contract { address: contract_address_const::<0>() }
+    }
+
+    fn is_zero(self: @ERC20Contract) -> bool {
+        self.address.is_zero()
+    }
+
+    fn is_non_zero(self: @ERC20Contract) -> bool {
+        !self.is_zero()
     }
 }

--- a/cairo-contracts/packages/apps/src/transfer/errors.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/errors.cairo
@@ -13,6 +13,7 @@ pub mod TransferErrors {
     pub const INVALID_DENOM: felt252 = 'ICS20: invalid denom';
     pub const INVALID_PACKET_DATA: felt252 = 'ICS20: invalid packet data';
     pub const INVALID_OWNER: felt252 = 'ICS20: invalid owner';
+    pub const MISSING_TRACE_PREFIX: felt252 = 'ICS20: missing trace prefix';
     pub const EMPTY_ACK_STATUS: felt252 = 'ICS20: empty ack status';
     pub const MAXIMUM_MEMO_LENGTH: felt252 = 'ICS20: memo exceeds max length';
     pub const INSUFFICIENT_BALANCE: felt252 = 'ICS20: insufficient balance';

--- a/cairo-contracts/packages/apps/src/transfer/errors.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/errors.cairo
@@ -19,4 +19,5 @@ pub mod TransferErrors {
     pub const INSUFFICIENT_BALANCE: felt252 = 'ICS20: insufficient balance';
     pub const NO_SEND_CAPABILITY: felt252 = 'ICS20: No send capability';
     pub const NO_RECEIVE_CAPABILITY: felt252 = 'ICS20: No receive capability';
+    pub const TOKEN_ALREADY_EXISTS: felt252 = 'ICS20: token already exists';
 }

--- a/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
@@ -1,6 +1,5 @@
 use starknet::ContractAddress;
-use starknet_ibc_apps::transfer::types::MsgTransfer;
-use starknet_ibc_core::host::ChannelId;
+use starknet_ibc_apps::transfer::types::{MsgTransfer, PrefixedDenom};
 
 #[starknet::interface]
 pub trait ISendTransfer<TContractState> {
@@ -11,9 +10,7 @@ pub trait ISendTransfer<TContractState> {
 pub trait ICreateIbcToken<TContractState> {
     /// Allows the pre-creation of an IBC token using the expected channel ID on which it will be
     /// received and the denomination from its originating chain.
-    fn create_ibc_token(
-        ref self: TContractState, chan_id_on_b: ChannelId, base_denom: ByteArray,
-    ) -> ContractAddress;
+    fn create_ibc_token(ref self: TContractState, denom: PrefixedDenom) -> ContractAddress;
 }
 
 #[starknet::interface]

--- a/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
@@ -8,7 +8,7 @@ pub trait ISendTransfer<TContractState> {
 
 #[starknet::interface]
 pub trait ICreateIbcToken<TContractState> {
-    /// Allows the pre-creation of an IBC token using the expeced `PrefixedDenom` on Starknet.
+    /// Allows the pre-creation of an IBC token using the expected `PrefixedDenom` on Starknet.
     fn create_ibc_token(ref self: TContractState, denom: PrefixedDenom) -> ContractAddress;
 }
 

--- a/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/interfaces/transfer.cairo
@@ -8,8 +8,7 @@ pub trait ISendTransfer<TContractState> {
 
 #[starknet::interface]
 pub trait ICreateIbcToken<TContractState> {
-    /// Allows the pre-creation of an IBC token using the expected channel ID on which it will be
-    /// received and the denomination from its originating chain.
+    /// Allows the pre-creation of an IBC token using the expeced `PrefixedDenom` on Starknet.
     fn create_ibc_token(ref self: TContractState, denom: PrefixedDenom) -> ContractAddress;
 }
 

--- a/cairo-contracts/packages/apps/src/transfer/types.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/types.cairo
@@ -102,7 +102,8 @@ pub impl PrefixedDenomImpl of PrefixedDenomTrait {
         }
     }
 
-    fn last_prefix(self: @PrefixedDenom) -> Option<@TracePrefix> {
+    /// Returns the outermost (first) prefix relevant to this chain (Starknet).
+    fn first_prefix(self: @PrefixedDenom) -> Option<@TracePrefix> {
         let len = self.trace_path.len();
         if len.is_zero() {
             Option::None

--- a/cairo-contracts/packages/apps/src/transfer/types.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/types.cairo
@@ -3,9 +3,7 @@ use core::fmt::{Display, Error, Formatter};
 use core::num::traits::Zero;
 use serde_json::{Serialize, SerializerTrait};
 use starknet::ContractAddress;
-use starknet_ibc_apps::transfer::{
-    ERC20Contract, ERC20ContractTrait, TRANSFER_PORT_ID_HASH, TransferErrors,
-};
+use starknet_ibc_apps::transfer::{ERC20Contract, TRANSFER_PORT_ID_HASH, TransferErrors};
 use starknet_ibc_core::client::{Height, Timestamp};
 use starknet_ibc_core::host::{ChannelId, ChannelIdTrait, PortId, PortIdTrait};
 use starknet_ibc_utils::{ComputeKey, LocalKeyBuilderImpl, ValidateBasic};

--- a/cairo-contracts/packages/apps/src/transfer/types.cairo
+++ b/cairo-contracts/packages/apps/src/transfer/types.cairo
@@ -102,6 +102,15 @@ pub impl PrefixedDenomImpl of PrefixedDenomTrait {
         }
     }
 
+    fn last_prefix(self: @PrefixedDenom) -> Option<@TracePrefix> {
+        let len = self.trace_path.len();
+        if len.is_zero() {
+            Option::None
+        } else {
+            Option::Some(self.trace_path.at(len - 1))
+        }
+    }
+
     fn as_byte_array(self: @PrefixedDenom) -> ByteArray {
         let mut denom_prefix: ByteArray = "";
         let mut trace_path_span = self.trace_path.span();

--- a/cairo-contracts/packages/contracts/src/tests/transfer.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/transfer.cairo
@@ -214,6 +214,17 @@ fn test_create_ibc_token_with_multihop() {
 }
 
 #[test]
+#[should_panic(expected: 'ICS20: token already exists')]
+fn test_recreate_existing_ibc_token() {
+    let (_, ics20, _, _, _, transfer_cfg, _) = setup(Mode::WithChannel);
+    let prefixed_denom = transfer_cfg.prefix_hosted_denom();
+    ics20.create_ibc_token(prefixed_denom.clone());
+
+    // The second time creation should panic.
+    ics20.create_ibc_token(prefixed_denom.clone());
+}
+
+#[test]
 #[should_panic(expected: 'ICS20: missing trace prefix')]
 fn test_create_ibc_token_without_prefix() {
     let (_, ics20, _, _, _, transfer_cfg, _) = setup(Mode::WithChannel);

--- a/cairo-contracts/packages/contracts/src/tests/transfer.cairo
+++ b/cairo-contracts/packages/contracts/src/tests/transfer.cairo
@@ -148,3 +148,72 @@ fn test_mint_burn_roundtrip() {
     // Check the total supply of the ERC20 contract.
     erc20.assert_total_supply(0);
 }
+
+#[test]
+fn test_mint_with_pre_created_token() {
+    // -----------------------------------------------------------
+    // Setup Essentials
+    // -----------------------------------------------------------
+
+    let (core, ics20, _, _, _, transfer_cfg, mut spy) = setup(Mode::WithChannel);
+
+    let prefixed_denom = transfer_cfg.prefix_hosted_denom();
+
+    /// Pre-creates the IBC token
+    let token_address = ics20.create_ibc_token(prefixed_denom.clone());
+
+    // -----------------------------------------------------------
+    // Mint
+    // -----------------------------------------------------------
+
+    let msg_recv_packet = transfer_cfg
+        .dummy_msg_recv_packet(transfer_cfg.hosted_denom.clone(), COSMOS(), STARKNET());
+
+    core.recv_packet(msg_recv_packet.clone());
+
+    spy
+        .assert_recv_event(
+            ics20.address, CS_USER(), SN_USER(), prefixed_denom.clone(), transfer_cfg.amount, true,
+        );
+
+    let mut erc20: ERC20Contract = token_address.into();
+
+    spy.assert_transfer_event(erc20.address, ics20.address, SN_USER(), transfer_cfg.amount);
+
+    erc20.assert_balance(SN_USER(), transfer_cfg.amount);
+
+    erc20.assert_total_supply(transfer_cfg.amount);
+}
+
+#[test]
+fn test_create_ibc_token_ok() {
+    let (_, ics20, _, _, _, transfer_cfg, mut spy) = setup(Mode::WithChannel);
+    let prefixed_denom = transfer_cfg.prefix_hosted_denom();
+    let address = ics20.create_ibc_token(prefixed_denom.clone());
+    spy.assert_create_token_event(ics20.address, NAME(), SYMBOL(), DECIMAL_ZERO, address, 0);
+    let queried = ics20.ibc_token_address(prefixed_denom.key());
+    assert_eq!(address, queried);
+}
+
+#[test]
+#[should_panic(expected: 'ICS20: missing trace prefix')]
+fn test_create_ibc_token_without_prefix() {
+    let (_, ics20, _, _, _, transfer_cfg, _) = setup(Mode::WithChannel);
+    ics20.create_ibc_token(transfer_cfg.hosted_denom);
+}
+
+#[test]
+#[should_panic(expected: 'ICS20: invalid denom')]
+fn test_create_ibc_token_with_wrong_base() {
+    let (_, ics20, _, _, _, transfer_cfg, _) = setup(Mode::WithChannel);
+    let prefixed_denom = transfer_cfg.prefix_native_denom();
+    ics20.create_ibc_token(prefixed_denom);
+}
+
+#[test]
+#[should_panic(expected: 'ICS04: missing channel end')]
+fn test_create_ibc_token_without_channel() {
+    let (_, ics20, _, _, _, transfer_cfg, _) = setup(Mode::WithConnection);
+    let prefixed_denom = transfer_cfg.prefix_hosted_denom();
+   ics20.create_ibc_token(prefixed_denom.clone());
+}

--- a/cairo-contracts/packages/testkit/src/handles/app.cairo
+++ b/cairo-contracts/packages/testkit/src/handles/app.cairo
@@ -3,13 +3,12 @@ use openzeppelin_testing::events::EventSpyExtImpl;
 use openzeppelin_utils::serde::SerializedAppend;
 use snforge_std::ContractClass;
 use starknet::ContractAddress;
-use starknet_ibc_apps::transfer::types::MsgTransfer;
+use starknet_ibc_apps::transfer::types::{MsgTransfer, PrefixedDenom};
 use starknet_ibc_apps::transfer::{
     ICreateIbcTokenDispatcher, ICreateIbcTokenDispatcherTrait, ISendTransferDispatcher,
     ISendTransferDispatcherTrait, ITransferQueryDispatcher, ITransferQueryDispatcherTrait,
 };
 use starknet_ibc_core::channel::IAppCallbackDispatcher;
-use starknet_ibc_core::host::ChannelId;
 use starknet_ibc_core::router::AppContract;
 
 #[generate_trait]
@@ -43,10 +42,7 @@ pub impl AppHandleImpl of AppHandle {
         self.send_dispatcher().send_transfer(msg);
     }
 
-    fn create_ibc_token(
-        self: @AppContract, chan_id_on_b: ChannelId, base_denom: ByteArray,
-    ) -> ContractAddress {
-        ICreateIbcTokenDispatcher { contract_address: *self.address }
-            .create_ibc_token(chan_id_on_b, base_denom)
+    fn create_ibc_token(self: @AppContract, denom: PrefixedDenom) -> ContractAddress {
+        ICreateIbcTokenDispatcher { contract_address: *self.address }.create_ibc_token(denom)
     }
 }

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/denom.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/denom.rs
@@ -12,7 +12,7 @@ use hermes_encoding_components::traits::transform::{Transformer, TransformerRef}
 
 use crate::impls::types::address::StarknetAddress;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Denom {
     Native(StarknetAddress),
     Hosted(String),
@@ -27,7 +27,7 @@ impl Display for Denom {
     }
 }
 
-#[derive(Debug, HasField)]
+#[derive(Clone, Debug, HasField)]
 pub struct PrefixedDenom {
     pub trace_path: Vec<TracePrefix>,
     pub base: Denom,
@@ -45,7 +45,7 @@ impl Display for PrefixedDenom {
     }
 }
 
-#[derive(Debug, HasField)]
+#[derive(Clone, Debug, HasField)]
 pub struct TracePrefix {
     pub port_id: String,
     pub channel_id: String,

--- a/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
@@ -435,11 +435,16 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
             balance_cosmos_a_step_0
         );
 
+        let denom = PrefixedDenom {
+            trace_path: vec![TracePrefix {
+                port_id: ics20_port.to_string(),
+                channel_id: starknet_channel_id.to_string(),
+            }],
+            base: Denom::Hosted(denom_cosmos.to_string()),
+        };
+
         let ics20_token_address: StarknetAddress = {
-            let calldata = cairo_encoding.encode(&product![
-                starknet_channel_id.clone(),
-                denom_cosmos.to_string(),
-            ])?;
+            let calldata = cairo_encoding.encode(&product![denom.clone()])?;
 
             let message = StarknetMessage {
                 call: Call {
@@ -516,14 +521,6 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
 
         let starknet_ics20_send_message = {
             let current_starknet_time = starknet_chain.query_chain_status().await?.time;
-
-            let denom = PrefixedDenom {
-                trace_path: vec![TracePrefix {
-                    port_id: ics20_port.to_string(),
-                    channel_id: starknet_channel_id.to_string(),
-                }],
-                base: Denom::Hosted(denom_cosmos.to_string()),
-            };
 
             MsgTransfer {
                 port_id_on_a: ics20_port.clone(),

--- a/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/ics20.rs
@@ -34,6 +34,7 @@ use hermes_relayer_components::transaction::traits::poll_tx_response::CanPollTxR
 use hermes_runtime_components::traits::fs::read_file::CanReadFileAsString;
 use hermes_starknet_chain_components::impls::types::address::StarknetAddress;
 use hermes_starknet_chain_components::impls::types::message::StarknetMessage;
+use hermes_starknet_chain_components::traits::contract::call::CanCallContract;
 use hermes_starknet_chain_components::traits::contract::declare::CanDeclareContract;
 use hermes_starknet_chain_components::traits::contract::deploy::CanDeployContract;
 use hermes_starknet_chain_components::traits::queries::token_balance::CanQueryTokenBalance;
@@ -58,6 +59,7 @@ use hermes_test_components::chain::traits::queries::balance::CanQueryBalance;
 use hermes_test_components::chain::traits::transfer::ibc_transfer::CanIbcTransferToken;
 use ibc::core::connection::types::version::Version as IbcConnectionVersion;
 use ibc::core::host::types::identifiers::PortId as IbcPortId;
+use poseidon::Poseidon3Hasher;
 use sha2::{Digest, Sha256};
 use starknet::accounts::{Account, AccountError, Call, ExecutionEncoding, SingleOwnerAccount};
 use starknet::core::types::U256;
@@ -461,6 +463,44 @@ fn test_starknet_ics20_contract() -> Result<(), Error> {
         };
 
         info!("ics20 token address: {:?}", ics20_token_address);
+
+        let expected_ics20_token_address: StarknetAddress = {
+            let ibc_prefixed_denom = PrefixedDenom {
+                trace_path: vec![TracePrefix {
+                    port_id: ics20_port.to_string(),
+                    channel_id: starknet_channel_id.to_string(),
+                }],
+                base: Denom::Hosted(denom_cosmos.to_string()),
+            };
+
+            let mut denom_serialized = vec![];
+
+            {
+                // https://github.com/informalsystems/ibc-starknet/blob/06cb7587557e6f3bef323abe7b5d9c3ab35bd97a/cairo-contracts/packages/apps/src/transfer/types.cairo#L120-L130
+                for trace_prefix in &ibc_prefixed_denom.trace_path {
+                    denom_serialized.extend(cairo_encoding.encode(trace_prefix)?);
+                }
+
+                denom_serialized.extend(cairo_encoding.encode(&ibc_prefixed_denom.base)?);
+            }
+
+            // https://github.com/informalsystems/ibc-starknet/blob/06cb7587557e6f3bef323abe7b5d9c3ab35bd97a/cairo-contracts/packages/utils/src/utils.cairo#L35
+            let ibc_prefixed_denom_key = Poseidon3Hasher::digest(&denom_serialized);
+
+            let calldata = cairo_encoding.encode(&product![ibc_prefixed_denom_key])?;
+
+            let output = starknet_chain
+                .call_contract(
+                    &ics20_contract_address,
+                    &selector!("ibc_token_address"),
+                    &calldata,
+                )
+                .await?;
+
+            cairo_encoding.decode(&output)?
+        };
+
+        assert_eq!(ics20_token_address, expected_ics20_token_address);
 
         let _packet = <CosmosChain as CanIbcTransferToken<StarknetChain>>::ibc_transfer_token(
             cosmos_chain,


### PR DESCRIPTION
Completes #321

## Description
- Checks if channel end exists and is open
- Works with multihop scenarios