### PR TITLE
Fix ack clearing from Cosmos to Starknet

### DIFF
--- a/cairo-contracts/packages/core/src/channel/components/events.cairo
+++ b/cairo-contracts/packages/core/src/channel/components/events.cairo
@@ -133,7 +133,7 @@ pub mod ChannelEventEmitterComponent {
         pub port_id_on_b: PortId,
         #[key]
         pub channel_id_on_b: ChannelId,
-        pub packet_data: Array<felt252>,
+        pub packet: Packet,
         pub acknowledgement: Acknowledgement,
     }
 
@@ -306,6 +306,7 @@ pub mod ChannelEventEmitterComponent {
             packet: Packet,
             acknowledgement: Acknowledgement,
         ) {
+            let packet_clone = packet.clone();
             self
                 .emit(
                     WriteAcknowledgementEvent {
@@ -314,7 +315,7 @@ pub mod ChannelEventEmitterComponent {
                         channel_id_on_a: packet.chan_id_on_a,
                         port_id_on_b: packet.port_id_on_b,
                         channel_id_on_b: packet.chan_id_on_b,
-                        packet_data: packet.data,
+                        packet: packet_clone,
                         acknowledgement: acknowledgement,
                     },
                 );

--- a/cairo-contracts/packages/core/src/commitment/types.cairo
+++ b/cairo-contracts/packages/core/src/commitment/types.cairo
@@ -55,7 +55,7 @@ pub fn compute_packet_commitment(
     let mut coll = U32CollectorImpl::init();
     // ibc-go uses nanosecs
     // https://github.com/cosmos/ibc-go/blob/98d7e7550a23ecf8d96ce042ab11ef857b184f2a/proto/ibc/core/channel/v1/channel.proto#L179-L180
-    coll.extend(timeout_timestamp.timestamp * 1_000_000_000);
+    coll.extend(timeout_timestamp.timestamp);
     coll.extend(timeout_height);
     coll.extend_from_chunk(compute_sha256_byte_array(json_packet_data));
     compute_sha256_u32_array(coll.value(), 0, 0).into()

--- a/cairo-contracts/packages/core/src/tests/commitment.cairo
+++ b/cairo-contracts/packages/core/src/tests/commitment.cairo
@@ -7,8 +7,7 @@ use starknet_ibc_testkit::dummies::{ERC20, PACKET_COMMITMENT_ON_SN};
 fn test_compute_packet_commitment() {
     let commitment = PACKET_COMMITMENT_ON_SN(ERC20());
     let expected: [u32; 8] = [
-        3066915652, 3854894583, 2733453543, 2666376403, 1143720361, 1661963047, 2055864332,
-        3822377424,
+        856241231, 3469104917, 1785344229, 494716067, 2803211746, 2587725132, 353823231, 1337717589,
     ];
     assert_eq!(commitment, expected.into());
 }

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -1858,7 +1858,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hermes-any-counterparty"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-cosmos-chain-components",
@@ -1875,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "hermes-async-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "async-trait",
  "cgp",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-type-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
 ]
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "clap",
@@ -1955,11 +1955,10 @@ dependencies = [
 [[package]]
 name = "hermes-cli-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "clap",
- "hermes-cosmos-chain-components",
  "hermes-encoding-components",
  "hermes-error",
  "hermes-logging-components",
@@ -1976,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli-framework"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "clap",
@@ -1996,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2005,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-context"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "eyre",
@@ -2021,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -2074,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -2088,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-integration-tests"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "eyre",
@@ -2121,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "dirs-next",
@@ -2170,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hdpath",
@@ -2197,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-wasm-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "eyre",
@@ -2246,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "hermes-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
 ]
@@ -2254,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "hermes-error"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "eyre",
@@ -2264,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "hermes-ibc-test-suite"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2275,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "hermes-logger"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2289,7 +2288,7 @@ dependencies = [
 [[package]]
 name = "hermes-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
 ]
@@ -2297,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "hermes-protobuf-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -2308,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "futures",
@@ -2322,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components-extra"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2334,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-async-runtime-components",
@@ -2346,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
 ]
@@ -2578,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "hermes-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2591,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "hermes-tokio-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "futures",
@@ -2605,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "hermes-tracing-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2617,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-cosmos-chain-components",
@@ -2636,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-cosmos-encoding-components",
@@ -2650,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#27168d1ee8c004d87b39d769e80c686d79ed53c5"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -4486,7 +4485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -2367,6 +2367,7 @@ dependencies = [
  "hermes-cosmos-chain-components",
  "hermes-cosmos-encoding-components",
  "hermes-encoding-components",
+ "hermes-logging-components",
  "hermes-protobuf-encoding-components",
  "hermes-relayer-components",
  "hermes-runtime-components",
@@ -2384,6 +2385,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "starknet",
+ "time",
  "tonic",
 ]
 

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -2367,7 +2367,6 @@ dependencies = [
  "hermes-cosmos-chain-components",
  "hermes-cosmos-encoding-components",
  "hermes-encoding-components",
- "hermes-logging-components",
  "hermes-protobuf-encoding-components",
  "hermes-relayer-components",
  "hermes-runtime-components",

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -1858,7 +1858,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hermes-any-counterparty"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-cosmos-chain-components",
@@ -1875,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "hermes-async-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "async-trait",
  "cgp",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "hermes-chain-type-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
 ]
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "clap",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "clap",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "hermes-cli-framework"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "clap",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "hermes-comet-light-client-context"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "eyre",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-chain-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "bech32 0.9.1",
  "bitcoin",
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -2087,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-integration-tests"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "eyre",
@@ -2120,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "dirs-next",
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hdpath",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "hermes-cosmos-wasm-relayer"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "eyre",
@@ -2245,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "hermes-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
 ]
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "hermes-error"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "eyre",
@@ -2263,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "hermes-ibc-test-suite"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2274,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "hermes-logger"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2288,7 +2288,7 @@ dependencies = [
 [[package]]
 name = "hermes-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
 ]
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "hermes-protobuf-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-encoding-components",
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "futures",
@@ -2321,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "hermes-relayer-components-extra"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-async-runtime-components",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "hermes-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
 ]
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "hermes-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "hermes-tokio-runtime-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "futures",
@@ -2604,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "hermes-tracing-logging-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-logging-components",
@@ -2616,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-client-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-cosmos-chain-components",
@@ -2635,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-encoding-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-cosmos-encoding-components",
@@ -2649,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "hermes-wasm-test-components"
 version = "0.1.0"
-source = "git+https://github.com/informalsystems/hermes-sdk.git#0ff9d64245fd8e5da0e6e6bcac83888531372c8c"
+source = "git+https://github.com/informalsystems/hermes-sdk.git#83bfd3db2ffdffab81dca6a3548d9f91f960aa2d"
 dependencies = [
  "cgp",
  "hermes-chain-type-components",
@@ -4485,7 +4485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",

--- a/relayer/crates/starknet-chain-components/Cargo.toml
+++ b/relayer/crates/starknet-chain-components/Cargo.toml
@@ -28,9 +28,6 @@ hermes-protobuf-encoding-components = { workspace = true }
 hermes-cosmos-encoding-components   = { workspace = true }
 hermes-wasm-encoding-components     = { workspace = true }
 
-
-hermes-logging-components           = { workspace = true }
-
 ibc       = { workspace = true }
 ibc-proto = { workspace = true }
 

--- a/relayer/crates/starknet-chain-components/Cargo.toml
+++ b/relayer/crates/starknet-chain-components/Cargo.toml
@@ -28,6 +28,9 @@ hermes-protobuf-encoding-components = { workspace = true }
 hermes-cosmos-encoding-components   = { workspace = true }
 hermes-wasm-encoding-components     = { workspace = true }
 
+
+hermes-logging-components           = { workspace = true }
+
 ibc       = { workspace = true }
 ibc-proto = { workspace = true }
 
@@ -43,5 +46,6 @@ sha2                        = { workspace = true }
 starknet                    = { workspace = true }
 tonic                       = { workspace = true }
 futures                     = { workspace = true }
+time                        = { version = "0.3.36" }
 crypto-bigint               = "0.5.5"
 derive_more                 = { version = "2.0", features = [ "constructor", "deref", "display", "from", "from_str" ], default-features = false }

--- a/relayer/crates/starknet-chain-components/src/components/chain.rs
+++ b/relayer/crates/starknet-chain-components/src/components/chain.rs
@@ -1,6 +1,6 @@
 #[cgp::re_export_imports]
 mod preset {
-    use cgp::core::types::UseDelegatedType;
+    use cgp::core::types::{UseDelegatedType, WithType};
     use cgp::prelude::*;
     use hermes_chain_components::impls::payload_builders::channel::BuildChannelHandshakePayload;
     use hermes_chain_components::impls::payload_builders::connection::BuildConnectionHandshakePayload;
@@ -118,7 +118,7 @@ mod preset {
     use hermes_chain_components::traits::types::ibc_events::write_ack::WriteAckEventComponent;
     use hermes_chain_components::traits::types::packet::OutgoingPacketTypeComponent;
     use hermes_chain_components::traits::types::packets::ack::{
-        AckPacketPayloadTypeComponent, AcknowledgementTypeComponent,
+        AckCommitmentHashTypeComponent, AckPacketPayloadTypeComponent, AcknowledgementTypeComponent,
     };
     use hermes_chain_components::traits::types::packets::receive::{
         PacketCommitmentTypeComponent, ReceivePacketPayloadTypeComponent,
@@ -368,6 +368,8 @@ mod preset {
                 ProvideBytesPacketCommitment,
             AcknowledgementTypeComponent:
                 ProvideBytesAcknowlegement,
+            AckCommitmentHashTypeComponent:
+                WithType<Vec<u8>>,
             PacketReceiptTypeComponent:
                 ProvideBytesPacketReceipt,
             [

--- a/relayer/crates/starknet-chain-components/src/components/chain.rs
+++ b/relayer/crates/starknet-chain-components/src/components/chain.rs
@@ -178,11 +178,14 @@ mod preset {
     use hermes_test_components::chain::traits::queries::balance::BalanceQuerierComponent;
     use hermes_test_components::chain::traits::transfer::ibc_transfer::TokenIbcTransferrerComponent;
     use hermes_test_components::chain::traits::transfer::string_memo::ProvideStringMemoType;
+    use hermes_test_components::chain::traits::transfer::timeout::IbcTransferTimeoutCalculatorComponent;
     use hermes_test_components::chain::traits::types::address::AddressTypeComponent;
     use hermes_test_components::chain::traits::types::amount::AmountTypeComponent;
     use hermes_test_components::chain::traits::types::denom::DenomTypeComponent;
     use hermes_test_components::chain::traits::types::memo::MemoTypeComponent;
-    use hermes_test_components::chain::traits::types::wallet::WalletTypeComponent;
+    use hermes_test_components::chain::traits::types::wallet::{
+        WalletSignerComponent, WalletTypeComponent,
+    };
     use starknet::core::types::Felt;
 
     use crate::components::types::StarknetChainTypes;
@@ -221,7 +224,7 @@ mod preset {
     use crate::impls::queries::status::QueryStarknetChainStatus;
     use crate::impls::queries::token_balance::QueryErc20TokenBalance;
     use crate::impls::send_message::SendStarknetMessages;
-    use crate::impls::transfer::TransferErc20Token;
+    use crate::impls::transfer::{IbcTransferTimeoutAfterSeconds, TransferErc20Token};
     use crate::impls::tx_response::QueryTransactionReceipt;
     use crate::impls::types::address::ProvideFeltAddressType;
     use crate::impls::types::amount::ProvideU256Amount;
@@ -241,7 +244,7 @@ mod preset {
     use crate::impls::types::status::ProvideStarknetChainStatusType;
     use crate::impls::types::tx_hash::ProvideFeltTxHash;
     use crate::impls::types::tx_response::ProvideStarknetTxResponse;
-    use crate::impls::types::wallet::UseStarknetWallet;
+    use crate::impls::types::wallet::ProvideStarknetWallet;
     use crate::traits::contract::call::ContractCallerComponent;
     use crate::traits::contract::declare::ContractDeclarerComponent;
     use crate::traits::contract::deploy::ContractDeployerComponent;
@@ -293,8 +296,11 @@ mod preset {
                 ProvideTokenAddressDenom,
             MemoTypeComponent:
                 ProvideStringMemoType,
-            WalletTypeComponent:
-                UseStarknetWallet,
+            [
+                WalletTypeComponent,
+                WalletSignerComponent,
+            ]:
+                ProvideStarknetWallet,
             [
                 SignerTypeProviderComponent,
                 DefaultSignerGetterComponent,
@@ -304,6 +310,8 @@ mod preset {
                 UseType<Felt>,
             TokenIbcTransferrerComponent:
                 SendIbcTransferMessage,
+            IbcTransferTimeoutCalculatorComponent:
+                IbcTransferTimeoutAfterSeconds<90>,
             TransactionHashTypeComponent:
                 ProvideFeltTxHash,
             TxResponseTypeComponent:

--- a/relayer/crates/starknet-chain-components/src/impls/events/ack.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/events/ack.rs
@@ -1,7 +1,9 @@
 use core::marker::PhantomData;
+use std::str::FromStr;
 
 use cgp::prelude::*;
 use hermes_cairo_encoding_components::strategy::ViaCairo;
+use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_cairo_encoding_components::types::as_starknet_event::AsStarknetEvent;
 use hermes_chain_components::traits::extract_data::{EventExtractor, EventExtractorComponent};
 use hermes_chain_components::traits::packet::from_write_ack::{
@@ -16,13 +18,20 @@ use hermes_chain_components::traits::types::packets::ack::HasAcknowledgementType
 use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
+use ibc::apps::transfer::types::{Amount, BaseDenom, Memo, PrefixedDenom, TracePath};
 use ibc::core::channel::types::error::ChannelError;
-use ibc::core::channel::types::packet::Packet;
-use ibc::core::channel::types::timeout::{TimeoutHeight, TimeoutTimestamp};
+use ibc::core::channel::types::packet::Packet as IbcPacket;
 use ibc::core::host::types::error::IdentifierError;
+use ibc::core::host::types::identifiers::{ChannelId, PortId};
+use ibc::primitives::Signer;
+use ibc_proto::ibc::core::client::v1::Height as RawHeight;
+use serde::{Deserialize, Serialize};
+use starknet::core::types::Felt;
 
 use crate::impls::events::UseStarknetEvents;
 use crate::types::events::packet::{PacketRelayEvents, WriteAcknowledgementEvent};
+use crate::types::messages::ibc::ibc_transfer::TransferPacketData as CairoTransferPacketData;
+use crate::types::messages::ibc::packet::Packet;
 
 #[cgp_provider(WriteAckEventComponent)]
 impl<Chain, Counterparty> ProvideWriteAckEvent<Chain, Counterparty> for UseStarknetEvents
@@ -54,32 +63,24 @@ where
 }
 
 #[cgp_provider(PacketFromWriteAckEventBuilderComponent)]
-impl<Chain, Counterparty> PacketFromWriteAckEventBuilder<Chain, Counterparty> for UseStarknetEvents
+impl<Chain, Counterparty, Encoding> PacketFromWriteAckEventBuilder<Chain, Counterparty>
+    for UseStarknetEvents
 where
     Chain: HasWriteAckEvent<Counterparty, WriteAckEvent = WriteAcknowledgementEvent>
         + HasAcknowledgementType<Counterparty, Acknowledgement = Vec<u8>>
+        + HasEncoding<AsFelt, Encoding = Encoding>
         + CanRaiseAsyncError<IdentifierError>
         + CanRaiseAsyncError<ChannelError>
         + CanRaiseAsyncError<serde_json::Error>,
-    Counterparty: HasOutgoingPacketType<Chain, OutgoingPacket = Packet>,
+    Counterparty: HasOutgoingPacketType<Chain, OutgoingPacket = IbcPacket>,
+    Encoding: HasEncodedType<Encoded = Vec<Felt>> + CanDecode<ViaCairo, CairoTransferPacketData>,
 {
     async fn build_packet_from_write_ack_event(
-        _chain: &Chain,
+        chain: &Chain,
         event: &WriteAcknowledgementEvent,
-    ) -> Result<Packet, Chain::Error> {
-        let packet = Packet {
-            seq_on_a: event.sequence_on_a,
-            port_id_on_a: event.port_id_on_a.clone(),
-            chan_id_on_a: event.channel_id_on_a.clone(),
-            port_id_on_b: event.port_id_on_b.clone(),
-            chan_id_on_b: event.channel_id_on_b.clone(),
-            // FIXME: make the Cairo contract include these fields in the event
-            data: Vec::new(),
-            timeout_height_on_b: TimeoutHeight::Never,
-            timeout_timestamp_on_b: TimeoutTimestamp::Never,
-        };
-
-        Ok(packet)
+    ) -> Result<IbcPacket, Chain::Error> {
+        let ibc_packet = from_cairo_to_cosmos_packet(chain, &event.packet, chain.encoding()).await;
+        Ok(ibc_packet)
     }
 
     async fn build_ack_from_write_ack_event(
@@ -97,5 +98,86 @@ where
             .collect::<Vec<_>>();
 
         Ok(ack_bytes)
+    }
+}
+
+// FIXME: Fix conversion from Cairo to Cosmos packet
+#[derive(Serialize, Deserialize)]
+pub struct DummyTransferData {
+    pub amount: String,
+    pub denom: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default)]
+    pub memo: String,
+    pub receiver: String,
+    pub sender: String,
+}
+
+async fn from_cairo_to_cosmos_packet<Chain, Encoding>(
+    chain: &Chain,
+    packet: &Packet,
+    encoding: &Encoding,
+) -> IbcPacket
+where
+    Encoding: CanDecode<ViaCairo, CairoTransferPacketData> + HasEncodedType<Encoded = Vec<Felt>>,
+{
+    let seq_on_a = packet.sequence.into();
+    let port_id_on_a = PortId::new(packet.src_port_id.clone()).unwrap();
+    let chan_id_on_a = ChannelId::from_str(&packet.src_channel_id).unwrap();
+    let port_id_on_b = PortId::new(packet.dst_port_id.clone()).unwrap();
+    let chan_id_on_b = ChannelId::from_str(&packet.dst_channel_id).unwrap();
+
+    let timeout_height = RawHeight {
+        revision_number: packet.timeout_height.revision_number,
+        revision_height: packet.timeout_height.revision_height,
+    };
+
+    let timeout_timestamp_on_b = (packet.timeout_timestamp).into();
+
+    let cairo_transfer_packet_data = encoding.decode(&packet.data).unwrap();
+
+    let memo = Memo::from(cairo_transfer_packet_data.memo.to_string());
+
+    let sender = Signer::from(cairo_transfer_packet_data.sender.to_string());
+
+    let receiver = Signer::from(cairo_transfer_packet_data.receiver.to_string());
+
+    let raw_denom = cairo_transfer_packet_data.denom.to_string();
+
+    let mut parts: Vec<&str> = raw_denom.split('/').collect();
+    if !parts.is_empty() {
+        parts.pop();
+    }
+    let trace_path_str = parts.join("/");
+
+    let trace_path = TracePath::from_str(&trace_path_str).unwrap();
+
+    let denom = PrefixedDenom {
+        trace_path,
+        base_denom: BaseDenom::from_str(&cairo_transfer_packet_data.denom.base.to_string())
+            .unwrap(),
+    };
+
+    let amount = Amount::from_str(&cairo_transfer_packet_data.amount.to_string()).unwrap();
+
+    let raw_data = DummyTransferData {
+        denom: denom.to_string(),
+        amount: amount.to_string(),
+        sender: sender.to_string(),
+        receiver: receiver.to_string(),
+        memo: memo.to_string(),
+    };
+
+    let data = serde_json::to_vec(&raw_data).unwrap();
+
+    IbcPacket {
+        seq_on_a,
+        port_id_on_a,
+        chan_id_on_a,
+        port_id_on_b,
+        chan_id_on_b,
+        data,
+        timeout_height_on_b: timeout_height.try_into().unwrap(),
+        timeout_timestamp_on_b,
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
@@ -1,9 +1,21 @@
+use std::marker::PhantomData;
+use std::str::FromStr;
+
 use cgp::prelude::*;
+use hermes_cairo_encoding_components::strategy::ViaCairo;
+use hermes_cairo_encoding_components::types::as_felt::AsFelt;
 use hermes_chain_components::traits::types::height::HasHeightType;
 use hermes_chain_components::traits::types::ibc::{HasChannelIdType, HasPortIdType};
 use hermes_chain_components::traits::types::message::HasMessageType;
 use hermes_chain_components::traits::types::timestamp::HasTimeoutType;
 use hermes_chain_type_components::traits::types::address::HasAddressType;
+use hermes_encoding_components::traits::decode::CanDecode;
+use hermes_encoding_components::traits::encode::CanEncode;
+use hermes_encoding_components::traits::has_encoding::HasEncoding;
+use hermes_encoding_components::traits::types::encoded::HasEncodedType;
+use hermes_logging_components::traits::has_logger::HasLogger;
+use hermes_logging_components::traits::logger::CanLog;
+use hermes_logging_components::types::level::LevelInfo;
 use hermes_test_components::chain::traits::messages::ibc_transfer::{
     IbcTokenTransferMessageBuilder, IbcTokenTransferMessageBuilderComponent,
 };
@@ -11,15 +23,26 @@ use hermes_test_components::chain::traits::types::amount::HasAmountType;
 use hermes_test_components::chain::traits::types::memo::HasMemoType;
 use ibc::core::host::types::identifiers::PortId;
 use ibc::primitives::Timestamp;
+use starknet::accounts::Call;
+use starknet::core::types::Felt;
+use starknet::macros::selector;
 
+use crate::impls::types::address::StarknetAddress;
 use crate::impls::types::message::StarknetMessage;
+use crate::traits::contract::call::CanCallContract;
+use crate::traits::queries::address::CanQueryContractAddress;
+use crate::traits::types::blob::HasBlobType;
+use crate::traits::types::method::HasSelectorType;
 use crate::types::amount::StarknetAmount;
 use crate::types::channel_id::ChannelId;
+use crate::types::cosmos::height::Height;
+use crate::types::messages::ibc::denom::PrefixedDenom;
+use crate::types::messages::ibc::ibc_transfer::MsgTransfer;
 
 pub struct BuildStarknetIbcTransferMessage;
 
 #[cgp_provider(IbcTokenTransferMessageBuilderComponent)]
-impl<Chain, Counterparty> IbcTokenTransferMessageBuilder<Chain, Counterparty>
+impl<Chain, Counterparty, Encoding> IbcTokenTransferMessageBuilder<Chain, Counterparty>
     for BuildStarknetIbcTransferMessage
 where
     Chain: HasAsyncErrorType
@@ -29,20 +52,115 @@ where
         + HasHeightType<Height = u64>
         + HasTimeoutType<Timeout = Timestamp>
         + HasChannelIdType<Counterparty, ChannelId = ChannelId>
-        + HasPortIdType<Counterparty, PortId = PortId>,
+        + HasPortIdType<Counterparty, PortId = PortId>
+        + HasEncoding<AsFelt, Encoding = Encoding>
+        + HasAddressType<Address = StarknetAddress>
+        + HasLogger
+        + CanCallContract
+        + HasBlobType<Blob = Vec<Felt>>
+        + HasSelectorType<Selector = Felt>
+        + CanQueryContractAddress<symbol!("ibc_ics20_contract_address")>
+        + CanRaiseAsyncError<Encoding::Error>
+        + CanRaiseAsyncError<String>,
     Counterparty: HasAddressType,
+    Encoding: CanEncode<ViaCairo, MsgTransfer>
+        + CanEncode<ViaCairo, Product![StarknetAddress]>
+        + HasEncodedType<Encoded = Vec<Felt>>
+        + CanDecode<ViaCairo, String>,
+    Chain::Logger: CanLog<LevelInfo>,
 {
     async fn build_ibc_token_transfer_message(
-        _chain: &Chain,
-        _channel_id: &ChannelId,
-        _port_id: &PortId,
-        _recipient_address: &Counterparty::Address,
-        _amount: &StarknetAmount,
-        _memo: &Option<String>,
-        _timeout_height: Option<&u64>,
-        _timeout_time: Option<&Timestamp>,
+        chain: &Chain,
+        channel_id: &ChannelId,
+        port_id: &PortId,
+        recipient_address: &Counterparty::Address,
+        amount: &StarknetAmount,
+        memo: &Option<String>,
+        timeout_height: Option<&u64>,
+        timeout_time: Option<&Timestamp>,
     ) -> Result<Chain::Message, Chain::Error> {
-        // FIXME: Implement the logic to build the token transfer message
-        todo!()
+        let ics20_contract_address = chain.query_contract_address(PhantomData).await?;
+
+        chain
+            .logger()
+            .log(
+                &format!("ics20_contract_address: {ics20_contract_address}"),
+                &LevelInfo,
+            )
+            .await;
+
+        let calldata = chain
+            .encoding()
+            .encode(&product![amount.token_address])
+            .map_err(Chain::raise_error)?;
+
+        let output = chain
+            .call_contract(
+                &ics20_contract_address,
+                &selector!("ibc_token_denom"),
+                &calldata,
+                None,
+            )
+            .await?;
+
+        let prefix_denom_str = chain
+            .encoding()
+            .decode(&output)
+            .map_err(Chain::raise_error)?;
+
+        chain
+            .logger()
+            .log(
+                &format!("prefix_denom_str: {prefix_denom_str}"),
+                &LevelInfo,
+            )
+            .await;
+
+        let denom = PrefixedDenom::from_str(&prefix_denom_str).map_err(Chain::raise_error)?;
+
+        let timeout_height_on_b = if let Some(timeout_height) = timeout_height {
+            Height {
+                revision_number: 0,
+                revision_height: *timeout_height,
+            }
+        } else {
+            Height {
+                revision_number: 0,
+                revision_height: 0,
+            }
+        };
+
+        let timeout_timestamp_on_b = if let Some(timeout_time) = timeout_time {
+            *timeout_time
+        } else {
+            Timestamp::from_nanoseconds(0)
+        };
+
+        let memo = if let Some(memo) = memo {
+            memo.clone()
+        } else {
+            String::new()
+        };
+
+        let ics20_transfer_message = MsgTransfer {
+            port_id_on_a: port_id.clone(),
+            chan_id_on_a: channel_id.clone(),
+            denom,
+            amount: amount.quantity,
+            receiver: recipient_address.to_string(),
+            memo,
+            timeout_height_on_b,
+            timeout_timestamp_on_b,
+        };
+
+        let call_data = chain.encoding().encode(&ics20_transfer_message).unwrap();
+
+        let call = Call {
+            to: ics20_contract_address.0,
+            selector: selector!("send_transfer"),
+            calldata: call_data,
+        };
+
+        Ok(StarknetMessage::new(call))
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
@@ -89,6 +89,14 @@ where
             )
             .await;
 
+        chain
+            .logger()
+            .log(
+                &format!("will query denom with: address {}", amount.token_address),
+                &LevelInfo,
+            )
+            .await;
+
         let calldata = chain
             .encoding()
             .encode(&product![amount.token_address])
@@ -110,10 +118,7 @@ where
 
         chain
             .logger()
-            .log(
-                &format!("prefix_denom_str: {prefix_denom_str}"),
-                &LevelInfo,
-            )
+            .log(&format!("prefix_denom_str: {prefix_denom_str}"), &LevelInfo)
             .await;
 
         let denom = PrefixedDenom::from_str(&prefix_denom_str).map_err(Chain::raise_error)?;

--- a/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
@@ -13,9 +13,6 @@ use hermes_encoding_components::traits::decode::CanDecode;
 use hermes_encoding_components::traits::encode::CanEncode;
 use hermes_encoding_components::traits::has_encoding::HasEncoding;
 use hermes_encoding_components::traits::types::encoded::HasEncodedType;
-use hermes_logging_components::traits::has_logger::HasLogger;
-use hermes_logging_components::traits::logger::CanLog;
-use hermes_logging_components::types::level::LevelInfo;
 use hermes_test_components::chain::traits::messages::ibc_transfer::{
     IbcTokenTransferMessageBuilder, IbcTokenTransferMessageBuilderComponent,
 };
@@ -55,7 +52,6 @@ where
         + HasPortIdType<Counterparty, PortId = PortId>
         + HasEncoding<AsFelt, Encoding = Encoding>
         + HasAddressType<Address = StarknetAddress>
-        + HasLogger
         + CanCallContract
         + HasBlobType<Blob = Vec<Felt>>
         + HasSelectorType<Selector = Felt>
@@ -67,7 +63,6 @@ where
         + CanEncode<ViaCairo, Product![StarknetAddress]>
         + HasEncodedType<Encoded = Vec<Felt>>
         + CanDecode<ViaCairo, String>,
-    Chain::Logger: CanLog<LevelInfo>,
 {
     async fn build_ibc_token_transfer_message(
         chain: &Chain,
@@ -80,22 +75,6 @@ where
         timeout_time: Option<&Timestamp>,
     ) -> Result<Chain::Message, Chain::Error> {
         let ics20_contract_address = chain.query_contract_address(PhantomData).await?;
-
-        chain
-            .logger()
-            .log(
-                &format!("ics20_contract_address: {ics20_contract_address}"),
-                &LevelInfo,
-            )
-            .await;
-
-        chain
-            .logger()
-            .log(
-                &format!("will query denom with: address {}", amount.token_address),
-                &LevelInfo,
-            )
-            .await;
 
         let calldata = chain
             .encoding()
@@ -115,11 +94,6 @@ where
             .encoding()
             .decode(&output)
             .map_err(Chain::raise_error)?;
-
-        chain
-            .logger()
-            .log(&format!("prefix_denom_str: {prefix_denom_str}"), &LevelInfo)
-            .await;
 
         let denom = PrefixedDenom::from_str(&prefix_denom_str).map_err(Chain::raise_error)?;
 

--- a/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/ibc_transfer.rs
@@ -132,7 +132,10 @@ where
             timeout_timestamp_on_b,
         };
 
-        let call_data = chain.encoding().encode(&ics20_transfer_message).unwrap();
+        let call_data = chain
+            .encoding()
+            .encode(&ics20_transfer_message)
+            .map_err(Chain::raise_error)?;
 
         let call = Call {
             to: ics20_contract_address.0,

--- a/relayer/crates/starknet-chain-components/src/impls/messages/packet.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/messages/packet.rs
@@ -363,7 +363,7 @@ where
 
     let timeout_timestamp = match packet.timeout_timestamp_on_b {
         TimeoutTimestamp::Never => 0,
-        TimeoutTimestamp::At(timeout_timestamp) => timeout_timestamp.nanoseconds() / 1_000_000_000,
+        TimeoutTimestamp::At(timeout_timestamp) => timeout_timestamp.nanoseconds(),
     };
 
     CairoPacket {

--- a/relayer/crates/starknet-chain-components/src/impls/queries/ack_commitment.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/ack_commitment.rs
@@ -12,7 +12,7 @@ use hermes_chain_components::traits::types::height::HasHeightType;
 use hermes_chain_components::traits::types::ibc::{
     HasChannelIdType, HasPortIdType, HasSequenceType,
 };
-use hermes_chain_components::traits::types::packets::ack::HasAcknowledgementType;
+use hermes_chain_components::traits::types::packets::ack::HasAckCommitmentHashType;
 use hermes_chain_components::traits::types::proof::HasCommitmentProofType;
 use hermes_cosmos_chain_components::types::key_types::secp256k1::Secp256k1KeyPair;
 use hermes_encoding_components::traits::decode::CanDecode;
@@ -35,9 +35,6 @@ use crate::types::membership_proof_signer::MembershipVerifierContainer;
 use crate::types::messages::ibc::channel::PortId as CairoPortId;
 use crate::types::messages::ibc::packet::Sequence;
 use crate::types::status::StarknetChainStatus;
-
-const SUCCESS_ACK: &[u8] = br#"{"result":"AQ=="}"#;
-
 pub struct QueryStarknetAckCommitment;
 
 #[cgp_provider(PacketAcknowledgementQuerierComponent)]
@@ -49,7 +46,7 @@ where
         + HasIbcCommitmentPrefix<CommitmentPrefix = Vec<u8>>
         + HasChannelIdType<Counterparty, ChannelId = ChannelId>
         + HasPortIdType<Counterparty, PortId = IbcPortId>
-        + HasAcknowledgementType<Counterparty, Acknowledgement = Vec<u8>>
+        + HasAckCommitmentHashType<AckCommitmentHash = Vec<u8>>
         + HasCommitmentProofType<CommitmentProof = StarknetCommitmentProof>
         + HasBlobType<Blob = Vec<Felt>>
         + HasSelectorType<Selector = Felt>
@@ -65,7 +62,7 @@ where
         + CanDecode<ViaCairo, Product![[u32; 8]]>
         + HasEncodedType<Encoded = Vec<Felt>>,
 {
-    async fn query_packet_acknowledgement(
+    async fn query_packet_acknowledgement_with_proof(
         chain: &Chain,
         channel_id: &ChannelId,
         port_id: &IbcPortId,
@@ -120,14 +117,9 @@ where
             proof_bytes: signed_bytes,
         };
 
-        // assert sha256 hash of SUCCESS_ACK is stored ack_bytes
-        // asset_eq!(ack_bytes, SUCCESS_ACK);
+        // `ack_bytes` is stored after hashing.
+        // query block event is required to get the original ack_bytes.
 
-        // FIXME: we can't send `ack_bytes` as it is stored after hashing.
-        // We should query block event to get the original ack_bytes.
-        //
-        // For now, we just return the SUCCESS_ACK as ack_bytes.
-
-        Ok((SUCCESS_ACK.to_vec(), dummy_proof))
+        Ok((ack_bytes, dummy_proof))
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/queries/nonce.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/queries/nonce.rs
@@ -8,17 +8,19 @@ use starknet::accounts::ConnectedAccount;
 use starknet::core::types::Felt;
 use starknet::providers::ProviderError;
 
-use crate::traits::account::HasStarknetAccountType;
+use crate::traits::account::{CanBuildAccountFromSigner, HasStarknetAccountType};
 
 #[cgp_new_provider(NonceQuerierComponent)]
 impl<Chain> NonceQuerier<Chain> for QueryStarknetNonce
 where
     Chain: HasStarknetAccountType
-        + HasSignerType<Signer = Chain::Account>
+        + HasSignerType
+        + CanBuildAccountFromSigner
         + HasNonceType<Nonce = Felt>
         + CanRaiseAsyncError<ProviderError>,
 {
-    async fn query_nonce(chain: &Chain, account: &Chain::Account) -> Result<Felt, Chain::Error> {
+    async fn query_nonce(chain: &Chain, signer: &Chain::Signer) -> Result<Felt, Chain::Error> {
+        let account = chain.build_account_from_signer(signer);
         let nonce = account.get_nonce().await.map_err(Chain::raise_error)?;
         Ok(nonce)
     }

--- a/relayer/crates/starknet-chain-components/src/impls/types/config.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/config.rs
@@ -27,6 +27,7 @@ pub struct StarknetChainConfig {
 pub struct StarknetContractAddresses {
     pub ibc_core: Option<StarknetAddress>,
     pub ibc_client: Option<StarknetAddress>,
+    pub ibc_ics20: Option<StarknetAddress>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/relayer/crates/starknet-chain-components/src/impls/types/signer.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/signer.rs
@@ -6,7 +6,9 @@ use hermes_relayer_components::transaction::traits::types::signer::{
     HasSignerType, SignerTypeProvider, SignerTypeProviderComponent,
 };
 
-use crate::traits::account::{HasStarknetAccount, HasStarknetAccountType};
+use crate::traits::account::HasStarknetAccountType;
+use crate::traits::signer::HasStarknetSigner;
+use crate::types::wallet::StarknetWallet;
 
 pub struct UseStarknetAccountSigner;
 
@@ -15,15 +17,15 @@ impl<Chain> SignerTypeProvider<Chain> for UseStarknetAccountSigner
 where
     Chain: HasStarknetAccountType,
 {
-    type Signer = Chain::Account;
+    type Signer = StarknetWallet;
 }
 
 #[cgp_provider(DefaultSignerGetterComponent)]
 impl<Chain> DefaultSignerGetter<Chain> for UseStarknetAccountSigner
 where
-    Chain: HasStarknetAccount + HasSignerType<Signer = Chain::Account>,
+    Chain: HasStarknetSigner + HasSignerType<Signer = StarknetWallet>,
 {
     fn get_default_signer(chain: &Chain) -> &Chain::Signer {
-        chain.account()
+        chain.signer()
     }
 }

--- a/relayer/crates/starknet-chain-components/src/impls/types/wallet.rs
+++ b/relayer/crates/starknet-chain-components/src/impls/types/wallet.rs
@@ -1,16 +1,18 @@
 use cgp::prelude::*;
+use hermes_relayer_components::transaction::traits::types::signer::HasSignerType;
 use hermes_test_components::chain::traits::types::address::HasAddressType;
 use hermes_test_components::chain::traits::types::wallet::{
-    ProvideWalletType, WalletTypeComponent,
+    HasWalletType, ProvideWalletType, WalletSignerComponent, WalletSignerProvider,
+    WalletTypeComponent,
 };
 
 use crate::impls::types::address::StarknetAddress;
 use crate::types::wallet::StarknetWallet;
 
-pub struct UseStarknetWallet;
+pub struct ProvideStarknetWallet;
 
 #[cgp_provider(WalletTypeComponent)]
-impl<Bootstrap> ProvideWalletType<Bootstrap> for UseStarknetWallet
+impl<Bootstrap> ProvideWalletType<Bootstrap> for ProvideStarknetWallet
 where
     Bootstrap: HasAddressType<Address = StarknetAddress>,
 {
@@ -18,5 +20,15 @@ where
 
     fn wallet_address(wallet: &StarknetWallet) -> &StarknetAddress {
         &wallet.account_address
+    }
+}
+
+#[cgp_provider(WalletSignerComponent)]
+impl<Chain> WalletSignerProvider<Chain> for ProvideStarknetWallet
+where
+    Chain: HasWalletType<Wallet = StarknetWallet> + HasSignerType<Signer = StarknetWallet>,
+{
+    fn wallet_signer(wallet: &StarknetWallet) -> &StarknetWallet {
+        wallet
     }
 }

--- a/relayer/crates/starknet-chain-components/src/traits/account.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/account.rs
@@ -1,4 +1,5 @@
 use cgp::prelude::*;
+use hermes_relayer_components::transaction::traits::types::signer::HasSignerType;
 use starknet::accounts::{Account, AccountError, ConnectedAccount};
 
 #[cgp_type {
@@ -15,6 +16,14 @@ pub trait HasStarknetAccountType: Async {
 }]
 pub trait HasStarknetAccount: HasStarknetAccountType {
     fn account(&self) -> &Self::Account;
+}
+
+#[cgp_component {
+    provider: AccountFromSignerBuilder,
+    context: Chain
+}]
+pub trait CanBuildAccountFromSigner: HasStarknetAccountType + HasSignerType {
+    fn build_account_from_signer(&self, signer: &Self::Signer) -> Self::Account;
 }
 
 pub trait CanRaiseAccountErrors:

--- a/relayer/crates/starknet-chain-components/src/traits/mod.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/mod.rs
@@ -5,5 +5,6 @@ pub mod messages;
 pub mod proof_signer;
 pub mod provider;
 pub mod queries;
+pub mod signer;
 pub mod transfer;
 pub mod types;

--- a/relayer/crates/starknet-chain-components/src/traits/signer.rs
+++ b/relayer/crates/starknet-chain-components/src/traits/signer.rs
@@ -1,0 +1,10 @@
+use cgp::prelude::*;
+use hermes_relayer_components::transaction::traits::types::signer::HasSignerType;
+
+#[cgp_getter {
+    provider: StarknetSignerGetter,
+    context: Chain,
+}]
+pub trait HasStarknetSigner: HasSignerType {
+    fn signer(&self) -> &Self::Signer;
+}

--- a/relayer/crates/starknet-chain-components/src/types/cosmos/timestamp.rs
+++ b/relayer/crates/starknet-chain-components/src/types/cosmos/timestamp.rs
@@ -19,7 +19,7 @@ where
         value: &Timestamp,
         buffer: &mut Encoding::EncodeBuffer,
     ) -> Result<(), Encoding::Error> {
-        let unix_secs = value.nanoseconds() / 1_000_000_000;
+        let unix_secs = value.nanoseconds();
         encoding.encode_mut(&product![unix_secs], buffer)?;
         Ok(())
     }
@@ -35,6 +35,6 @@ where
         buffer: &mut Encoding::DecodeBuffer<'a>,
     ) -> Result<Timestamp, Encoding::Error> {
         let product![unix_secs] = encoding.decode_mut(buffer)?;
-        Ok(Timestamp::from_nanoseconds(unix_secs * 1_000_000_000))
+        Ok(Timestamp::from_nanoseconds(unix_secs))
     }
 }

--- a/relayer/crates/starknet-chain-components/src/types/events/packet.rs
+++ b/relayer/crates/starknet-chain-components/src/types/events/packet.rs
@@ -12,7 +12,7 @@ use crate::types::cosmos::height::Height;
 use crate::types::cosmos::timestamp::Timestamp;
 use crate::types::event::{StarknetEvent, UnknownEvent};
 use crate::types::messages::ibc::channel::{ChannelOrdering, PortId};
-use crate::types::messages::ibc::packet::{Acknowledgement, Sequence};
+use crate::types::messages::ibc::packet::{Acknowledgement, Packet, Sequence};
 
 #[derive(Debug)]
 pub enum PacketRelayEvents {
@@ -59,7 +59,7 @@ pub struct WriteAcknowledgementEvent {
     pub port_id_on_b: PortId,
     pub channel_id_on_b: ChannelId,
 
-    pub packet_data: Vec<Felt>,
+    pub packet: Packet,
     pub acknowledgement: Acknowledgement,
 }
 
@@ -255,7 +255,7 @@ where
         + CanRaiseAsyncError<CairoEncoding::Error>,
     CairoEncoding: HasEncodedType<Encoded = Vec<Felt>>
         + CanDecode<ViaCairo, Product![Sequence, PortId, ChannelId, PortId, ChannelId]>
-        + CanDecode<ViaCairo, Product![Vec<Felt>, Acknowledgement]>,
+        + CanDecode<ViaCairo, Product![Packet, Acknowledgement]>,
 {
     fn decode(
         event_encoding: &EventEncoding,
@@ -273,7 +273,7 @@ where
             .decode(&event.keys)
             .map_err(EventEncoding::raise_error)?;
 
-        let product![packet_data, acknowledgement,] = cairo_encoding
+        let product![packet, acknowledgement,] = cairo_encoding
             .decode(&event.data)
             .map_err(EventEncoding::raise_error)?;
 
@@ -283,7 +283,7 @@ where
             channel_id_on_a,
             port_id_on_b,
             channel_id_on_b,
-            packet_data,
+            packet,
             acknowledgement,
         })
     }

--- a/relayer/crates/starknet-chain-components/src/types/messages/ibc/packet.rs
+++ b/relayer/crates/starknet-chain-components/src/types/messages/ibc/packet.rs
@@ -16,7 +16,7 @@ use starknet::core::types::Felt;
 
 use crate::types::cosmos::height::Height;
 
-#[derive(HasField, Clone)]
+#[derive(HasField, Clone, Debug)]
 pub struct Packet {
     pub sequence: u64,
     pub src_port_id: String,

--- a/relayer/crates/starknet-chain-context/src/contexts/chain.rs
+++ b/relayer/crates/starknet-chain-context/src/contexts/chain.rs
@@ -1,5 +1,6 @@
 use core::ops::Deref;
 use core::time::Duration;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use cgp::core::component::UseDelegate;
@@ -153,7 +154,8 @@ use hermes_starknet_chain_components::impls::provider::GetStarknetProviderField;
 use hermes_starknet_chain_components::impls::types::address::StarknetAddress;
 use hermes_starknet_chain_components::impls::types::events::StarknetCreateClientEvent;
 use hermes_starknet_chain_components::traits::account::{
-    HasStarknetAccount, StarknetAccountGetterComponent, StarknetAccountTypeProviderComponent,
+    AccountFromSignerBuilder, AccountFromSignerBuilderComponent, HasStarknetAccount,
+    StarknetAccountGetterComponent, StarknetAccountTypeProviderComponent,
 };
 use hermes_starknet_chain_components::traits::client::{
     JsonRpcClientGetter, JsonRpcClientGetterComponent,
@@ -170,6 +172,7 @@ use hermes_starknet_chain_components::traits::provider::{
 };
 use hermes_starknet_chain_components::traits::queries::address::CanQueryContractAddress;
 use hermes_starknet_chain_components::traits::queries::token_balance::CanQueryTokenBalance;
+use hermes_starknet_chain_components::traits::signer::StarknetSignerGetterComponent;
 use hermes_starknet_chain_components::traits::transfer::CanTransferToken;
 use hermes_starknet_chain_components::traits::types::blob::HasBlobType;
 use hermes_starknet_chain_components::traits::types::method::HasSelectorType;
@@ -188,6 +191,7 @@ use hermes_starknet_chain_components::types::payloads::client::{
     StarknetCreateClientPayloadOptions, StarknetUpdateClientPayload,
 };
 use hermes_starknet_chain_components::types::status::StarknetChainStatus;
+use hermes_starknet_chain_components::types::wallet::StarknetWallet;
 use hermes_test_components::chain::traits::assert::eventual_amount::CanAssertEventualAmount;
 use hermes_test_components::chain::traits::messages::ibc_transfer::CanBuildIbcTokenTransferMessage;
 use hermes_test_components::chain::traits::queries::balance::CanQueryBalance;
@@ -195,11 +199,11 @@ use hermes_test_components::chain::traits::types::address::HasAddressType;
 use hermes_test_components::chain::traits::types::memo::HasMemoType;
 use ibc::core::channel::types::packet::Packet;
 use ibc::core::host::types::identifiers::{ChainId, PortId as IbcPortId, Sequence};
-use starknet::accounts::SingleOwnerAccount;
+use starknet::accounts::{ExecutionEncoding, SingleOwnerAccount};
 use starknet::core::types::Felt;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
-use starknet::signers::LocalWallet;
+use starknet::signers::{LocalWallet, SigningKey};
 
 use crate::contexts::encoding::cairo::StarknetCairoEncoding;
 use crate::contexts::encoding::event::StarknetEventEncoding;
@@ -220,12 +224,14 @@ pub struct StarknetChainFields {
     pub account: Arc<SingleOwnerAccount<Arc<JsonRpcClient<HttpTransport>>, LocalWallet>>,
     pub ibc_client_contract_address: Option<StarknetAddress>,
     pub ibc_core_contract_address: Option<StarknetAddress>,
+    pub ibc_ics20_contract_address: Option<StarknetAddress>,
     pub event_encoding: StarknetEventEncoding,
     pub poll_interval: Duration,
     pub block_time: Duration,
     // FIXME: only needed for demo2
     pub proof_signer: Secp256k1KeyPair,
     pub nonce_mutex: Arc<Mutex<()>>,
+    pub signer: StarknetWallet,
 }
 
 impl Deref for StarknetChain {
@@ -268,6 +274,8 @@ delegate_components! {
             StarknetProofSignerGetterComponent,
         ]:
             GetStarknetProofSignerField<symbol!("proof_signer")>,
+        StarknetSignerGetterComponent:
+            WithField<symbol!("signer")>,
         NonceAllocationMutexGetterComponent:
             GetGlobalNonceMutex<symbol!("nonce_mutex")>,
         BlockTimeQuerierComponent:
@@ -335,6 +343,22 @@ impl JsonRpcClientGetter<StarknetChain> for StarknetChainContextComponents {
 impl ChainIdGetter<StarknetChain> for StarknetChainContextComponents {
     fn chain_id(chain: &StarknetChain) -> &ChainId {
         &chain.chain_id
+    }
+}
+
+#[cgp_provider(AccountFromSignerBuilderComponent)]
+impl AccountFromSignerBuilder<StarknetChain> for StarknetChainContextComponents {
+    fn build_account_from_signer(
+        chain: &StarknetChain,
+        signer: &StarknetWallet,
+    ) -> Arc<SingleOwnerAccount<Arc<JsonRpcClient<HttpTransport>>, LocalWallet>> {
+        Arc::new(SingleOwnerAccount::new(
+            chain.rpc_client.clone(),
+            LocalWallet::from_signing_key(SigningKey::from_secret_scalar(signer.signing_key)),
+            *signer.account_address,
+            Felt::from_str(chain.chain_id.as_str()).unwrap(),
+            ExecutionEncoding::New,
+        ))
     }
 }
 

--- a/relayer/crates/starknet-chain-context/src/impls/error.rs
+++ b/relayer/crates/starknet-chain-context/src/impls/error.rs
@@ -40,6 +40,7 @@ use hermes_starknet_chain_components::impls::queries::contract_address::Contract
 use hermes_starknet_chain_components::impls::send_message::UnexpectedTransactionTraceType;
 use hermes_starknet_chain_components::types::event::UnknownEvent;
 use hermes_test_components::chain::impls::assert::poll_assert_eventual_amount::EventualAmountTimeoutError;
+use hermes_test_components::chain::impls::ibc_transfer::MissingSendPacketEventError;
 use hermes_test_components::chain::traits::types::amount::HasAmountType;
 use ibc::core::channel::types::error::ChannelError;
 use ibc::core::client::types::error::ClientError;
@@ -100,6 +101,7 @@ delegate_components! {
             ContractAddressNotFound,
             EmptyMessageResponse,
             ConsensusStateNotFound,
+            MissingSendPacketEventError,
             <'a> UnknownEvent<'a>,
             <'a, Chain: HasAddressType + HasAmountType> EventualAmountTimeoutError<'a, Chain>,
             <'a, Chain: HasTransactionHashType> TxNoResponseError<'a, Chain>,

--- a/relayer/crates/starknet-cli/src/contexts/app.rs
+++ b/relayer/crates/starknet-cli/src/contexts/app.rs
@@ -233,6 +233,7 @@ impl ConfigUpdater<StarknetChainDriver, StarknetRelayerConfig> for UpdateStarkne
         let contract_addresses = StarknetContractAddresses {
             ibc_client: chain_driver.chain.ibc_client_contract_address,
             ibc_core: chain_driver.chain.ibc_core_contract_address,
+            ibc_ics20: chain_driver.chain.ibc_ics20_contract_address,
         };
 
         let contract_classes = StarknetContractClasses {

--- a/relayer/crates/starknet-integration-tests/src/contexts/bootstrap.rs
+++ b/relayer/crates/starknet-integration-tests/src/contexts/bootstrap.rs
@@ -185,11 +185,13 @@ impl ChainDriverBuilder<StarknetBootstrap> for StarknetBootstrapComponents {
                 account: Arc::new(account),
                 ibc_client_contract_address: None,
                 ibc_core_contract_address: None,
+                ibc_ics20_contract_address: None,
                 event_encoding: Default::default(),
                 proof_signer,
                 poll_interval: core::time::Duration::from_millis(200),
                 block_time: core::time::Duration::from_secs(1),
                 nonce_mutex: Arc::new(Mutex::new(())),
+                signer: relayer_wallet.clone(),
             }),
         };
 

--- a/relayer/crates/starknet-integration-tests/src/tests/clear_packets.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/clear_packets.rs
@@ -711,7 +711,7 @@ fn test_packet_clearing() -> Result<(), Error> {
         );
 
         birelay
-            .auto_bi_relay(Some(Duration::from_secs(20)), Some(Duration::from_secs(0)))
+            .auto_bi_relay(Some(Duration::from_secs(30)), Some(Duration::from_secs(0)))
             .await?;
 
         cosmos_chain
@@ -727,6 +727,11 @@ fn test_packet_clearing() -> Result<(), Error> {
                 - (transfer_back_quantity * 2).into(),
             balance_starknet_b_step_2.quantity
         );
+
+        // FIXME: Remove the second clearing once the lock issue has been fixed in Hermes SDK
+        birelay
+            .auto_bi_relay(Some(Duration::from_secs(10)), Some(Duration::from_secs(0)))
+            .await?;
 
         // Assert all packets have been cleared after auto relaying
         let cosmos_latest_height = cosmos_chain.query_chain_height().await?;

--- a/relayer/crates/starknet-integration-tests/src/tests/clear_packets.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/clear_packets.rs
@@ -1338,8 +1338,7 @@ fn test_relay_timeout_packet() -> Result<(), Error> {
                     revision_height: 0,
                 },
                 timeout_timestamp_on_b: Timestamp::from_nanoseconds(
-                    u64::try_from(current_starknet_time.unix_timestamp() + 90).unwrap()
-                        * 1_000_000_000,
+                    u64::try_from(current_starknet_time.unix_timestamp() + 90).unwrap(),
                 ),
             }
         };

--- a/relayer/crates/starknet-integration-tests/src/tests/clear_packets.rs
+++ b/relayer/crates/starknet-integration-tests/src/tests/clear_packets.rs
@@ -728,11 +728,6 @@ fn test_packet_clearing() -> Result<(), Error> {
             balance_starknet_b_step_2.quantity
         );
 
-        // FIXME: Remove the second clearing once the lock issue has been fixed in Hermes SDK
-        birelay
-            .auto_bi_relay(Some(Duration::from_secs(10)), Some(Duration::from_secs(0)))
-            .await?;
-
         // Assert all packets have been cleared after auto relaying
         let cosmos_latest_height = cosmos_chain.query_chain_height().await?;
         let starknet_latest_height = starknet_chain.query_chain_height().await?;

--- a/relayer/crates/starknet-relayer/src/contexts/builder.rs
+++ b/relayer/crates/starknet-relayer/src/contexts/builder.rs
@@ -296,11 +296,13 @@ impl StarknetBuilder {
                     .contract_addresses
                     .ibc_client,
                 ibc_core_contract_address: self.starknet_chain_config.contract_addresses.ibc_core,
+                ibc_ics20_contract_address: self.starknet_chain_config.contract_addresses.ibc_ics20,
                 event_encoding,
                 proof_signer,
                 poll_interval: self.starknet_chain_config.poll_interval,
                 block_time: self.starknet_chain_config.block_time,
                 nonce_mutex: Arc::new(Mutex::new(())),
+                signer: relayer_wallet,
             }),
         };
 


### PR DESCRIPTION
Closes: #345 #337

## Changes

### Cairo

This PR has 2 changes on Cairo side:

* Use nanoseconds instead of seconds for timeout timestamps
* Replace the `packet_data` field with `packet` in the `WriteAcknowledgementEvent`

### Relayer

This PR has 2 changes on the relayer side:

* Improve packet clearing test to assert recv and ack are cleared both ways
* Fix `build_packet_from_write_ack_event`