### PR TITLE
ci: optimize integration test runtime

### DIFF
--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -56,40 +56,9 @@ jobs:
             relayer
             light-client
 
-      - name: Install osmosisd v28.0.1
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: osmosis-labs/osmosis
-          fileName: ${{ matrix.value.osmosis }}
-          tag: v28.0.1
-          extract: true
-
-      - name: Install starknet-devnet v0.2.4
-        uses: robinraju/release-downloader@v1
-        with:
-          repository: 0xSpaceShard/starknet-devnet
-          fileName: ${{ matrix.value.starknet-devnet }}
-          tag: v0.2.4
-          extract: true
-
-      - name: Install simd-ibc-go-v8-wasm
-        run: |
-          nix build .#wasm-simapp
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
-
       - uses: taiki-e/cache-cargo-install-action@v2
         with:
           tool: cosmwasm-check
-
-      - run: echo "$PWD" >> $GITHUB_PATH
-
-      - run: |
-          osmosisd version
-          starknet-devnet --version
-          cosmwasm-check --version
 
       - name: Build Cairo contracts
         working-directory: ./cairo-contracts
@@ -107,7 +76,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUST_LOG: debug
           # Tests are run with a single thread to avoid Connection refused (os error 61) with macOS
-          TEST_THREADS: ${{ matrix.value.os == 'macos-14' && 1 || 4 }}
+          TEST_THREADS: 4
         working-directory: ./relayer
         run: |
           export ERC20_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_ERC20Mintable.contract_class.json"
@@ -116,7 +85,13 @@ jobs:
           export STARKNET_WASM_CLIENT_PATH="$(pwd)/../light-client/target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm"
           export IBC_CORE_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_IBCCore.contract_class.json"
 
-          nix shell ..#wasm-simapp -c \
+          nix shell \
+            ..#osmosis \
+            ..#wasm-simapp \
+            ..#starknet-devnet \
+            ..#rust \
+            ..#cargo-nextest \
+            -c \
             cargo nextest run --release \
             --test-threads=$TEST_THREADS
 

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -21,16 +21,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - name: Install osmosisd v28.0.0
+        uses: jaxxstorm/action-install-gh-release@v1.14.0
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          repo: osmosis-labs/osmosis
+          tag: v28.0.0
+          cache: enable
 
-      - uses: cachix/cachix-action@v15
+      - name: Install starknet-devnet
+        uses: jaxxstorm/action-install-gh-release@v1.14.0
         with:
-          name: ibc-starknet
-          extraPullNames: hermes-sdk,cosmos-nix
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          repo: starknet/starknet-devnet
+          tag: v0.3.0-rc.0
+          cache: enable
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cosmwasm-check
+
+      - run: |
+          osmosisd version
+          starknet-devnet --version
+          cosmwasm-check --version
 
       - name: Install Rust nightly toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -58,28 +70,11 @@ jobs:
         run: |
           scarb build -p starknet_ibc_contracts
 
-      - name: Nix build
+      - name: Build CW light client contract
+        working-directory: ./light-client
         run: |
-          sudo rm -rf /opt/homebrew/
-
-          nix build \
-            .#starknet-devnet \
-            .#universal-sierra-compiler \
-            .#rust \
-            .#rust-wasm \
-            .#rust-nightly \
-            .#taplo \
-            .#nixfmt \
-            .#cargo-nextest \
-            .#ibc-starknet-cw \
-            .#wasm-simapp \
-            .#osmosis
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            relayer -> relayer/target
-            light-client -> light-client/target
+          cargo +nightly build -p ibc-client-starknet-cw --target wasm32-unknown-unknown
+          cosmwasm-check target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm
 
       - name: Run Integration Tests
         env:
@@ -91,17 +86,10 @@ jobs:
           export ERC20_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_ERC20Mintable.contract_class.json"
           export ICS20_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_TransferApp.contract_class.json"
           export COMET_CLIENT_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_CometClient.contract_class.json"
-          export STARKNET_WASM_CLIENT_PATH="$(nix build ..#ibc-starknet-cw --print-out-paths)/ibc_client_starknet_cw.wasm"
+          export STARKNET_WASM_CLIENT_PATH="$(pwd)/../light-client/target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm"
           export IBC_CORE_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_IBCCore.contract_class.json"
 
-          nix shell \
-            ..#osmosis \
-            ..#wasm-simapp \
-            ..#starknet-devnet \
-            ..#rust \
-            ..#cargo-nextest \
-            -c \
-            cargo nextest run --test-threads=1
+          cargo nextest run --test-threads=1
 
   lint-relayer:
     name: Lint Relayer Code

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -50,6 +50,8 @@ jobs:
           scarb build -p starknet_ibc_contracts
 
       - name: Run Integration Tests
+        # disable macos runner on PRs
+        if: ${{ matrix.os != 'macos-14' || github.event_name == 'push' }}
         env:
           RUST_BACKTRACE: 1
           RUST_LOG: debug

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -47,8 +47,8 @@ jobs:
           toolchain: 1.81,stable
           target: wasm32-unknown-unknown
           cache-workspaces: |
-            relayer -> target
-            light-client -> target
+            relayer
+            light-client
 
       - name: Install osmosisd v28.0.1
         uses: robinraju/release-downloader@v1
@@ -144,7 +144,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            relayer -> relayer/target
+            relayer
 
       - name: Run Clippy
         working-directory: ./relayer

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -46,7 +46,7 @@ jobs:
           tag: v0.2.4
           extract: true
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/cache-cargo-install-action@v2
         with:
           tool: cosmwasm-check
 

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -15,23 +15,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14]
-    runs-on: ${{ matrix.os }}
+        value:
+          - os: ubuntu-22.04
+            osmosis: osmosisd-28.0.0-linux-amd64.tar.gz
+            starknet-devnet: starknet-devnet-x86_64-unknown-linux-gnu.tar.gz
+          - os: ubuntu-22.04-arm
+            osmosis: osmosisd-28.0.0-linux-arm64.tar.gz
+            starknet-devnet: starknet-devnet-aarch64-unknown-linux-gnu.tar.gz
+          - os: macos-14
+            osmosis: osmosisd-28.0.0-darwin-amd64.tar.gz
+            starknet-devnet: starknet-devnet-x86_64-apple-darwin.tar.gz
+    runs-on: ${{ matrix.value.os }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
       - name: Install osmosisd v28.0.0
-        uses: jaxxstorm/action-install-gh-release@v1.14.0
+        uses: jaxxstorm/action-install-gh-release@master
         with:
           repo: osmosis-labs/osmosis
+          asset-name: ${{ matrix.value.osmosis }}
           tag: v28.0.0
           cache: enable
 
       - name: Install starknet-devnet
-        uses: jaxxstorm/action-install-gh-release@v1.14.0
+        uses: jaxxstorm/action-install-gh-release@master
         with:
           repo: starknet/starknet-devnet
+          asset-name: ${{ matrix.value.starknet-devnet }}
           tag: v0.2.4
           cache: enable
 

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -102,6 +102,9 @@ jobs:
 
           cargo nextest run --test-threads=1
 
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
   lint-relayer:
     name: Lint Relayer Code
     runs-on: ubuntu-latest

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -106,8 +106,9 @@ jobs:
         env:
           RUST_BACKTRACE: 1
           RUST_LOG: debug
+          # Tests are run with a single thread to avoid Connection refused (os error 61) with macOS
+          TEST_THREADS: ${{ matrix.value.os == 'macos-14' && 1 || 4 }}
         working-directory: ./relayer
-        # Tests are run with a single thread to avoid Connection refused (os error 61) with macOS
         run: |
           export ERC20_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_ERC20Mintable.contract_class.json"
           export ICS20_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_TransferApp.contract_class.json"
@@ -115,7 +116,9 @@ jobs:
           export STARKNET_WASM_CLIENT_PATH="$(pwd)/../light-client/target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm"
           export IBC_CORE_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_IBCCore.contract_class.json"
 
-          nix shell ..#wasm-simapp -c cargo nextest run
+          nix shell ..#wasm-simapp -c \
+            cargo nextest run --release \
+            --test-threads=$TEST_THREADS
 
   lint-relayer:
     name: Lint Relayer Code

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -46,6 +46,9 @@ jobs:
         with:
           toolchain: 1.81,stable
           target: wasm32-unknown-unknown
+          cache-workspaces: |
+            relayer -> relayer/target
+            light-client -> light-client/target
 
       - name: Install osmosisd v28.0.1
         uses: robinraju/release-downloader@v1

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.14.0
         with:
           repo: starknet/starknet-devnet
-          tag: v0.3.0-rc.0
+          tag: v0.2.4
           cache: enable
 
       - uses: taiki-e/install-action@v2

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -121,7 +121,7 @@ jobs:
           export STARKNET_WASM_CLIENT_PATH="$(pwd)/../light-client/target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm"
           export IBC_CORE_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_IBCCore.contract_class.json"
 
-          nix shell github:informalsystems/cosmos.nix#ibc-go-v8-wasm-simapp -c cargo nextest run
+          nix shell ..#wasm-simapp -c cargo nextest run
 
   lint-relayer:
     name: Lint Relayer Code

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -31,26 +31,20 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install osmosisd v28.0.1
-        uses: jaxxstorm/action-install-gh-release@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: osmosis-labs/osmosis
-          asset-name: ${{ matrix.value.osmosis }}
+          repository: osmosis-labs/osmosis
+          fileName: ${{ matrix.value.osmosis }}
           tag: v28.0.1
-          cache: enable
-          rename-to: ${{ matrix.value.osmosis }}
-          chmod: 0755
-          extension-matching: disable
+          extract: true
 
       - name: Install starknet-devnet
-        uses: jaxxstorm/action-install-gh-release@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: starknet/starknet-devnet
-          asset-name: ${{ matrix.value.starknet-devnet }}
+          repository: starknet/starknet-devnet
+          fileName: ${{ matrix.value.starknet-devnet }}
           tag: v0.2.4
-          cache: enable
-          rename-to: ${{ matrix.value.starknet-devnet }}
-          chmod: 0755
-          extension-matching: disable
+          extract: true
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -17,25 +17,25 @@ jobs:
       matrix:
         value:
           - os: ubuntu-22.04
-            osmosis: osmosisd-28.0.0-linux-amd64.tar.gz
+            osmosis: osmosisd-28.0.1-linux-amd64.tar.gz
             starknet-devnet: starknet-devnet-x86_64-unknown-linux-gnu.tar.gz
           - os: ubuntu-22.04-arm
-            osmosis: osmosisd-28.0.0-linux-arm64.tar.gz
+            osmosis: osmosisd-28.0.1-linux-arm64.tar.gz
             starknet-devnet: starknet-devnet-aarch64-unknown-linux-gnu.tar.gz
           - os: macos-14
-            osmosis: osmosisd-28.0.0-darwin-amd64.tar.gz
+            osmosis: osmosisd-28.0.1-darwin-amd64.tar.gz
             starknet-devnet: starknet-devnet-x86_64-apple-darwin.tar.gz
     runs-on: ${{ matrix.value.os }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install osmosisd v28.0.0
+      - name: Install osmosisd v28.0.1
         uses: jaxxstorm/action-install-gh-release@master
         with:
           repo: osmosis-labs/osmosis
           asset-name: ${{ matrix.value.osmosis }}
-          tag: v28.0.0
+          tag: v28.0.1
           cache: enable
 
       - name: Install starknet-devnet

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -50,8 +50,9 @@ jobs:
         with:
           tool: cosmwasm-check
 
+      - run: echo "$PWD" >> $GITHUB_PATH
+
       - run: |
-          ls -l
           osmosisd version
           starknet-devnet --version
           cosmwasm-check --version

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -50,7 +50,7 @@ jobs:
           scarb build -p starknet_ibc_contracts
 
       - name: Run Integration Tests
-        # disable macos runner on PRs
+        # don't run tests on macos during PRs
         if: ${{ matrix.os != 'macos-14' || github.event_name != 'pull_request' }}
         env:
           RUST_BACKTRACE: 1

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -53,21 +53,10 @@ jobs:
             relayer
             light-client
 
-      - uses: taiki-e/cache-cargo-install-action@v2
-        with:
-          tool: cosmwasm-check
-
       - name: Build Cairo contracts
         working-directory: ./cairo-contracts
         run: |
           scarb build -p starknet_ibc_contracts
-
-      - name: Build CW light client contract
-        working-directory: ./light-client
-        run: |
-          nix shell ..#rust-wasm -c \
-            cargo build -p ibc-client-starknet-cw --target wasm32-unknown-unknown --release
-          cosmwasm-check target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm
 
       - name: Run Integration Tests
         env:
@@ -80,8 +69,9 @@ jobs:
           export ERC20_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_ERC20Mintable.contract_class.json"
           export ICS20_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_TransferApp.contract_class.json"
           export COMET_CLIENT_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_CometClient.contract_class.json"
-          export STARKNET_WASM_CLIENT_PATH="$(pwd)/../light-client/target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm"
           export IBC_CORE_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_IBCCore.contract_class.json"
+
+          export STARKNET_WASM_CLIENT_PATH="$(nix build ..#ibc-starknet-cw --print-out-paths)/ibc_client_starknet_cw.wasm"
 
           nix shell \
             ..#osmosis \

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Build CW light client contract
         working-directory: ./light-client
         run: |
-          cargo +nightly build -p ibc-client-starknet-cw --target wasm32-unknown-unknown
+          cargo +nightly build -p ibc-client-starknet-cw --target wasm32-unknown-unknown --release
           cosmwasm-check target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm
 
       - name: Run Integration Tests

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -47,8 +47,8 @@ jobs:
           toolchain: 1.81,stable
           target: wasm32-unknown-unknown
           cache-workspaces: |
-            relayer -> relayer/target
-            light-client -> light-client/target
+            relayer -> target
+            light-client -> target
 
       - name: Install osmosisd v28.0.1
         uses: robinraju/release-downloader@v1

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run Integration Tests
         # disable macos runner on PRs
-        if: ${{ matrix.os != 'macos-14' || github.event_name == 'push' }}
+        if: ${{ matrix.os != 'macos-14' || github.event_name != 'pull_request' }}
         env:
           RUST_BACKTRACE: 1
           RUST_LOG: debug

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -74,7 +74,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUST_LOG: debug
           # Tests are run with a single thread to avoid Connection refused (os error 61) with macOS
-          TEST_THREADS: 4
+          TEST_THREADS: ${{ matrix.value.os == 'macos-14' && 1 || 4 }}
         working-directory: ./relayer
         run: |
           export ERC20_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_ERC20Mintable.contract_class.json"

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -51,6 +51,7 @@ jobs:
           tool: cosmwasm-check
 
       - run: |
+          ls -l
           osmosisd version
           starknet-devnet --version
           cosmwasm-check --version

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -23,8 +23,8 @@ jobs:
             osmosis: osmosisd-28.0.1-linux-arm64.tar.gz
             starknet-devnet: starknet-devnet-aarch64-unknown-linux-gnu.tar.gz
           - os: macos-14
-            osmosis: osmosisd-28.0.1-darwin-amd64.tar.gz
-            starknet-devnet: starknet-devnet-x86_64-apple-darwin.tar.gz
+            osmosis: osmosisd-28.0.1-darwin-arm64.tar.gz
+            starknet-devnet: starknet-devnet-aarch64-apple-darwin.tar.gz
     runs-on: ${{ matrix.value.os }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -46,6 +46,10 @@ jobs:
           tag: v0.2.4
           extract: true
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - uses: taiki-e/cache-cargo-install-action@v2
         with:
           tool: cosmwasm-check

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -30,6 +30,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ibc-starknet
+          extraPullNames: hermes-sdk,cosmos-nix
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -107,7 +118,7 @@ jobs:
           export STARKNET_WASM_CLIENT_PATH="$(pwd)/../light-client/target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm"
           export IBC_CORE_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_IBCCore.contract_class.json"
 
-          cargo nextest run --test-threads=1
+          nix shell github:informalsystems/cosmos.nix#ibc-go-v8-wasm-simapp -c cargo nextest run --test-threads=1
 
       - name: Setup tmate session
         if: ${{ failure() }}

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -87,16 +87,6 @@ jobs:
           tool-versions: cairo-contracts/.tool-versions
           scarb-lock: cairo-contracts/Scarb.lock
 
-      - name: Install Universal Sierra Compiler
-        uses: software-mansion/setup-universal-sierra-compiler@v1
-        with:
-          tool-versions: cairo-contracts/.tool-versions
-
-      - name: Install Starknet Foundry
-        uses: foundry-rs/setup-snfoundry@v3
-        with:
-          tool-versions: cairo-contracts/.tool-versions
-
       - name: Build Cairo contracts
         working-directory: ./cairo-contracts
         run: |

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -15,17 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        value:
-          - os: ubuntu-22.04
-            osmosis: osmosisd-28.0.1-linux-amd64.tar.gz
-            starknet-devnet: starknet-devnet-x86_64-unknown-linux-gnu.tar.gz
-          - os: ubuntu-22.04-arm
-            osmosis: osmosisd-28.0.1-linux-arm64.tar.gz
-            starknet-devnet: starknet-devnet-aarch64-unknown-linux-gnu.tar.gz
-          - os: macos-14
-            osmosis: osmosisd-28.0.1-darwin-arm64.tar.gz
-            starknet-devnet: starknet-devnet-aarch64-apple-darwin.tar.gz
-    runs-on: ${{ matrix.value.os }}
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +54,7 @@ jobs:
           RUST_BACKTRACE: 1
           RUST_LOG: debug
           # Tests are run with a single thread to avoid Connection refused (os error 61) with macOS
-          TEST_THREADS: ${{ matrix.value.os == 'macos-14' && 1 || 4 }}
+          TEST_THREADS: ${{ matrix.os == 'macos-14' && 1 || 4 }}
         working-directory: ./relayer
         run: |
           export ERC20_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_ERC20Mintable.contract_class.json"

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -66,6 +66,10 @@ jobs:
           tag: v0.2.4
           extract: true
 
+      - name: Install simd-ibc-go-v8-wasm
+        run: |
+          nix build .#wasm-simapp
+
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -121,7 +121,7 @@ jobs:
           export STARKNET_WASM_CLIENT_PATH="$(pwd)/../light-client/target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm"
           export IBC_CORE_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_IBCCore.contract_class.json"
 
-          nix shell github:informalsystems/cosmos.nix#ibc-go-v8-wasm-simapp -c cargo nextest run --test-threads=1
+          nix shell github:informalsystems/cosmos.nix#ibc-go-v8-wasm-simapp -c cargo nextest run --test-threads=3
 
       - name: Setup tmate session
         if: ${{ failure() }}

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -30,6 +30,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.81,stable
+          target: wasm32-unknown-unknown
+
       - name: Install osmosisd v28.0.1
         uses: robinraju/release-downloader@v1
         with:
@@ -60,12 +66,6 @@ jobs:
           osmosisd version
           starknet-devnet --version
           cosmwasm-check --version
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable,1.81
-          target: wasm32-unknown-unknown
 
       - name: Install Scarb
         uses: software-mansion/setup-scarb@v1

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -61,6 +61,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
+          target: wasm32-unknown-unknown
 
       - name: Install Scarb
         uses: software-mansion/setup-scarb@v1

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -123,9 +123,6 @@ jobs:
 
           nix shell github:informalsystems/cosmos.nix#ibc-go-v8-wasm-simapp -c cargo nextest run
 
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
   lint-relayer:
     name: Lint Relayer Code
     runs-on: ubuntu-latest

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -47,12 +47,9 @@ jobs:
           tool-versions: cairo-contracts/.tool-versions
           scarb-lock: cairo-contracts/Scarb.lock
 
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
         with:
-          toolchain: 1.81,stable
-          target: wasm32-unknown-unknown
-          cache-workspaces: |
+          workspaces: |
             relayer
             light-client
 
@@ -68,7 +65,8 @@ jobs:
       - name: Build CW light client contract
         working-directory: ./light-client
         run: |
-          cargo +1.81 build -p ibc-client-starknet-cw --target wasm32-unknown-unknown --release
+          nix shell ..#rust-wasm -c \
+            cargo build -p ibc-client-starknet-cw --target wasm32-unknown-unknown --release
           cosmwasm-check target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm
 
       - name: Run Integration Tests

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -121,7 +121,7 @@ jobs:
           export STARKNET_WASM_CLIENT_PATH="$(pwd)/../light-client/target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm"
           export IBC_CORE_CONTRACT="$(pwd)/../cairo-contracts/target/dev/starknet_ibc_contracts_IBCCore.contract_class.json"
 
-          nix shell github:informalsystems/cosmos.nix#ibc-go-v8-wasm-simapp -c cargo nextest run --test-threads=3
+          nix shell github:informalsystems/cosmos.nix#ibc-go-v8-wasm-simapp -c cargo nextest run
 
       - name: Setup tmate session
         if: ${{ failure() }}

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Install starknet-devnet
         uses: robinraju/release-downloader@v1
         with:
-          repository: starknet/starknet-devnet
+          repository: 0xSpaceShard/starknet-devnet
           fileName: ${{ matrix.value.starknet-devnet }}
           tag: v0.2.4
           extract: true

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -37,6 +37,9 @@ jobs:
           asset-name: ${{ matrix.value.osmosis }}
           tag: v28.0.1
           cache: enable
+          rename-to: ${{ matrix.value.osmosis }}
+          chmod: 0755
+          extension-matching: disable
 
       - name: Install starknet-devnet
         uses: jaxxstorm/action-install-gh-release@master
@@ -45,6 +48,9 @@ jobs:
           asset-name: ${{ matrix.value.starknet-devnet }}
           tag: v0.2.4
           cache: enable
+          rename-to: ${{ matrix.value.starknet-devnet }}
+          chmod: 0755
+          extension-matching: disable
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -41,6 +41,12 @@ jobs:
           extraPullNames: hermes-sdk,cosmos-nix
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
+      - name: Install Scarb
+        uses: software-mansion/setup-scarb@v1
+        with:
+          tool-versions: cairo-contracts/.tool-versions
+          scarb-lock: cairo-contracts/Scarb.lock
+
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -58,7 +64,7 @@ jobs:
           tag: v28.0.1
           extract: true
 
-      - name: Install starknet-devnet
+      - name: Install starknet-devnet v0.2.4
         uses: robinraju/release-downloader@v1
         with:
           repository: 0xSpaceShard/starknet-devnet
@@ -84,12 +90,6 @@ jobs:
           osmosisd version
           starknet-devnet --version
           cosmwasm-check --version
-
-      - name: Install Scarb
-        uses: software-mansion/setup-scarb@v1
-        with:
-          tool-versions: cairo-contracts/.tool-versions
-          scarb-lock: cairo-contracts/Scarb.lock
 
       - name: Build Cairo contracts
         working-directory: ./cairo-contracts

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -57,10 +57,10 @@ jobs:
           starknet-devnet --version
           cosmwasm-check --version
 
-      - name: Install Rust nightly toolchain
+      - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable,1.81
           target: wasm32-unknown-unknown
 
       - name: Install Scarb
@@ -87,7 +87,7 @@ jobs:
       - name: Build CW light client contract
         working-directory: ./light-client
         run: |
-          cargo +nightly build -p ibc-client-starknet-cw --target wasm32-unknown-unknown --release
+          cargo +1.81 build -p ibc-client-starknet-cw --target wasm32-unknown-unknown --release
           cosmwasm-check target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm
 
       - name: Run Integration Tests

--- a/.github/workflows/light-client.yaml
+++ b/.github/workflows/light-client.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            light-client -> light-client/target
+            light-client
 
       - name: Build CosmWasm light client contract
         working-directory: ./light-client
@@ -65,7 +65,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            light-client -> light-client/target
+            light-client
 
       - name: Run Clippy
         working-directory: ./light-client

--- a/.github/workflows/light-client.yaml
+++ b/.github/workflows/light-client.yaml
@@ -41,11 +41,16 @@ jobs:
           workspaces: |
             light-client
 
+      - uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cosmwasm-check
+
       - name: Build CosmWasm light client contract
         working-directory: ./light-client
         run: |
           nix shell ..#rust-wasm -c \
-            cargo build -p ibc-client-starknet-cw --target wasm32-unknown-unknown
+            cargo build -p ibc-client-starknet-cw --target wasm32-unknown-unknown --release
+          cosmwasm-check target/wasm32-unknown-unknown/release/ibc_client_starknet_cw.wasm
 
   lint-light-client:
     name: Lint CosmWasm Light Client Contract

--- a/cairo-contracts/packages/apps/Scarb.toml
+++ b/cairo-contracts/packages/apps/Scarb.toml
@@ -26,7 +26,6 @@ openzeppelin_token   = { workspace = true }
 openzeppelin_utils   = { workspace = true }
 openzeppelin_testing = { workspace = true }
 starknet             = { workspace = true }
-snforge_std          = { workspace = true }
 
 # internal dependencies
 serde_json = { workspace = true }
@@ -36,6 +35,8 @@ starknet_ibc_core  = { workspace = true }
 starknet_ibc_utils = { workspace = true }
 
 [dev-dependencies]
+snforge_std = { workspace = true }
+
 # ibc dependencies
 starknet_ibc_testkit   = { workspace = true }
 starknet_ibc_contracts = { workspace = true }

--- a/cairo-contracts/packages/clients/Scarb.toml
+++ b/cairo-contracts/packages/clients/Scarb.toml
@@ -23,7 +23,6 @@ fmt = { workspace = true }
 alexandria_data_structures = { workspace = true }
 alexandria_sorting         = { workspace = true }
 openzeppelin_access        = { workspace = true }
-snforge_std                = { workspace = true }
 
 # external dependencies
 starknet = { workspace = true }
@@ -33,4 +32,5 @@ starknet_ibc_core  = { workspace = true }
 starknet_ibc_utils = { workspace = true }
 
 [dev-dependencies]
+snforge_std          = { workspace = true }
 starknet_ibc_testkit = { workspace = true }

--- a/cairo-contracts/packages/testkit/Scarb.toml
+++ b/cairo-contracts/packages/testkit/Scarb.toml
@@ -25,7 +25,6 @@ openzeppelin_access  = { workspace = true }
 openzeppelin_testing = { workspace = true }
 openzeppelin_utils   = { workspace = true }
 openzeppelin_token   = { workspace = true }
-snforge_std          = { workspace = true }
 starknet             = { workspace = true }
 
 # ibc dependencies
@@ -34,6 +33,9 @@ starknet_ibc_clients = { workspace = true }
 starknet_ibc_apps    = { workspace = true }
 
 serde_json = { workspace = true }
+
+[dev-dependencies]
+snforge_std = { workspace = true }
 
 [[target.starknet-contract]]
 allowed-libfuncs-list.name = "experimental"


### PR DESCRIPTION
fix

- correct rust cache paths
- sequential test runner only for macos-arm64
  - getting failure will be faster on linux-amd64 and linux-arm64
- release profile during integration tests for faster runtime 

current bottleneck

- integration tests themselves
- `snforge_scarb_plugin` always gets recompiled by cargo (pulled as `snforge_std` dep)
  - opened software-mansion/setup-scarb#37
- nix fetch for necessary tools -- it recursively tries to pull all their dependencies.
  - using a rust toolchain action and something like `robinraju/release-downloader@v1` would be faster.
  - although we don't have a release binary for simd-ibc-go-v8-wasm - for that we rely on nix