### PR TITLE
ci: output logs even when tests succeed

### DIFF
--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -88,6 +88,7 @@ jobs:
               --exclude hermes-starknet-madara-tests \
               --retries 2 \
               --test-threads=$TEST_THREADS
+              --success-output=final
 
   madara-integration-tests:
     name: Run Madara Integration Tests
@@ -156,6 +157,7 @@ jobs:
             cargo nextest run \
               -p hermes-starknet-madara-tests \
               --test-threads=$TEST_THREADS
+              --success-output=final
 
   lint-relayer:
     name: Lint Relayer Code

--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -87,7 +87,7 @@ jobs:
               --workspace \
               --exclude hermes-starknet-madara-tests \
               --retries 2 \
-              --test-threads=$TEST_THREADS
+              --test-threads=$TEST_THREADS \
               --success-output=final
 
   madara-integration-tests:
@@ -156,7 +156,7 @@ jobs:
             -c \
             cargo nextest run \
               -p hermes-starknet-madara-tests \
-              --test-threads=$TEST_THREADS
+              --test-threads=$TEST_THREADS \
               --success-output=final
 
   lint-relayer:


### PR DESCRIPTION
This PR adds the flag `--success-output=final` to `starknet-integration-tests` and `madara-integration-tests` so that logs are displayed even when tests succeeds in CI