### PR TITLE
ci: show cairo contract sizes

### DIFF
--- a/.github/workflows/hermes.yaml
+++ b/.github/workflows/hermes.yaml
@@ -76,6 +76,11 @@ jobs:
           export COMET_CLIENT_CONTRACT="$(pwd)/../cairo-contracts/target/release/starknet_ibc_contracts_CometClient.contract_class.json"
           export IBC_CORE_CONTRACT="$(pwd)/../cairo-contracts/target/release/starknet_ibc_contracts_IBCCore.contract_class.json"
 
+          cargo run --quiet --example contract_size "$ERC20_CONTRACT"
+          cargo run --quiet --example contract_size "$ICS20_CONTRACT"
+          cargo run --quiet --example contract_size "$COMET_CLIENT_CONTRACT"
+          cargo run --quiet --example contract_size "$IBC_CORE_CONTRACT"
+
           export STARKNET_WASM_CLIENT_PATH="$(nix build ..#ibc-starknet-cw --print-out-paths)/ibc_client_starknet_cw.wasm"
 
           nix shell \

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -2460,6 +2460,7 @@ dependencies = [
 name = "hermes-starknet-integration-tests"
 version = "0.1.0"
 dependencies = [
+ "cairo-lang-starknet-classes",
  "cgp",
  "eyre",
  "flate2",

--- a/relayer/crates/starknet-integration-tests/Cargo.toml
+++ b/relayer/crates/starknet-integration-tests/Cargo.toml
@@ -43,3 +43,6 @@ prost-types = { workspace = true }
 tracing     = { workspace = true }
 flate2      = { workspace = true }
 tiny-bip39  = { workspace = true }
+
+[dev-dependencies]
+cairo-lang-starknet-classes = { workspace = true }

--- a/relayer/crates/starknet-integration-tests/examples/contract_size.rs
+++ b/relayer/crates/starknet-integration-tests/examples/contract_size.rs
@@ -1,0 +1,25 @@
+use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
+use cairo_lang_starknet_classes::contract_class::ContractClass;
+use starknet::core::types::contract::SierraClass;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let contract_path = std::env::args().nth(1).unwrap();
+
+    let contract_str: String = std::fs::read_to_string(&contract_path)?;
+
+    println!("Contract: {contract_path}");
+
+    let contract_class: SierraClass = serde_json::from_str(&contract_str)?;
+
+    let sierra_class_json = serde_json::to_string(&contract_class)?;
+
+    let contract_class: ContractClass = serde_json::from_str(&sierra_class_json)?;
+
+    println!("  Sierra size: {}", contract_class.sierra_program.len());
+
+    let casm_contract = CasmContractClass::from_contract_class(contract_class, false, 180_000)?;
+
+    println!("  Casm size: {}", casm_contract.bytecode.len());
+
+    Ok(())
+}


### PR DESCRIPTION
prints sierra contract length and casm bytecode size on CI via a cargo example binary.