### PR TITLE
Enhance start CLI to accept parameters by chain type name

### DIFF
--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -2405,6 +2405,7 @@ dependencies = [
  "hermes-starknet-relayer",
  "hermes-starknet-test-components",
  "hex",
+ "humantime",
  "ibc",
  "serde",
  "serde_json",

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -61,6 +61,7 @@ hex                         = { version = "0.4.3" }
 sha256                      = { version = "1.6.0" }
 reqwest                     = { version = "0.12.5" }
 indexmap                    = { version = "2.9.0" }
+humantime                   = { version = "2.1.0" }
 
 ibc                       = { version = "0.56.0" }
 ibc-proto                 = { version = "0.51.1" }

--- a/relayer/crates/starknet-cli/Cargo.toml
+++ b/relayer/crates/starknet-cli/Cargo.toml
@@ -45,6 +45,7 @@ tokio              = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 stable-eyre        = { workspace = true }
+humantime          = { workspace = true }
 
 [dev-dependencies]
 hex                     = { workspace = true }

--- a/relayer/crates/starknet-cli/src/commands/all.rs
+++ b/relayer/crates/starknet-cli/src/commands/all.rs
@@ -2,13 +2,12 @@ use hermes_cli_components::traits::{CanRunCommand, CommandRunner, CommandRunnerC
 use hermes_prelude::*;
 
 use crate::commands::{
-    BootstrapSubCommand, CreateSubCommand, QuerySubCommand, StartSubCommand, UpdateSubCommand,
+    BootstrapSubCommand, CreateSubCommand, QuerySubCommand, StartRelayerArgs, UpdateSubCommand,
 };
 
 #[derive(Debug, clap::Subcommand)]
 pub enum AllSubCommands {
-    #[clap(subcommand)]
-    Start(StartSubCommand),
+    Start(StartRelayerArgs),
 
     #[clap(subcommand)]
     Bootstrap(BootstrapSubCommand),
@@ -32,7 +31,7 @@ where
         + CanRunCommand<QuerySubCommand>
         + CanRunCommand<CreateSubCommand>
         + CanRunCommand<UpdateSubCommand>
-        + CanRunCommand<StartSubCommand>,
+        + CanRunCommand<StartRelayerArgs>,
 {
     async fn run_command(
         app: &App,

--- a/relayer/crates/starknet-cli/src/commands/start.rs
+++ b/relayer/crates/starknet-cli/src/commands/start.rs
@@ -2,7 +2,7 @@ use hermes_prelude::*;
 
 #[derive(Debug, clap::Parser, HasField)]
 pub struct StartRelayerArgs {
-    /// Identifier of chain A
+    /// Identifier of Starknet chain
     #[clap(
         long = "starknet-chain-id",
         required = true,
@@ -11,7 +11,7 @@ pub struct StartRelayerArgs {
     )]
     chain_id_a: String,
 
-    /// Identifier of client A
+    /// Identifier of Starknet client
     #[clap(
         long = "starknet-client-id",
         required = true,
@@ -20,7 +20,7 @@ pub struct StartRelayerArgs {
     )]
     client_id_a: String,
 
-    /// Identifier of chain B
+    /// Identifier of Cosmos chain
     #[clap(
         long = "cosmos-chain-id",
         required = true,
@@ -29,7 +29,7 @@ pub struct StartRelayerArgs {
     )]
     chain_id_b: String,
 
-    /// Identifier of client B
+    /// Identifier of Cosmos client
     #[clap(
         long = "cosmos-client-id",
         required = true,

--- a/relayer/crates/starknet-cli/src/commands/start.rs
+++ b/relayer/crates/starknet-cli/src/commands/start.rs
@@ -1,32 +1,46 @@
-use cgp::core::field::Index;
-use hermes_cli_components::impls::{RunStartRelayerCommand, StartRelayerArgs};
-use hermes_cli_components::traits::{CommandRunner, CommandRunnerComponent, HasOutputType};
 use hermes_prelude::*;
 
-#[derive(Debug, clap::Subcommand)]
-pub enum StartSubCommand {
-    StarknetWithCosmos(StartRelayerArgs),
-    CosmosWithStarknet(StartRelayerArgs),
-}
+#[derive(Debug, clap::Parser, HasField)]
+pub struct StartRelayerArgs {
+    /// Identifier of chain A
+    #[clap(
+        long = "starknet-chain-id",
+        required = true,
+        value_name = "STARKNET_CHAIN_ID",
+        help_heading = "REQUIRED"
+    )]
+    chain_id_a: String,
 
-#[cgp_new_provider(CommandRunnerComponent)]
-impl<App> CommandRunner<App, StartSubCommand> for RunStartSubCommand
-where
-    App: HasOutputType + HasAsyncErrorType,
-    RunStartRelayerCommand<Index<0>, Index<1>>: CommandRunner<App, StartRelayerArgs>,
-    RunStartRelayerCommand<Index<1>, Index<0>>: CommandRunner<App, StartRelayerArgs>,
-{
-    async fn run_command(
-        app: &App,
-        subcommand: &StartSubCommand,
-    ) -> Result<App::Output, App::Error> {
-        match subcommand {
-            StartSubCommand::StarknetWithCosmos(args) => {
-                <RunStartRelayerCommand<Index<0>, Index<1>>>::run_command(app, args).await
-            }
-            StartSubCommand::CosmosWithStarknet(args) => {
-                <RunStartRelayerCommand<Index<1>, Index<0>>>::run_command(app, args).await
-            }
-        }
-    }
+    /// Identifier of client A
+    #[clap(
+        long = "starknet-client-id",
+        required = true,
+        value_name = "STARKNET_CLIENT_ID",
+        help_heading = "REQUIRED"
+    )]
+    client_id_a: String,
+
+    /// Identifier of chain B
+    #[clap(
+        long = "cosmos-chain-id",
+        required = true,
+        value_name = "COSMOS_CHAIN_ID",
+        help_heading = "REQUIRED"
+    )]
+    chain_id_b: String,
+
+    /// Identifier of client B
+    #[clap(
+        long = "cosmos-client-id",
+        required = true,
+        value_name = "COSMOS_CLIENT_ID",
+        help_heading = "REQUIRED"
+    )]
+    client_id_b: String,
+
+    #[clap(long = "clear-past-blocks", required = false)]
+    clear_past_blocks: Option<humantime::Duration>,
+
+    #[clap(long = "stop-after-blocks", required = false)]
+    stop_after_blocks: Option<humantime::Duration>,
 }

--- a/relayer/crates/starknet-cli/src/contexts/app.rs
+++ b/relayer/crates/starknet-cli/src/contexts/app.rs
@@ -12,8 +12,7 @@ use hermes_cli_components::impls::{
     QueryConsensusStateArgs, RunBootstrapChainCommand, RunCreateChannelCommand,
     RunCreateClientCommand, RunCreateConnectionCommand, RunQueryBalanceCommand,
     RunQueryChainStatusCommand, RunQueryClientStateCommand, RunQueryConsensusStateCommand,
-    RunStartRelayerCommand, RunUpdateClientCommand, StartRelayerArgs, UpdateClientArgs,
-    WriteTomlConfig,
+    RunStartRelayerCommand, RunUpdateClientCommand, UpdateClientArgs, WriteTomlConfig,
 };
 use hermes_cli_components::traits::{
     AnyCounterpartyTypeProviderComponent, ArgParserComponent, BootstrapLoaderComponent,
@@ -49,8 +48,8 @@ use toml::to_string_pretty;
 
 use crate::commands::{
     AllSubCommands, BootstrapSubCommand, CreateSubCommand, QuerySubCommand, RunAllSubCommand,
-    RunBootstrapSubCommand, RunCreateSubCommand, RunQuerySubCommand, RunStartSubCommand,
-    RunUpdateSubCommand, StartSubCommand, UpdateSubCommand,
+    RunBootstrapSubCommand, RunCreateSubCommand, RunQuerySubCommand, RunUpdateSubCommand,
+    StartRelayerArgs, UpdateSubCommand,
 };
 use crate::impls::{
     BootstrapOsmosisChainArgs, BootstrapStarknetChainArgs, CreateStarknetClientArgs,
@@ -182,7 +181,6 @@ delegate_components! {
         BootstrapSubCommand: RunBootstrapSubCommand,
 
         StartRelayerArgs: RunStartRelayerCommand<Index<0>, Index<1>>,
-        StartSubCommand: RunStartSubCommand,
 
         QuerySubCommand: RunQuerySubCommand,
         QueryClientStateArgs: RunQueryClientStateCommand,
@@ -309,7 +307,6 @@ check_components! {
         ],
         CommandRunnerComponent: [
             AllSubCommands,
-            StartSubCommand,
             BootstrapSubCommand,
             BootstrapStarknetChainArgs,
             BootstrapOsmosisChainArgs,


### PR DESCRIPTION
Part of: #198

## Summary

This PR enhances the `start` CLI for `hermes-starknet`, so that the chain ID and client ID parameters are named by the chain type instead of by the position. e.g. `--starknet-chain-id` and `--cosmos-chain-id` are used instead of `--chain-id-a` and `--chain-id-b`.

This is done by defining our own version of `StartRelayerArgs`, which renames the name of the command line arguments. The underlying fields are still named the same, e.g. `--starknet-chain-id` is mapped to `chain_id_a`.

Following this PR, similar pattern can be applied to other CLIs so that we can make the CLI less confusing.